### PR TITLE
Command to resolve a manifest to target platform

### DIFF
--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -14,28 +14,15 @@ public class ImageCommand : Command
 
     private class InspectCommand : Command
     {
-        private const string OsOptionName = "--os";
-        private const string OsVersionOptionName = "--os-version";
-        private const string ArchOptionName = "--arch";
-
         public InspectCommand() : base("inspect", "Return low-level information on a container image")
         {
             Argument<string> imageArg = new("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)");
             AddArgument(imageArg);
 
-            Option<string?> osOpt = new(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")");
-            AddOption(osOpt);
-
-            Option<string?> osVersionOpt = new(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")");
-            AddOption(osVersionOpt);
-
-            Option<string?> archOpt = new(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")");
-            AddOption(archOpt);
-
-            this.SetHandler(ExecuteAsync, imageArg, osOpt, osVersionOpt, archOpt);
+            this.SetHandler(ExecuteAsync, imageArg);
         }
 
-        private Task ExecuteAsync(string image, string? os, string? osVersion, string? arch)
+        private Task ExecuteAsync(string image)
         {
             ImageName imageName = ImageName.Parse(image);
             return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
@@ -43,25 +30,10 @@ public class ImageCommand : Command
                 using DockerRegistryClient.DockerRegistryClient client = await CommandHelper.GetRegistryClientAsync(imageName.Registry);
                 ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
                 
-                if (manifestInfo.Manifest is ManifestList manifestList)
+                if (manifestInfo.Manifest is ManifestList)
                 {
-                    ManifestReference? manifestRef = manifestList.Manifests
-                        .FirstOrDefault(manifest =>
-                            manifest.Platform?.Os == os &&
-                            manifest.Platform?.OsVersion == osVersion &&
-                            manifest.Platform?.Architecture == arch);
-                    if (manifestRef is null)
-                    {
-                        throw new Exception(
-                            $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {OsOptionName}, {ArchOptionName}, and {OsVersionOptionName} (Windows only) to specify the target platform to match.");
-                    }
-
-                    if (manifestRef.Digest is null)
-                    {
-                        throw new Exception($"Digest of resolved manifest is not set.");
-                    }
-
-                    manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
+                    throw new NotSupportedException(
+                        $"The name '{image}' is a manifest list and doesn't directly refer to an image. Resolve the manifest name to an image first by using the \"dredge manifest resolve\" command.");
                 }
                 
                 if (manifestInfo.Manifest is not DockerManifestV2 manifest)

--- a/src/Valleysoft.Dredge/ImageName.cs
+++ b/src/Valleysoft.Dredge/ImageName.cs
@@ -65,4 +65,26 @@ public class ImageName
 
         return new ImageName(registry, repo, tag, digest);
     }
+
+    public override string ToString()
+    {
+        string result = string.Empty;
+        if (Registry is not null)
+        {
+            result += Registry + "/";
+        }
+
+        result += Repo;
+
+        if (Tag is not null)
+        {
+            result += ":" + Tag;
+        }
+        else if (Digest is not null)
+        {
+            result += "@" + Digest;
+        }
+
+        return result;
+    }
 }

--- a/src/Valleysoft.Dredge/ManifestCommand.cs
+++ b/src/Valleysoft.Dredge/ManifestCommand.cs
@@ -7,17 +7,18 @@ namespace Valleysoft.Dredge;
 
 public class ManifestCommand : Command
 {
-    public ManifestCommand() : base("manifest", "Commands related to container image manifests")
+    public ManifestCommand() : base("manifest", "Commands related to manifests")
     {
         AddCommand(new GetCommand());
         AddCommand(new DigestCommand());
+        AddCommand(new ResolveCommand());
     }
 
     private class GetCommand : Command
     {
-        public GetCommand() : base("get", "Queries a container image manifest")
+        public GetCommand() : base("get", "Queries a manifest")
         {
-            Argument<string> imageArg = new("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)");
+            Argument<string> imageArg = new("name", "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)");
             AddArgument(imageArg);
             this.SetHandler(ExecuteAsync, imageArg);
         }
@@ -40,9 +41,9 @@ public class ManifestCommand : Command
 
     private class DigestCommand : Command
     {
-        public DigestCommand() : base("digest", "Queries the digest of a container image manifest")
+        public DigestCommand() : base("digest", "Queries the digest of a manifest")
         {
-            Argument<string> imageArg = new("image", "Name of the container image image (<image> or <image>:<tag>");
+            Argument<string> imageArg = new("name", "Name of the manifest (<name> or <name>:<tag>)");
             AddArgument(imageArg);
             this.SetHandler(ExecuteAsync, imageArg);
         }
@@ -57,6 +58,65 @@ public class ManifestCommand : Command
                 string digest = await client.Manifests.GetDigestAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
 
                 Console.Out.WriteLine(digest);
+            });
+        }
+    }
+
+    private class ResolveCommand : Command
+    {
+        private const string OsOptionName = "--os";
+        private const string OsVersionOptionName = "--os-version";
+        private const string ArchOptionName = "--arch";
+
+        public ResolveCommand() : base("resolve", "Resolves a manifest to a target platform's fully-qualified image digest")
+        {
+            Argument<string> imageArg = new("name", "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)");
+            AddArgument(imageArg);
+
+            Option<string?> osOpt = new(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")");
+            AddOption(osOpt);
+
+            Option<string?> osVersionOpt = new(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")");
+            AddOption(osVersionOpt);
+
+            Option<string?> archOpt = new(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")");
+            AddOption(archOpt);
+
+            this.SetHandler(ExecuteAsync, imageArg, osOpt, osVersionOpt, archOpt);
+        }
+
+        private Task ExecuteAsync(string image, string? os, string? osVersion, string? arch)
+        {
+            ImageName imageName = ImageName.Parse(image);
+            return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+            {
+                using DockerRegistryClient.DockerRegistryClient client = await CommandHelper.GetRegistryClientAsync(imageName.Registry);
+                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+
+                if (manifestInfo.Manifest is ManifestList manifestList)
+                {
+                    ManifestReference? manifestRef = manifestList.Manifests
+                        .SingleOrDefault(manifest =>
+                            manifest.Platform?.Os == os &&
+                            manifest.Platform?.OsVersion == osVersion &&
+                            manifest.Platform?.Architecture == arch);
+                    if (manifestRef is null)
+                    {
+                        throw new Exception(
+                            $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {OsOptionName}, {ArchOptionName}, and {OsVersionOptionName} (Windows only) to specify the target platform to match.");
+                    }
+
+                    if (manifestRef.Digest is null)
+                    {
+                        throw new Exception($"Digest of resolved manifest is not set.");
+                    }
+
+                    manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
+                }
+
+                ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
+
+                Console.Out.WriteLine(fullyQualifiedDigest.ToString());
             });
         }
     }


### PR DESCRIPTION
This adds a `manifest resolve` command which resolves a manifest name to a target platform, outputting a fully qualified digest value. This would primarily be used for resolving a manifest list to one of its underlying images, indicated by the options used to filter the platform: `os`, `arch`, `os-version`.

This also removes the same resolving functionality that previously existed in the `image inspect` command from https://github.com/mthalman/dredge/pull/17. The intent here is to have a standalone command that can be used to do this resolving behavior rather than integrating that behavior in all commands that it would be relevant to.