### PR TITLE
Add compressed-size option for comparing layers

### DIFF
--- a/src/Valleysoft.Dredge/CompareLayersResult.cs
+++ b/src/Valleysoft.Dredge/CompareLayersResult.cs
@@ -71,12 +71,14 @@ public enum LayerDiff
 
 public class LayerInfo
 {
-    public LayerInfo(string? digest, string? history)
+    public LayerInfo(string? digest, string? history, long? compressedSize)
     {
         Digest = digest;
         History = history;
+        CompressedSize = compressedSize;
     }
 
     public string? Digest { get; }
     public string? History { get; }
+    public long? CompressedSize { get; }
 }


### PR DESCRIPTION
This adds a new `--compressed-size` option to the `image compare layers` command. This will include the compressed size of the layers in the output.