### PR TITLE
Adds "image compare files" command

### DIFF
--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -14,7 +14,7 @@ public class CompareLayersCommandTests
     private static readonly ImageName baseImageName = ImageName.Parse($"{Registry}/base:latest");
     private static readonly ImageName targetImageName = ImageName.Parse($"{Registry}/target:latest");
 
-    public static object[][] GetTestData(CompareOutputFormat format)
+    public static object[][] GetTestData(CompareLayersOutput format)
     {
         CommandOptions[] optionsSet = new[]
         {
@@ -45,7 +45,7 @@ public class CompareLayersCommandTests
     private static class Scenarios
     {
         // Identical images
-        public static object[] GetEqualImagesTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetEqualImagesTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -78,7 +78,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json => new CompareLayersResult(
+                CompareLayersOutput.Json => new CompareLayersResult(
                     new CompareLayersSummary(areEqual: true, targetIncludesAllBaseLayers: true, lastCommonLayerIndex: 1),
                     new LayerComparison[]
                     {
@@ -91,7 +91,7 @@ public class CompareLayersCommandTests
                         new LayerInfo("layer-1", options.IncludeHistory ? "b" : null),
                         LayerDiff.Equal)
                     }),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -103,7 +103,7 @@ public class CompareLayersCommandTests
                       layer-0
                       layer-1
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -125,7 +125,7 @@ public class CompareLayersCommandTests
         }
 
         // Same base layer, but next layer differs
-        public static object[] GetDifferingImagesTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetDifferingImagesTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -183,7 +183,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json =>
+                CompareLayersOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: false, lastCommonLayerIndex: 0),
                         new LayerComparison[]
@@ -197,7 +197,7 @@ public class CompareLayersCommandTests
                                 new LayerInfo("layer-1a", options.IncludeHistory ? "b" : null),
                                 LayerDiff.NotEqual)
                         }),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -212,7 +212,7 @@ public class CompareLayersCommandTests
                     - layer-1
                     + layer-1a
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -234,7 +234,7 @@ public class CompareLayersCommandTests
         }
 
         // Target removes a layer from base
-        public static object[] GetRemovedLayerFromBaseTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetRemovedLayerFromBaseTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -284,7 +284,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json =>
+                CompareLayersOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: false, lastCommonLayerIndex: 0),
                         new LayerComparison[]
@@ -298,7 +298,7 @@ public class CompareLayersCommandTests
                                 null,
                                 LayerDiff.Removed)
                         }),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -310,7 +310,7 @@ public class CompareLayersCommandTests
                       layer-0
                     - layer-1
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -332,7 +332,7 @@ public class CompareLayersCommandTests
         }
 
         // Target adds a layer
-        public static object[] GetAddedLayerTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetAddedLayerTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -382,7 +382,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json =>
+                CompareLayersOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: true, lastCommonLayerIndex: 0),
                         new LayerComparison[]
@@ -396,7 +396,7 @@ public class CompareLayersCommandTests
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b" : null),
                                 LayerDiff.Added)
                         }),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -408,7 +408,7 @@ public class CompareLayersCommandTests
                       layer-0
                     + layer-1
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -430,7 +430,7 @@ public class CompareLayersCommandTests
         }
 
         // The images only differ by history
-        public static object[] GetDifferByHistoryOnlyTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetDifferByHistoryOnlyTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -488,7 +488,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json =>
+                CompareLayersOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(
                             areEqual: !options.IncludeHistory,
@@ -505,7 +505,7 @@ public class CompareLayersCommandTests
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b1" : null),
                                 options.IncludeHistory ? LayerDiff.NotEqual : LayerDiff.Equal)
                         }),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -519,7 +519,7 @@ public class CompareLayersCommandTests
                       layer-0
                       layer-1
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -541,7 +541,7 @@ public class CompareLayersCommandTests
         }
 
         // The images contain empty layers that differ in their history
-        public static object[] GetWithHistoryDifferingByEmptyLayersTestData(CompareOutputFormat format, CommandOptions options)
+        public static object[] GetWithHistoryDifferingByEmptyLayersTestData(CompareLayersOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -630,14 +630,14 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareOutputFormat.Json =>
+                CompareLayersOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(
                             areEqual: !options.IncludeHistory,
                             targetIncludesAllBaseLayers: !options.IncludeHistory,
                             lastCommonLayerIndex: options.IncludeHistory ? 0 : 1),
                         comparisons),
-                CompareOutputFormat.Inline => options.IncludeHistory ?
+                CompareLayersOutput.Inline => options.IncludeHistory ?
                     """
                       layer-0
                       a
@@ -654,7 +654,7 @@ public class CompareLayersCommandTests
                       layer-0
                       layer-1
                     """,
-                CompareOutputFormat.SideBySide =>
+                CompareLayersOutput.SideBySide =>
                     ToArray(
                         DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
                         HistoryRow("a", "a", options),
@@ -706,32 +706,32 @@ public class CompareLayersCommandTests
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareOutputFormat.Json)]
+    [MemberData(nameof(GetTestData), CompareLayersOutput.Json)]
     public async void Json(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, CompareLayersResult expectedResult)
     {
-        Text text = (Text)await ExecuteTestAsync(scenario, CompareOutputFormat.Json, cmdOptions, baseImageSetup, targetImageSetup);
+        Text text = (Text)await ExecuteTestAsync(scenario, CompareLayersOutput.Json, cmdOptions, baseImageSetup, targetImageSetup);
 
         CompareLayersResult actualResult = GetJson<CompareLayersResult>(text.GetSegments(AnsiConsole.Console));
         CompareJson(expectedResult, actualResult);
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareOutputFormat.Inline)]
+    [MemberData(nameof(GetTestData), CompareLayersOutput.Inline)]
     public async void Inline(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, string expectedResult)
     {
-        Rows rows = (Rows)await ExecuteTestAsync(scenario, CompareOutputFormat.Inline, cmdOptions, baseImageSetup, targetImageSetup);
+        Rows rows = (Rows)await ExecuteTestAsync(scenario, CompareLayersOutput.Inline, cmdOptions, baseImageSetup, targetImageSetup);
         string actualResult = GetString(rows.GetSegments(AnsiConsole.Console));
         Assert.Equal(Normalize(expectedResult), Normalize(actualResult));
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareOutputFormat.SideBySide)]
+    [MemberData(nameof(GetTestData), CompareLayersOutput.SideBySide)]
     public async void SideBySide(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, string[][] expectedRows)
     {
-        Table table = (Table)await ExecuteTestAsync(scenario, CompareOutputFormat.SideBySide, cmdOptions, baseImageSetup, targetImageSetup);
+        Table table = (Table)await ExecuteTestAsync(scenario, CompareLayersOutput.SideBySide, cmdOptions, baseImageSetup, targetImageSetup);
 
         Assert.Equal(cmdOptions.IsColorDisabled ? 3 : 2, table.Columns.Count);
         Assert.Equal(baseImageName.ToString(), GetString(table.Columns[0].Header.GetSegments(AnsiConsole.Console)));
@@ -757,7 +757,7 @@ public class CompareLayersCommandTests
     private static string Normalize(string val) =>
         val.Replace("\r", string.Empty).TrimEnd();
 
-    private static Task<IRenderable> ExecuteTestAsync(string scenario, CompareOutputFormat format, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup)
+    private static Task<IRenderable> ExecuteTestAsync(string scenario, CompareLayersOutput format, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup)
     {
         Assert.NotNull(scenario);
 

--- a/src/Valleysoft.Dredge/CompareFilesOutput.cs
+++ b/src/Valleysoft.Dredge/CompareFilesOutput.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.Dredge;
+
+public enum CompareFilesOutput
+{
+    ExternalTool
+}

--- a/src/Valleysoft.Dredge/CompareLayersOutput.cs
+++ b/src/Valleysoft.Dredge/CompareLayersOutput.cs
@@ -1,6 +1,6 @@
 ﻿namespace Valleysoft.Dredge;
 
-public enum CompareOutputFormat
+public enum CompareLayersOutput
 {
     SideBySide,
     Inline,

--- a/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
+++ b/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
@@ -15,8 +15,7 @@ internal class DockerRegistryClientFactory : IDockerRegistryClientFactory
         }
         catch (CredsNotFoundException)
         {
-            return new DockerRegistryClientWrapper(
-                new DockerRegistryClient.DockerRegistryClient(DockerHubHelper.GetApiRegistry(registry)));
+            return new DockerRegistryClientWrapper(CreateClient(DockerHubHelper.GetApiRegistry(registry)));
         }
         ServiceClientCredentials clientCreds;
         if (creds.IdentityToken is not null)
@@ -32,7 +31,13 @@ internal class DockerRegistryClientFactory : IDockerRegistryClientFactory
             };
         }
 
-        return new DockerRegistryClientWrapper(
-            new DockerRegistryClient.DockerRegistryClient(DockerHubHelper.GetApiRegistry(registry), clientCreds));
+        return new DockerRegistryClientWrapper(CreateClient(registry, clientCreds));
+    }
+
+    private DockerRegistryClient.DockerRegistryClient CreateClient(string? registry, ServiceClientCredentials? clientCreds = null)
+    {
+        DockerRegistryClient.DockerRegistryClient client = new(DockerHubHelper.GetApiRegistry(registry), clientCreds);
+        client.HttpClient.Timeout = new TimeSpan(0, 30, 0);
+        return client;
     }
 }

--- a/src/Valleysoft.Dredge/Settings.cs
+++ b/src/Valleysoft.Dredge/Settings.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json;
+
+namespace Valleysoft.Dredge;
+
+internal class Settings
+{
+    public static readonly string SettingsPath =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Valleysoft.Dredge", "settings.json");
+
+    public const string FileCompareToolName = "fileCompareTool";
+
+    [JsonProperty(FileCompareToolName)]
+    public FileCompareToolSettings FileCompareTool { get; set; } = new();
+
+    private Settings() {}
+
+    public static Settings Load()
+    {
+        if (!File.Exists(SettingsPath))
+        {
+            Settings settings = new();
+            string settingsStr = JsonConvert.SerializeObject(settings, Formatting.Indented);
+
+            string dirName = Path.GetDirectoryName(SettingsPath)!;
+            if (!Directory.Exists(dirName))
+            {
+                Directory.CreateDirectory(dirName);
+            }
+
+            File.WriteAllText(SettingsPath, settingsStr);
+            return settings;
+        }
+        else
+        {
+            string settings = File.ReadAllText(SettingsPath);
+            return JsonConvert.DeserializeObject<Settings>(settings);
+        }
+    }
+}
+
+internal class FileCompareToolSettings
+{
+    [JsonProperty("exePath")]
+    public string ExePath { get; set; } = string.Empty;
+
+    [JsonProperty("args")]
+    public string Args { get; set; } = string.Empty;
+}

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
-    <RollForward>Major</RollForward>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AssemblyName>dredge</AssemblyName>
     <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
Adds an `image compare files` command that provides a way to compare the file contents of two images. 

Example usage:

```shell
dredge image compare files amd64/node:19.1-alpine amd64/node:19.2-alpine
```

The layers of the images are downloaded and applied (squashed) to produce a local representation of the file system for each image.

The actual comparison of the files requires an external tool provided by the user. This external comparison tool is configured with Dredge's settings.json file.

Example:

```json
{
  "fileCompareTool": {
    "exePath": "C:\\Program Files\\Beyond Compare 4\\BCompare.exe",
    "args": "{0} {1}"
  }
}
```

In addition to comparing the entire image, you can also include a subset of the image by specifying a layer index in the command options. This will only apply the layers of the image up to the specified index. For example, the following command compares only the first two layers of the images:

```shell
dredge image compare files amd64/node:19.1-alpine amd64/node:19.2-alpine --base-layer-index 1 --target-layer-index 1
```

This option also enables you to compare the layers of a single image. This command compares the difference between the 2nd and 3rd layer of the `amd64/node:19.1-alpine` image:

```shell
dredge image compare files amd64/node:19.1-alpine amd64/node:19.1-alpine --base-layer-index 1 --target-layer-index 2
```