### PR TITLE
Support tarball extraction with empty directory

### DIFF
--- a/src/Valleysoft.Dredge/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/ImageCommand.cs
@@ -132,6 +132,11 @@ public class ImageCommand : Command
 
             if (entry.IsDirectory)
             {
+                string directoryPath = Path.Combine(layerDir, entry.Name);
+                if (!Directory.Exists(directoryPath))
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
                 continue;
             }
 


### PR DESCRIPTION
The logic for extracting a layer tarball didn't handle the existence of an empty directory. It relied on there being a file in a directory to actually create the directory.