### PR TITLE
Fix implicit latest tag handling

### DIFF
--- a/src/Valleysoft.Dredge/ImageName.cs
+++ b/src/Valleysoft.Dredge/ImageName.cs
@@ -15,7 +15,7 @@ public class ImageName
     public string? Tag { get; }
     public string? Digest { get; }
 
-    public static ImageName Parse(string imageName, bool requireTagOrDigest = false)
+    public static ImageName Parse(string imageName)
     {
         string? registry = null;
         int separatorIndex = imageName.IndexOf('/');
@@ -46,9 +46,9 @@ public class ImageName
             digest = imageName[(separatorIndex + 1)..];
         }
 
-        if (requireTagOrDigest && tag is null && digest is null)
+        if (tag is null && digest is null)
         {
-            throw new ArgumentException($"Image name '{imageName}' is missing a tag or digest", nameof(imageName));
+            tag = "latest";
         }
 
         string repo;


### PR DESCRIPTION
Commands that accept an image name should allow an implicit `latest` tag if no tag is specified with the repo name. This wasn't handled properly, causing commands to attempt to query the registry with an empty value for the tag, resulting in a 404.

This is fixed by automatically resolving a missing tag value to `latest`.