### PR TITLE
Adds "clear-cache" command

### DIFF
--- a/src/Valleysoft.Dredge/ClearCacheCommand.cs
+++ b/src/Valleysoft.Dredge/ClearCacheCommand.cs
@@ -1,0 +1,52 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge;
+
+internal class ClearCacheCommand : Command
+{
+    public ClearCacheCommand()
+        : base("clear-cache", "Deletes the cached files used by Dredge")
+    {
+        this.SetHandler(ExecuteAsync);
+    }
+
+    private Task ExecuteAsync()
+    {
+        return CommandHelper.ExecuteCommandAsync(null, () =>
+        {
+            DirectoryInfo dredgeTempDir = new(DredgeState.DredgeTempPath);
+
+            if (dredgeTempDir.Exists)
+            {
+                long dirSize = DirSize(dredgeTempDir);
+                dredgeTempDir.Delete(recursive: true);
+
+                Console.WriteLine($"{dirSize:n0} bytes deleted from '{DredgeState.DredgeTempPath}'");
+            }    
+            else
+            {
+                Console.WriteLine($"Nothing to do. Cache directory '{DredgeState.DredgeTempPath}' does not exist.");
+            }
+            
+            return Task.CompletedTask;
+        });
+    }
+
+    private static long DirSize(DirectoryInfo dir)
+    {
+        long size = 0;
+        FileInfo[] files = dir.GetFiles();
+        foreach (FileInfo file in files)
+        {
+            size += file.Length;
+        }
+
+        DirectoryInfo[] subDirs = dir.GetDirectories();
+        foreach (DirectoryInfo subDir in subDirs)
+        {
+            size += DirSize(subDir);
+        }
+
+        return size;
+    }
+}

--- a/src/Valleysoft.Dredge/DredgeState.cs
+++ b/src/Valleysoft.Dredge/DredgeState.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.Dredge;
+
+internal static class DredgeState
+{
+    public static readonly string DredgeTempPath = Path.Combine(Path.GetTempPath(), "Valleysoft.Dredge");
+}

--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -19,8 +19,7 @@ public class ImageCommand : Command
     private const string WhiteoutMarkerPrefix = ".wh.";
     private const string OpaqueWhiteoutMarker = ".wh..wh..opq";
 
-    private static readonly string DredgeTempPath = Path.Combine(Path.GetTempPath(), "Valleysoft.Dredge");
-    private static readonly string LayersTempPath = Path.Combine(DredgeTempPath, "layers");
+    private static readonly string LayersTempPath = Path.Combine(DredgeState.DredgeTempPath, "layers");
 
     public ImageCommand(IDockerRegistryClientFactory dockerRegistryClientFactory) : base("image", "Commands related to container images")
     {
@@ -796,7 +795,7 @@ public class ImageCommand : Command
             private const string BaseOutputDirName = "base";
             private const string TargetOutputDirName = "target";
 
-            private static readonly string CompareTempPath = Path.Combine(DredgeTempPath, "compare");
+            private static readonly string CompareTempPath = Path.Combine(DredgeState.DredgeTempPath, "compare");
 
             public FilesCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
                 : base("files", "Compares two images by their files")

--- a/src/Valleysoft.Dredge/Program.cs
+++ b/src/Valleysoft.Dredge/Program.cs
@@ -7,8 +7,9 @@ RootCommand rootCmd = new("CLI for executing commands on a container registry's 
     new ImageCommand(clientFactory),
     new ManifestCommand(clientFactory),
     new RepoCommand(clientFactory),
-    new SettingsCommand(),
     new TagCommand(clientFactory),
+    new SettingsCommand(),
+    new ClearCacheCommand()
 };
 
 return rootCmd.Invoke(args);

--- a/src/Valleysoft.Dredge/SettingsCommand.cs
+++ b/src/Valleysoft.Dredge/SettingsCommand.cs
@@ -8,21 +8,26 @@ internal class SettingsCommand : Command
     public SettingsCommand()
         : base("settings", "Opens the Dredge settings file")
     {
-        this.SetHandler(Execute);
+        this.SetHandler(ExecuteAsync);
     }
 
-    private void Execute()
+    private Task ExecuteAsync()
     {
-        // Ensure the settings are loaded which creates a default settings file if necessary
-        Settings.Load();
+        return CommandHelper.ExecuteCommandAsync(null, () =>
+        {
+            // Ensure the settings are loaded which creates a default settings file if necessary
+            Settings.Load();
 
-        try
-        {
-            Process.Start(new ProcessStartInfo(Settings.SettingsPath) { UseShellExecute = true });
-        }
-        catch(Exception)
-        {
-            Console.WriteLine(Settings.SettingsPath);
-        }
+            try
+            {
+                Process.Start(new ProcessStartInfo(Settings.SettingsPath) { UseShellExecute = true });
+            }
+            catch (Exception)
+            {
+                Console.WriteLine(Settings.SettingsPath);
+            }
+
+            return Task.CompletedTask;
+        });
     }
 }


### PR DESCRIPTION
The `clear-cache` command provides a way to delete the temporary cache directory used by Dredge.