### PR TITLE
Fix pack and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish
         working-directory: src/Valleysoft.Dredge
-        run: dotnet publish -f net7.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --self-contained
+        run: dotnet publish -f net7.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --self-contained /p:IsPublish=true
 
       - name: Rename output
         run: |

--- a/src/Valleysoft.Dredge/Dockerfile
+++ b/src/Valleysoft.Dredge/Dockerfile
@@ -5,7 +5,7 @@ COPY *.csproj .
 RUN dotnet restore --use-current-runtime
 
 COPY . .
-RUN dotnet publish -c Release -f net7.0 -o /app --use-current-runtime --self-contained true --no-restore
+RUN dotnet publish -c Release -f net7.0 -o /app --use-current-runtime --self-contained true --no-restore /p:IsPublish=true
 
 
 FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0-jammy-chiseled

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -14,7 +14,7 @@
     <ToolCommandName>dredge</ToolCommandName>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(IsPublish)' == 'true' ">
     <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
Because of the changes to add publish properties into the csproj, the `dotnet pack` command is failing because it thinks things are configured for self-contained which it doesn't support.

Updated the csproj to conditional set the publish properties.