### PR TITLE
Defines "image compare layers" command

### DIFF
--- a/src/Valleysoft.Dredge/CompareLayersResult.cs
+++ b/src/Valleysoft.Dredge/CompareLayersResult.cs
@@ -1,0 +1,82 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace Valleysoft.Dredge;
+
+public class CompareLayersResult
+{
+    public CompareLayersResult(CompareLayersSummary summary, IEnumerable<LayerComparison> layerComparisons)
+    {
+        Summary = summary;
+        LayerComparisons = layerComparisons;
+    }
+
+    public CompareLayersSummary Summary { get; }
+    public IEnumerable<LayerComparison> LayerComparisons { get; }
+}
+
+public class CompareLayersSummary
+{
+    public CompareLayersSummary(bool areEqual, bool targetIncludesAllBaseLayers, int commonLayerIndex)
+    {
+        AreEqual = areEqual;
+        TargetIncludesAllBaseLayers = targetIncludesAllBaseLayers;
+        LastCommonLayerIndex = commonLayerIndex;
+    }
+
+    /// <summary>
+    /// Indicates whether the two images have the same set of layers.
+    /// </summary>
+    public bool AreEqual { get; }
+
+    /// <summary>
+    /// Indicates whether the target image includes all the layers that the base image has.
+    /// </summary>
+    public bool TargetIncludesAllBaseLayers { get; }
+
+    /// <summary>
+    /// Indicates the index of the last layer shared by the two images. Any layers after this index indicates divergence between
+    /// the two images.
+    /// </summary>
+    public int LastCommonLayerIndex { get; }
+}
+
+public class LayerComparison
+{
+    public LayerComparison(LayerInfo? baseLayer, LayerInfo? targetLayer, LayerDiff layerDiff)
+    {
+        Base = baseLayer;
+        Target = targetLayer;
+        LayerDiff = layerDiff;
+    }
+
+    public LayerInfo? Base { get; }
+    public LayerInfo? Target { get; }
+    public LayerDiff LayerDiff { get; }
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum LayerDiff
+{
+    [EnumMember(Value = "Equal")]
+    Equal,
+    [EnumMember(Value = "Not Equal")]
+    NotEqual,
+    [EnumMember(Value = "Added")]
+    Added,
+    [EnumMember(Value = "Removed")]
+    Removed
+}
+
+public class LayerInfo
+{
+    public LayerInfo(string digest, string? history)
+    {
+        Digest = digest;
+        History = history;
+    }
+
+    public string Digest { get; }
+    public string? History { get; }
+}

--- a/src/Valleysoft.Dredge/CompareOutputFormat.cs
+++ b/src/Valleysoft.Dredge/CompareOutputFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace Valleysoft.Dredge;
+
+internal enum CompareOutputFormat
+{
+    SideBySide,
+    Inline,
+    Json
+}

--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -1,7 +1,11 @@
 ﻿using ICSharpCode.SharpZipLib.Tar;
 using Newtonsoft.Json;
+using Spectre.Console;
+using Spectre.Console.Rendering;
 using System.CommandLine;
 using System.IO.Compression;
+using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
@@ -14,6 +18,7 @@ public class ImageCommand : Command
     {
         AddCommand(new InspectCommand());
         AddCommand(new OsCommand());
+        AddCommand(new CompareCommand());
     }
 
     private static DockerManifestV2 GetManifest(string image, ManifestInfo manifestInfo)
@@ -33,7 +38,7 @@ public class ImageCommand : Command
         return manifest;
     }
 
-    private class InspectCommand : Command
+    public class InspectCommand : Command
     {
         public InspectCommand() : base("inspect", "Return low-level information on a container image")
         {
@@ -68,7 +73,7 @@ public class ImageCommand : Command
         }
     }
 
-    private class OsCommand : Command
+    public class OsCommand : Command
     {
         public OsCommand() : base("os", "Gets OS info about the container image")
         {
@@ -180,6 +185,336 @@ public class ImageCommand : Command
             else
             {
                 return null;
+            }
+        }
+    }
+
+    public class CompareCommand : Command
+    {
+        public CompareCommand() : base("compare", "Compares two images")
+        {
+            AddCommand(new LayersCommand());
+        }
+
+        public class LayersCommand : Command
+        {
+            public LayersCommand() : base("layers", "Compares two images by layers")
+            {
+                Argument<string> baseImageArg = new("base", "Name of the base container image (<image>, <image>:<tag>, or <image>@<digest>)");
+                AddArgument(baseImageArg);
+
+                Argument<string> targetImageArg = new("target", "Name of the target container image (<image>, <image>:<tag>, or <image>@<digest>)");
+                AddArgument(targetImageArg);
+
+                Option<CompareOutputFormat> outputOption = new("--output", () => CompareOutputFormat.SideBySide, "Output format");
+                AddOption(outputOption);
+
+                Option<bool> noColorOption = new("--no-color", "Disables dependency on color in comparison results");
+                AddOption(noColorOption);
+
+                Option<bool> historyOption = new("--history", "Include layer history");
+                AddOption(historyOption);
+
+                this.SetHandler(ExecuteAsync, baseImageArg, targetImageArg, outputOption, noColorOption, historyOption);
+            }
+
+            private Task ExecuteAsync(string baseImage, string targetImage, CompareOutputFormat outputFormat, bool isColorDisabled, bool includeHistory)
+            {
+                return CommandHelper.ExecuteCommandAsync(registry: null, async () =>
+                {
+                    CompareLayersResult result = await GetCompareLayersResult(baseImage, targetImage, includeHistory);
+
+                    switch (outputFormat)
+                    {
+                        case CompareOutputFormat.SideBySide:
+                            GenerateTable(result, baseImage, targetImage, isColorDisabled, includeHistory);
+                            break;
+                        case CompareOutputFormat.Inline:
+                            GenerateInline(result, isColorDisabled, includeHistory);
+                            break;
+                        case CompareOutputFormat.Json:
+                            GenerateJson(result);
+                            break;
+                        default:
+                            throw new NotImplementedException();
+                    }
+                });
+            }
+
+            private static async Task<CompareLayersResult> GetCompareLayersResult(string baseImage, string targetImage, bool includeHistory)
+            {
+                IList<LayerInfo> baseLayers = await GetLayersAsync(baseImage, includeHistory);
+                IList<LayerInfo> targetLayers = await GetLayersAsync(targetImage, includeHistory);
+                List<LayerComparison> layerComparisons = GetLayerComparisons(baseLayers, targetLayers);
+                CompareLayersSummary summary = GetSummary(layerComparisons);
+
+                return new CompareLayersResult(
+                    summary,
+                    layerComparisons);
+            }
+
+            private static CompareLayersSummary GetSummary(List<LayerComparison> layerComparisons)
+            {
+                bool areEqual = layerComparisons.All(comparison => comparison.LayerDiff == LayerDiff.Equal);
+                bool targetIncludesAllBaseLayers =
+                    areEqual ||
+                    !layerComparisons
+                        .Any(comparison => comparison.LayerDiff == LayerDiff.NotEqual || comparison.LayerDiff == LayerDiff.Removed);
+                int lastCommonLayerIndex = -1;
+                if (areEqual)
+                {
+                    lastCommonLayerIndex = layerComparisons.Count - 1;
+                }
+                else
+                {
+                    LayerComparison? lastEqualLayer = layerComparisons
+                        .LastOrDefault(comparison => comparison.LayerDiff == LayerDiff.Equal);
+                    if (lastEqualLayer is not null)
+                    {
+                        lastCommonLayerIndex = layerComparisons.IndexOf(lastEqualLayer);
+                    }
+                }
+
+                CompareLayersSummary summary = new(areEqual, targetIncludesAllBaseLayers, lastCommonLayerIndex);
+                return summary;
+            }
+
+            private static List<LayerComparison> GetLayerComparisons(IList<LayerInfo> baseLayers, IList<LayerInfo> targetLayers)
+            {
+                List<LayerComparison> layerComparisons = new();
+                int max = Math.Max(baseLayers.Count, targetLayers.Count);
+                for (int i = 0; i < max; i++)
+                {
+                    LayerInfo? baseLayer = null;
+                    LayerInfo? targetLayer = null;
+                    if (i < baseLayers.Count)
+                    {
+                        baseLayer = baseLayers[i];
+                    }
+                    if (i < targetLayers.Count)
+                    {
+                        targetLayer = targetLayers[i];
+                    }
+
+                    LayerDiff diff = GetLayerDiff(baseLayer, targetLayer);
+                    layerComparisons.Add(new LayerComparison(baseLayer, targetLayer, diff));
+                }
+
+                return layerComparisons;
+            }
+
+            private static LayerDiff GetLayerDiff(LayerInfo? baseLayer, LayerInfo? targetLayer)
+            {
+                LayerDiff diff;
+                if (baseLayer is null)
+                {
+                    if (targetLayer is null)
+                    {
+                        throw new Exception("Unexpected layer result: two null layers");
+                    }
+
+                    diff = LayerDiff.Added;
+                }
+                else
+                {
+                    if (targetLayer is null)
+                    {
+                        diff = LayerDiff.Removed;
+                    }
+                    else
+                    {
+                        diff = (baseLayer.Digest.Equals(targetLayer.Digest, StringComparison.OrdinalIgnoreCase)) ?
+                            LayerDiff.Equal : LayerDiff.NotEqual;
+                    }
+                }
+
+                return diff;
+            }
+
+            private static void GenerateJson(CompareLayersResult result)
+            {
+                string output = JsonConvert.SerializeObject(result, new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    Formatting = Formatting.Indented
+                });
+                Console.Out.WriteLine(output);
+            }
+
+            private static void GenerateInline(CompareLayersResult result, bool isColorDisabled, bool includeHistory)
+            {
+                List<IRenderable> rows = new();
+
+                for (int i = 0; i < result.LayerComparisons.Count(); i++)
+                {
+                    LayerComparison layerComparison = result.LayerComparisons.ElementAt(i);
+
+                    if (layerComparison.Base is not null)
+                    {
+                        AddInlineLayerInfo(rows, layerComparison.Base, layerComparison.LayerDiff, isBase: true, isColorDisabled, includeHistory);
+                    }
+
+                    if (layerComparison.LayerDiff != LayerDiff.Equal && layerComparison.Target is not null)
+                    {
+                        AddInlineLayerInfo(rows, layerComparison.Target, layerComparison.LayerDiff, isBase: false, isColorDisabled, includeHistory);
+                    }
+
+                    if (includeHistory && i + 1 != result.LayerComparisons.Count())
+                    {
+                        rows.Add(new Text(string.Empty));
+                    }
+                }
+
+                AnsiConsole.Write(new Rows(rows));
+            }
+
+            private static void AddInlineLayerInfo(List<IRenderable> rows, LayerInfo layer, LayerDiff diff, bool isBase,
+                bool isColorDisabled, bool includeHistory)
+            {
+                rows.Add(GetDigestMarkup(layer, diff, isBase, isColorDisabled, includeHistory, isInline: true));
+                if (includeHistory)
+                {
+                    rows.Add(GetHistoryMarkup(layer, diff, isBase, isColorDisabled, isInline: true));
+                }
+            }
+
+            private static void GenerateTable(CompareLayersResult result, string baseImage, string targetImage, bool isColorDisabled,
+                bool includeHistory)
+            {
+                Table table = new Table()
+                    .AddColumn(baseImage);
+
+                if (isColorDisabled)
+                {
+                    // Use a comparison column to indicate the diff result with text instead of color
+                    table.AddColumn(new TableColumn("Compare") { Alignment = Justify.Center });
+                }
+
+                table.AddColumn(targetImage);
+
+                for (int i = 0; i < result.LayerComparisons.Count(); i++)
+                {
+                    AddTableRows(result, isColorDisabled, includeHistory, table, i);
+                }
+
+                AnsiConsole.Write(table);
+            }
+
+            private static void AddTableRows(CompareLayersResult result, bool isColorDisabled, bool includeHistory, Table table, int i)
+            {
+                LayerComparison layerComparison = result.LayerComparisons.ElementAt(i);
+                IEnumerable<IRenderable> digestRowCells =
+                    GetDigestRowCells(isColorDisabled, includeHistory, table, layerComparison);
+                table.AddRow(digestRowCells);
+
+                if (includeHistory)
+                {
+                    List<IRenderable> historyRowCells = GetHistoryRowCells(isColorDisabled, layerComparison);
+                    table.AddRow(historyRowCells);
+
+                    if (i + 1 != result.LayerComparisons.Count())
+                    {
+                        table.AddEmptyRow();
+                    }
+                }
+            }
+
+            private static List<IRenderable> GetHistoryRowCells(bool isColorDisabled, LayerComparison layerComparison)
+            {
+                List<IRenderable> historyCells = new()
+                {
+                    GetHistoryMarkup(layerComparison.Base, layerComparison.LayerDiff, isBase: true, isColorDisabled, isInline: false)
+                };
+
+                if (isColorDisabled)
+                {
+                    historyCells.Add(new Markup(string.Empty));
+                }
+
+                historyCells.Add(GetHistoryMarkup(layerComparison.Target, layerComparison.LayerDiff, isBase: false, isColorDisabled, isInline: false));
+                return historyCells;
+            }
+
+            private static IEnumerable<IRenderable> GetDigestRowCells(bool isColorDisabled, bool includeHistory, Table table, LayerComparison layerComparison)
+            {
+                List<IRenderable> shaCells = new()
+                {
+                    GetDigestMarkup(
+                        layerComparison.Base, layerComparison.LayerDiff, isBase : true, isColorDisabled, includeHistory, isInline: false)
+                };
+                if (isColorDisabled)
+                {
+                    shaCells.Add(new Markup(GetLayerDiffDisplayName(layerComparison.LayerDiff)));
+                }
+
+                shaCells.Add(
+                    GetDigestMarkup(
+                        layerComparison.Target, layerComparison.LayerDiff, isBase: false, isColorDisabled, includeHistory, isInline: false));
+                return shaCells;
+            }
+
+            private static string GetLayerDiffDisplayName(LayerDiff diff) =>
+                typeof(LayerDiff).GetMember(diff.ToString()).Single().GetCustomAttribute<EnumMemberAttribute>()?.Value ??
+                    throw new Exception($"Enum member not set for {diff}.");
+
+            private static Color GetLayerDiffColor(LayerDiff diff, bool isBaseLayer, bool isColorDisabled) =>
+                isColorDisabled ? Color.Default : diff switch
+                {
+                    LayerDiff.Removed => Color.Red,
+                    LayerDiff.Added => Color.Green,
+                    LayerDiff.NotEqual => isBaseLayer ? Color.Red : Color.Green,
+                    LayerDiff.Equal => Color.Default,
+                    _ => throw new NotImplementedException()
+                };
+
+            private static Markup GetHistoryMarkup(LayerInfo? layer, LayerDiff diff, bool isBase, bool isColorDisabled,
+                bool isInline) =>
+                new(
+                    Markup.Escape($"{GetTextOffset(diff, isInline, isBase)}{layer?.History ?? string.Empty}"),
+                    new Style(GetLayerDiffColor(diff, isBaseLayer: true, isColorDisabled)));
+
+            private static Markup GetDigestMarkup(LayerInfo? layer, LayerDiff diff, bool isBase, bool isColorDisabled,
+                bool includeHistory, bool isInline) =>
+                new(
+                    Markup.Escape($"{GetTextOffset(diff, isInline, isBase)}{layer?.Digest ?? string.Empty}"),
+                    new Style(
+                        foreground: GetLayerDiffColor(diff, isBase, isColorDisabled),
+                        decoration: includeHistory ? Decoration.Invert : Decoration.None));
+
+            private static string GetTextOffset(LayerDiff diff, bool isInline, bool isBase) =>
+                !isInline ? string.Empty : diff switch
+                {
+                    LayerDiff.Added => "+ ",
+                    LayerDiff.Equal => "  ",
+                    LayerDiff.NotEqual => isBase ? "- " : "+ ",
+                    LayerDiff.Removed => "- ",
+                    _ => throw new NotImplementedException()
+                };
+
+            private static async Task<IList<LayerInfo>> GetLayersAsync(string image, bool includeHistory)
+            {
+                ImageName imageName = ImageName.Parse(image);
+                using DockerRegistryClient.DockerRegistryClient client =
+                    await CommandHelper.GetRegistryClientAsync(imageName.Registry);
+                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+
+                DockerManifestV2 manifest = GetManifest(image, manifestInfo);
+
+                string? digest = manifest.Config?.Digest;
+                if (digest is null)
+                {
+                    throw new NotSupportedException($"Could not resolve the image config digest of '{image}'.");
+                }
+
+                Image imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, digest);
+
+                IList<LayerInfo> layerInfos = manifest.Layers
+                    .Zip(
+                        imageConfig.History.Where(hist => !hist.IsEmptyLayer),
+                        (layer, history) => new LayerInfo(layer.Digest!, includeHistory ? history.CreatedBy : null))
+                    .ToList();
+
+                return layerInfos;
             }
         }
     }

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.4.1" />
+    <PackageReference Include="Spectre.Console" Version="0.45.1-preview.0.40" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
     <PackageReference Include="Valleysoft.DockerRegistryClient" Version="3.0.0" />


### PR DESCRIPTION
This "image compare layers" command allows you to compare the layer digests of two images.

There are a variety of output options available:
* SideBySide (default): Displays the comparison side-by-side in a table layout
* Inline: Displays the comparison in an inline fashion
* JSON: Returns a JSON representation of the comparison, including summary analysis

There's also a `--history` option to include the layer history information associated with the given layer. This can provide helpful context for a layer digest to understand how it was derived.

By default, the comparison makes use of green and red colors to indicate differences. For accessibility purposes, you can choose to use the `--no-color` option which will disable the use of these colors and use textual means to indicate diffs instead.