### PR TITLE
Change history option to compare layer history

### DIFF
--- a/src/Valleysoft.Dredge/CompareLayersResult.cs
+++ b/src/Valleysoft.Dredge/CompareLayersResult.cs
@@ -71,12 +71,12 @@ public enum LayerDiff
 
 public class LayerInfo
 {
-    public LayerInfo(string digest, string? history)
+    public LayerInfo(string? digest, string? history)
     {
         Digest = digest;
         History = history;
     }
 
-    public string Digest { get; }
+    public string? Digest { get; }
     public string? History { get; }
 }


### PR DESCRIPTION
This updates the `--history` option of the ["image compare layers" command](https://github.com/mthalman/dredge/pull/20) to compare layer history in addition to the layer digests. Previously the option only included the history in the output but didn't actually participate in the comparison. This then also accounts for empty layers as well. So even if a Dockerfile had layer digests that were identical, if a difference existed in the history (such as a LABEL instruction), that would show as a diff.