### PR TITLE
Fixes incorrect color for history row in sxs comparison

### DIFF
--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -358,7 +358,7 @@ public class ImageCommand : Command
                 bool isInline) =>
                 new(
                     Markup.Escape($"{GetTextOffset(diff, isInline, isBase)}{layer?.History ?? string.Empty}"),
-                    new Style(GetLayerDiffColor(diff, isBaseLayer: true, isColorDisabled)));
+                    new Style(GetLayerDiffColor(diff, isBaseLayer: isBase, isColorDisabled)));
 
             private static Markup GetDigestMarkup(LayerInfo? layer, LayerDiff diff, bool isBase, bool isColorDisabled,
                 bool includeHistory, bool isInline)
@@ -486,9 +486,9 @@ public class ImageCommand : Command
                     private static List<IRenderable> GetHistoryRowCells(bool isColorDisabled, LayerComparison layerComparison)
                     {
                         List<IRenderable> historyCells = new()
-                    {
-                        GetHistoryMarkup(layerComparison.Base, layerComparison.LayerDiff, isBase: true, isColorDisabled, isInline: false)
-                    };
+                        {
+                            GetHistoryMarkup(layerComparison.Base, layerComparison.LayerDiff, isBase: true, isColorDisabled, isInline: false)
+                        };
 
                         if (isColorDisabled)
                         {
@@ -502,10 +502,10 @@ public class ImageCommand : Command
                     private static IEnumerable<IRenderable> GetDigestRowCells(bool isColorDisabled, bool includeHistory, LayerComparison layerComparison)
                     {
                         List<IRenderable> shaCells = new()
-                    {
-                        GetDigestMarkup(
-                            layerComparison.Base, layerComparison.LayerDiff, isBase : true, isColorDisabled, includeHistory, isInline: false)
-                    };
+                        {
+                            GetDigestMarkup(
+                                layerComparison.Base, layerComparison.LayerDiff, isBase : true, isColorDisabled, includeHistory, isInline: false)
+                        };
                         if (isColorDisabled)
                         {
                             shaCells.Add(new Markup(GetLayerDiffDisplayName(layerComparison.LayerDiff)));


### PR DESCRIPTION
The `SideBySide` format for image layer comparison was not using the correct foreground color of the history row for the target image. In cases where it should have been green, it was showing red. This was due to not indicating the state correctly for whether the row represented the base image or not.

Before fix:

![image](https://user-images.githubusercontent.com/15789599/204679422-57540513-798f-4574-9f10-f2cc61449082.png)


After fix:

![image](https://user-images.githubusercontent.com/15789599/204679363-8bd4262f-e019-42a5-ae4d-82e1839d76dc.png)
