### PR TITLE
Add "image os" command to output OS info of an image

### DIFF
--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -1,5 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿using ICSharpCode.SharpZipLib.Tar;
+using Newtonsoft.Json;
 using System.CommandLine;
+using System.IO.Compression;
+using System.Text;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
 
@@ -10,6 +13,24 @@ public class ImageCommand : Command
     public ImageCommand() : base("image", "Commands related to container images")
     {
         AddCommand(new InspectCommand());
+        AddCommand(new OsCommand());
+    }
+
+    private static DockerManifestV2 GetManifest(string image, ManifestInfo manifestInfo)
+    {
+        if (manifestInfo.Manifest is ManifestList)
+        {
+            throw new NotSupportedException(
+                $"The name '{image}' is a manifest list and doesn't directly refer to an image. Resolve the manifest name to an image first by using the \"dredge manifest resolve\" command.");
+        }
+
+        if (manifestInfo.Manifest is not DockerManifestV2 manifest)
+        {
+            throw new NotSupportedException(
+                $"The image name '{image}' has a media type of '{manifestInfo.MediaType}' which is not supported.");
+        }
+
+        return manifest;
     }
 
     private class InspectCommand : Command
@@ -29,24 +50,12 @@ public class ImageCommand : Command
             {
                 using DockerRegistryClient.DockerRegistryClient client = await CommandHelper.GetRegistryClientAsync(imageName.Registry);
                 ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
-                
-                if (manifestInfo.Manifest is ManifestList)
-                {
-                    throw new NotSupportedException(
-                        $"The name '{image}' is a manifest list and doesn't directly refer to an image. Resolve the manifest name to an image first by using the \"dredge manifest resolve\" command.");
-                }
-                
-                if (manifestInfo.Manifest is not DockerManifestV2 manifest)
-                {
-                    throw new NotSupportedException(
-                        $"The image name '{image}' has a media type of '{manifestInfo.MediaType}' which is not supported.");
-                }
 
+                DockerManifestV2 manifest = GetManifest(image, manifestInfo);
                 string? digest = manifest.Config?.Digest;
-
                 if (digest is null)
                 {
-                    throw new NotSupportedException($"Could not resolve the image config digest of {image}.");
+                    throw new NotSupportedException($"Could not resolve the image config digest of '{image}'.");
                 }
 
                 Stream blob = await client.Blobs.GetAsync(imageName.Repo, digest);
@@ -56,6 +65,122 @@ public class ImageCommand : Command
                 string output = JsonConvert.SerializeObject(json, Formatting.Indented);
                 Console.Out.WriteLine(output);
             });
+        }
+    }
+
+    private class OsCommand : Command
+    {
+        public OsCommand() : base("os", "Gets OS info about the container image")
+        {
+            Argument<string> imageArg = new("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)");
+            AddArgument(imageArg);
+            this.SetHandler(ExecuteAsync, imageArg);
+        }
+
+        private Task ExecuteAsync(string image)
+        {
+            ImageName imageName = ImageName.Parse(image);
+            return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+            {
+                using DockerRegistryClient.DockerRegistryClient client = await CommandHelper.GetRegistryClientAsync(imageName.Registry);
+                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+
+                DockerManifestV2 manifest = GetManifest(image, manifestInfo);
+
+                string? configDigest = manifest.Config?.Digest;
+                if (configDigest is null)
+                {
+                    throw new NotSupportedException($"Could not resolve the image config digest of '{image}'.");
+                }
+
+                Image imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, configDigest);
+
+                ManifestLayer baseLayer = manifest.Layers.First();
+                if (baseLayer.Digest is null)
+                {
+                    throw new Exception($"No digest was found for the base layer of '{image}'.");
+                }
+
+                object? osInfo;
+                if (imageConfig.Os.Equals("windows", StringComparison.OrdinalIgnoreCase))
+                {
+                    osInfo = await GetWindowsOsInfoAsync(imageConfig, baseLayer.Digest);
+                }
+                else
+                {
+                    osInfo = await GetLinuxOsInfoAsync(client, imageName, baseLayer.Digest);
+                }
+
+                if (osInfo is null)
+                {
+                    throw new Exception("Unable to derive OS information from the image.");
+                }
+
+                string output = JsonConvert.SerializeObject(osInfo, new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    Formatting = Formatting.Indented
+                });
+                Console.Out.WriteLine(output);
+            });
+        }
+
+        private static async Task<LinuxOsInfo?> GetLinuxOsInfoAsync(DockerRegistryClient.DockerRegistryClient client, ImageName imageName, string baseLayerDigest)
+        {
+            Stream blobStream = await client.Blobs.GetAsync(imageName.Repo, baseLayerDigest);
+            GZipStream gZipStream = new(blobStream, CompressionMode.Decompress);
+
+            // Can't use System.Formats.Tar.TarReader because it fails to read certain types of tarballs:
+            // https://github.com/dotnet/runtime/issues/74316#issuecomment-1312227247
+
+            using TarInputStream tarStream = new(gZipStream, Encoding.UTF8);
+            TarEntry? entry = null;
+            do
+            {
+                entry = tarStream.GetNextEntry();
+
+                // Look for the os-release file (skip symlinks)
+                if (entry is not null &&
+                    entry.Size > 0 &&
+                    (entry.Name == "etc/os-release" || entry.Name == "usr/lib/os-release"))
+                {
+                    using MemoryStream memStream = new();
+                    tarStream.CopyEntryContents(memStream);
+                    memStream.Position = 0;
+                    using StreamReader reader = new(memStream);
+                    string content = await reader.ReadToEndAsync();
+                    return LinuxOsInfo.Parse(content);
+                }
+            } while (entry is not null);
+
+            return null;
+        }
+
+        private static async Task<WindowsOsInfo?> GetWindowsOsInfoAsync(Image imageConfig, string baseLayerDigest)
+        {
+            using DockerRegistryClient.DockerRegistryClient mcrClient =
+                await CommandHelper.GetRegistryClientAsync("mcr.microsoft.com");
+
+            if (await mcrClient.Blobs.ExistsAsync("windows/nanoserver", baseLayerDigest))
+            {
+                return new(WindowsType.NanoServer, imageConfig.OsVersion);
+            }
+            else if (await mcrClient.Blobs.ExistsAsync("windows/servercore", baseLayerDigest))
+            {
+                return new(WindowsType.ServerCore, imageConfig.OsVersion);
+            }
+            else if (await mcrClient.Blobs.ExistsAsync("windows/server", baseLayerDigest))
+            {
+                return new(WindowsType.Server, imageConfig.OsVersion);
+            }
+            else if (await mcrClient.Blobs.ExistsAsync("windows", baseLayerDigest))
+            {
+                return new(WindowsType.Windows, imageConfig.OsVersion);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/Valleysoft.Dredge/LinuxOsInfo.cs
+++ b/src/Valleysoft.Dredge/LinuxOsInfo.cs
@@ -1,0 +1,89 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.Dredge;
+
+public record LinuxOsInfo
+{
+    [JsonProperty("PRETTY_NAME")]
+    public string? PrettyName { get; private set; }
+
+    [JsonProperty("NAME")]
+    public string? Name { get; private set; }
+
+    [JsonProperty("ID")]
+    public string? Id { get; private set; }
+
+    [JsonProperty("ID_LIKE")]
+    public string[]? IdLike { get; private set; }
+
+    [JsonProperty("VERSION")]
+    public string? Version { get; private set; }
+
+    [JsonProperty("VERSION_ID")]
+    public string? VersionId { get; private set; }
+
+    [JsonProperty("VERSION_CODENAME")]
+    public string? VersionCodeName { get; private set; }
+
+    [JsonProperty("BUILD_ID")]
+    public string? BuildId { get; private set; }
+
+    [JsonProperty("IMAGE_ID")]
+    public string? ImageId { get; private set; }
+
+    [JsonProperty("IMAGE_VERSION")]
+    public string? ImageVersion { get; private set; }
+
+    [JsonProperty("VARIANT")]
+    public string? Variant { get; private set; }
+
+    [JsonProperty("VARIANT_ID")]
+    public string? VariantId { get; private set; }
+
+    [JsonProperty("HOME_URL")]
+    public string? HomeUrl { get; private set; }
+
+    [JsonProperty("SUPPORT_URL")]
+    public string? SupportUrl { get; private set; }
+
+    [JsonProperty("BUG_REPORT_URL")]
+    public string? BugReportUrl { get; private set; }
+
+    [JsonProperty("PRIVACY_POLICY_URL")]
+    public string? PrivacyPolicyUrl { get; private set; }
+
+    [JsonProperty("CPE_NAME")]
+    public string? CpeName { get; private set; }
+
+    public static LinuxOsInfo Parse(string osInfoContent)
+    {
+        Dictionary<string, string> osFields = new(osInfoContent
+            .Split("\n", StringSplitOptions.RemoveEmptyEntries)
+            .Select(line =>
+            {
+                int index = line.IndexOf('=');
+                return new KeyValuePair<string, string>(line[..index], line[(index + 1)..].TrimStart('"').TrimEnd('"'));
+            }));
+
+        return new LinuxOsInfo
+        {
+            PrettyName = osFields.GetValueOrDefault("PRETTY_NAME"),
+            Name = osFields.GetValueOrDefault("NAME"),
+            Id = osFields.GetValueOrDefault("ID"),
+            IdLike = osFields.GetValueOrDefault("ID_LIKE")?.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+            Version = osFields.GetValueOrDefault("VERSION"),
+            VersionId = osFields.GetValueOrDefault("VERSION_ID"),
+            VersionCodeName = osFields.GetValueOrDefault("VERSION_CODENAME"),
+            BuildId = osFields.GetValueOrDefault("BUILD_ID"),
+            ImageId = osFields.GetValueOrDefault("IMAGE_ID"),
+            ImageVersion = osFields.GetValueOrDefault("IMAGE_VERSION"),
+            Variant = osFields.GetValueOrDefault("VARIANT"),
+            VariantId = osFields.GetValueOrDefault("VARIANT_ID"),
+            HomeUrl = osFields.GetValueOrDefault("HOME_URL"),
+            SupportUrl = osFields.GetValueOrDefault("SUPPORT_URL"),
+            BugReportUrl = osFields.GetValueOrDefault("BUG_REPORT_URL"),
+            PrivacyPolicyUrl = osFields.GetValueOrDefault("PRIVACY_POLICY_URL"),
+            CpeName = osFields.GetValueOrDefault("CPE_NAME")
+        };
+    }
+}

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -27,9 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.4.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
-    <PackageReference Include="Valleysoft.DockerRegistryClient" Version="2.0.0" />
+    <PackageReference Include="Valleysoft.DockerRegistryClient" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Valleysoft.Dredge/WindowsOsInfo.cs
+++ b/src/Valleysoft.Dredge/WindowsOsInfo.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace Valleysoft.Dredge;
+
+public record WindowsOsInfo
+{
+    public WindowsOsInfo(WindowsType type, string? version)
+    {
+        Type = type;
+        Version = version;
+    }
+
+    public WindowsType Type { get; private set; }
+    
+    public string? Version { get; private set; }
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum WindowsType
+{
+    [EnumMember(Value = "Nano Server")]
+    NanoServer,
+
+    [EnumMember(Value = "Server Core")]
+    ServerCore,
+
+    [EnumMember(Value = "Server")]
+    Server,
+
+    [EnumMember(Value = "Windows")]
+    Windows
+}


### PR DESCRIPTION
This new "image os" command allows a caller to output the OS information of the specified image. In the case of a Linux image, it will output the contents of the `os-release` file in a JSON format. For Windows, it will return back a JSON format consisting of a Type and Version field.

### Examples

#### Linux

```
> dredge image os mcr.microsoft.com/dotnet/runtime@sha256:653251de361edf015e5ba8fd67e69543d3f32d91777cfdbf501bcab8aad5745b
{
  "PRETTY_NAME": "Alpine Linux v3.16",
  "NAME": "Alpine Linux",
  "ID": "alpine",
  "VERSION_ID": "3.16.2",
  "HOME_URL": "https://alpinelinux.org/",
  "BUG_REPORT_URL": "https://gitlab.alpinelinux.org/alpine/aports/-/issues"
}
```

#### Windows 

```
> dredge image os mcr.microsoft.com/dotnet/runtime@sha256:ebefddf43d2d74decc311aebf417df3b231d2d8d8221261a940cd44a2e4d7d1f
{
  "Type": "Server Core",
  "Version": "10.0.20348.1249"
}
```