### PR TITLE
Adds "image save-layers" command

### DIFF
--- a/src/Valleysoft.Dredge/FileHelper.cs
+++ b/src/Valleysoft.Dredge/FileHelper.cs
@@ -1,0 +1,36 @@
+﻿namespace Valleysoft.Dredge;
+
+internal static class FileHelper
+{
+    public static void CopyDirectory(string sourceDir, string destinationDir)
+    {
+        DirectoryInfo dir = new(sourceDir);
+        if (!dir.Exists)
+        {
+            throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+        }
+
+        Directory.CreateDirectory(destinationDir);
+
+        DirectoryInfo[] dirs = dir.GetDirectories();
+        foreach (FileInfo file in dir.GetFiles())
+        {
+            string targetFilePath = Path.Combine(destinationDir, file.Name);
+
+            if (file.LinkTarget is not null)
+            {
+                File.CreateSymbolicLink(targetFilePath, file.LinkTarget);
+            }
+            else
+            {
+                file.CopyTo(targetFilePath);
+            }
+        }
+        
+        foreach (DirectoryInfo subDir in dirs)
+        {
+            string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+            CopyDirectory(subDir.FullName, newDestinationDir);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `image save-layers` command which saves the layers of an image to disk. The tarballs of the layers are extracted. By default, the layers are squashed to have one applied file system. There is a `--no-squash` option that will save each layer in its own separate directory. In addition, the `--layer-index` option allows you to target a specific layer of the image.