### PR TITLE
Support no Docker installation

### DIFF
--- a/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
+++ b/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
@@ -33,7 +33,7 @@ internal class DockerRegistryClientFactory : IDockerRegistryClientFactory
             {
                 creds = await CredsProvider.GetCredentialsAsync(DockerHubHelper.GetAuthRegistry(registry));
             }
-            catch (CredsNotFoundException)
+            catch (Exception e) when (e is CredsNotFoundException || e is FileNotFoundException)
             {
                 return new DockerRegistryClientWrapper(CreateClient(DockerHubHelper.GetApiRegistry(registry)));
             }


### PR DESCRIPTION
If an attempt is made to use Dredge without having Docker installed, it results in a `FileNotFoundException` because the `<username>/.docker/config.json` file does not exist. An attempt is made to access this file by DockerCredsProvider which is part of the default behavior of Dredge in order to pick up any ambient registry creds.

To avoid requiring this file to exist, the fix is to simply handle this `FileNotFoundException` and default to no credentials in that case.