### PR TITLE
Support MacOS standalone executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         rid:
           - win-x64
           - win-arm64
+          - osx-x64
+          - osx-arm64
           - linux-x64
           - linux-arm64
           - linux-musl-x64
@@ -40,7 +42,7 @@ jobs:
 
       - name: Publish
         working-directory: src/Valleysoft.Dredge
-        run: dotnet publish -f net6.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --self-contained /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+        run: dotnet publish -f net7.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --self-contained /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
       - name: Rename output
         run: |


### PR DESCRIPTION
Supports standalone executables for MacOS by including the osx RID for both x64 and arm64.

Also updates the target version to .NET 7.