### PR TITLE
Add a settings command

### DIFF
--- a/src/Valleysoft.Dredge/Program.cs
+++ b/src/Valleysoft.Dredge/Program.cs
@@ -7,6 +7,7 @@ RootCommand rootCmd = new("CLI for executing commands on a container registry's 
     new ImageCommand(clientFactory),
     new ManifestCommand(clientFactory),
     new RepoCommand(clientFactory),
+    new SettingsCommand(),
     new TagCommand(clientFactory),
 };
 

--- a/src/Valleysoft.Dredge/SettingsCommand.cs
+++ b/src/Valleysoft.Dredge/SettingsCommand.cs
@@ -1,0 +1,28 @@
+﻿using System.CommandLine;
+using System.Diagnostics;
+
+namespace Valleysoft.Dredge;
+
+internal class SettingsCommand : Command
+{
+    public SettingsCommand()
+        : base("settings", "Opens the Dredge settings file")
+    {
+        this.SetHandler(Execute);
+    }
+
+    private void Execute()
+    {
+        // Ensure the settings are loaded which creates a default settings file if necessary
+        Settings.Load();
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(Settings.SettingsPath) { UseShellExecute = true });
+        }
+        catch(Exception)
+        {
+            Console.WriteLine(Settings.SettingsPath);
+        }
+    }
+}


### PR DESCRIPTION
Adds a `settings` command which opens the `settings.json` file in the default associated program associated. If unable to do so, it outputs the path of the file.