### PR TITLE
Set registry as required arg to "repo list" cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ Contributions are welcome. Submit a pull request or open an issue as necessary.
 ## Developer Prerequisites
 
 * [Docker](https://docs.docker.com/get-docker/)
-* [.NET 5.0 SDK](https://docs.microsoft.com/dotnet/core/install/)
+* [.NET 6.0 SDK](https://docs.microsoft.com/dotnet/core/install/)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Dredge is published as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/cor
 ### Notes
 
 > * Dredge relies on your credentials already being stored in your environment when targeting registries that require authentication. For those registries you need to run `docker login` (for Docker Hub) or `docker login <registry>` before running Dredge.
-> * Dredge targets the Docker Hub registry by default but can be configured to target other registries by using the `-r` or `--registry` option.
 
 ### Query Repositories
 
 ```console
-> dredge repo list -r contoso.azurecr.io
+> dredge repo list contoso.azurecr.io
 [
   "myrepo/app"
   "myrepo/app2"
@@ -32,7 +31,7 @@ Dredge is published as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/cor
 ### Query Tags
 
 ```console
-> dredge tag list myrepo/app -r contoso.azurecr.io
+> dredge tag list contoso.azurecr.io/myrepo/app
 [
   "1.0",
   "1.1"
@@ -42,7 +41,7 @@ Dredge is published as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/cor
 ### Query Manifest
 
 ```console
-> dredge manifest get myrepo/app 1.0 -r contoso.azurecr.io
+> dredge manifest get contoso.azurecr.io/myrepo/app:1.0
 {
   "config": {
     "mediaType": "application/vnd.docker.container.image.v1+json",
@@ -66,6 +65,6 @@ Dredge is published as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/cor
 ### Query Digest
 
 ```console
-> dredge manifest digest myrepo/app 1.0 -r contoso.azurecr.io
+> dredge manifest digest contoso.azurecr.io/myrepo/app:1.0
 sha256:95202993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e
 ```

--- a/src/Valleysoft.Dredge/DockerHubHelper.cs
+++ b/src/Valleysoft.Dredge/DockerHubHelper.cs
@@ -3,10 +3,10 @@
 internal static class DockerHubHelper
 {
     public static string GetAuthRegistry(string? registry) =>
-        registry ?? "https://index.docker.io/v1/";
+        string.IsNullOrEmpty(registry) ? "https://index.docker.io/v1/" : registry;
 
     public static string GetApiRegistry(string? registry) =>
-        registry ?? "registry-1.docker.io";
+        string.IsNullOrEmpty(registry) ? "registry-1.docker.io" : registry;
 
     public static string ResolveRepoName(string? registry, string repoName)
     {

--- a/src/Valleysoft.Dredge/RepoCommand.cs
+++ b/src/Valleysoft.Dredge/RepoCommand.cs
@@ -18,10 +18,10 @@ public class RepoCommand : Command
     {
         public ListCommand() : base("list", "Lists the repositories contained in the Docker registry")
         {
-            AddOption(
-                new Option<string>(
-                    new string[] { "--registry", "-r" },
-                    "Name of the Docker registry (by default, Docker Hub registry is used)"));
+            AddArgument(new Argument("registry")
+            {
+                Description = "Name of the Docker registry"
+            });
             Handler = CommandHandler.Create<string?, IConsole>(ExecuteAsync);
         }
 


### PR DESCRIPTION
The original reason for making registry optional to the `repo list` command was to indicate a default registry of Docker Hub. But given that the Docker Hub registry doesn't support querying a repo list, there is no need to make this optional. Changing it to be a required argument.