### PR TITLE
Resolve manifest list to image for "image inspect" command

### DIFF
--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -14,14 +14,28 @@ public class ImageCommand : Command
 
     private class InspectCommand : Command
     {
+        private const string OsOptionName = "--os";
+        private const string OsVersionOptionName = "--os-version";
+        private const string ArchOptionName = "--arch";
+
         public InspectCommand() : base("inspect", "Return low-level information on a container image")
         {
             Argument<string> imageArg = new("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)");
             AddArgument(imageArg);
-            this.SetHandler(ExecuteAsync, imageArg);
+
+            Option<string?> osOpt = new(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")");
+            AddOption(osOpt);
+
+            Option<string?> osVersionOpt = new(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")");
+            AddOption(osVersionOpt);
+
+            Option<string?> archOpt = new(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")");
+            AddOption(archOpt);
+
+            this.SetHandler(ExecuteAsync, imageArg, osOpt, osVersionOpt, archOpt);
         }
 
-        private Task ExecuteAsync(string image)
+        private Task ExecuteAsync(string image, string? os, string? osVersion, string? arch)
         {
             ImageName imageName = ImageName.Parse(image);
             return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
@@ -29,10 +43,25 @@ public class ImageCommand : Command
                 using DockerRegistryClient.DockerRegistryClient client = await CommandHelper.GetRegistryClientAsync(imageName.Registry);
                 ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
                 
-                if (manifestInfo.MediaType.Contains("list"))
+                if (manifestInfo.Manifest is ManifestList manifestList)
                 {
-                    throw new NotSupportedException(
-                        $"The image name '{image}' has a media type of '{manifestInfo.MediaType}' which does not represent an image. Resolve the underlying image and provide that name instead.");
+                    ManifestReference? manifestRef = manifestList.Manifests
+                        .FirstOrDefault(manifest =>
+                            manifest.Platform?.Os == os &&
+                            manifest.Platform?.OsVersion == osVersion &&
+                            manifest.Platform?.Architecture == arch);
+                    if (manifestRef is null)
+                    {
+                        throw new Exception(
+                            $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {OsOptionName}, {ArchOptionName}, and {OsVersionOptionName} (Windows only) to specify the target platform to match.");
+                    }
+
+                    if (manifestRef.Digest is null)
+                    {
+                        throw new Exception($"Digest of resolved manifest is not set.");
+                    }
+
+                    manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
                 }
                 
                 if (manifestInfo.Manifest is not DockerManifestV2 manifest)


### PR DESCRIPTION
The `image inspect` command doesn't support manifest list tags. It checks for that condition and throws an exception.

This change updates the behavior so that it resolves the manifest list to a matching platform from the list, based on the platform options that are provided by the caller. This allows the caller to specify the `os`, `os-version`, and `arch` options to help find the matching platform from the manifest list.