### PR TITLE
Include platform options for all commands referencing an image

### DIFF
--- a/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
@@ -124,9 +124,16 @@ public class DockerfileCommandTests
             .Setup(o => o.GetClientAsync(Registry))
             .ReturnsAsync(registryClientMock.Object);
 
-        DockerfileCommand command = new(clientFactoryMock.Object);
+        DockerfileCommand command = new(clientFactoryMock.Object)
+        {
+            Options = new DockerfileOptions
+            {
+                Image = ImageName,
+                NoFormat = scenario.NoFormat
+            }
+        };
 
-        string markupStr = await command.GetMarkupStringAsync(ImageName, false, scenario.NoFormat);
+        string markupStr = await command.GetMarkupStringAsync();
 
         string actual = TestHelper.Normalize(markupStr);
         string expected = TestHelper.Normalize(File.ReadAllText(scenario.ExpectedOutputPath));

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -52,6 +52,7 @@ public class CompareFilesCommand : CommandWithOptions<CompareFilesOptions>
             workingDir,
             layerIndex,
             layerIndexArg + CompareFilesOptions.LayerIndexSuffix,
-            noSquash: false);
+            noSquash: false,
+            Options);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -188,8 +188,7 @@ public class CompareLayersCommand : CommandWithOptions<CompareLayersOptions>
     {
         ImageName imageName = ImageName.Parse(image);
         using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
-
+        ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
         DockerManifestV2 manifest = ManifestHelper.GetManifest(image, manifestInfo);
 
         string? digest = manifest.Config?.Digest;

--- a/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class CompareOptionsBase : OptionsBase
+public class CompareOptionsBase : PlatformOptionsBase
 {
     public const string BaseArg = "base";
     public const string TargetArg = "target";
@@ -21,6 +21,7 @@ public class CompareOptionsBase : OptionsBase
 
     protected override void GetValues()
     {
+        base.GetValues();
         BaseImage = GetValue(baseImageArg);
         TargetImage = GetValue(targetImageArg);
     }

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class DockerfileOptions : PlatformOptionsBase
+{
+    private readonly Argument<string> imageArg;
+    private readonly Option<bool> noColorOption;
+    private readonly Option<bool> noFormatOption;
+
+    public string Image { get; set; } = string.Empty;
+    public bool NoColor { get; set; }
+    public bool NoFormat { get; set; }
+
+    public DockerfileOptions()
+    {
+        imageArg = Add(new Argument<string>("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"));
+        noColorOption = Add(new Option<bool>("--no-color", "Disables use of syntax color in the output"));
+        noFormatOption = Add(new Option<bool>("--no-format", "Disables use of heuristics to format the layer history for better readability"));
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        Image = GetValue(imageArg);
+        NoColor = GetValue(noColorOption);
+        NoFormat = GetValue(noFormatOption);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -17,7 +17,7 @@ public class InspectCommand : CommandWithOptions<InspectOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
 
             DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
             string? digest = manifest.Config?.Digest;

--- a/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class InspectOptions : OptionsBase
+public class InspectOptions : PlatformOptionsBase
 {
     private readonly Argument<string> imageArg;
 
@@ -15,6 +15,7 @@ public class InspectOptions : OptionsBase
 
     protected override void GetValues()
     {
+        base.GetValues();
         Image = GetValue(imageArg);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -21,7 +21,7 @@ public class OsCommand : CommandWithOptions<OsOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
 
             DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
 

--- a/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class OsOptions : OptionsBase
+public class OsOptions : PlatformOptionsBase
 {
     private readonly Argument<string> imageArg;
 
@@ -15,6 +15,7 @@ public class OsOptions : OptionsBase
 
     protected override void GetValues()
     {
+        base.GetValues();
         Image = GetValue(imageArg);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -16,7 +16,7 @@ public class SaveLayersCommand : CommandWithOptions<SaveLayersOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
 
             DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
             string? digest = manifest.Config?.Digest;
@@ -31,7 +31,8 @@ public class SaveLayersCommand : CommandWithOptions<SaveLayersOptions>
                 Options.OutputPath,
                 Options.LayerIndex,
                 SaveLayersOptions.LayerIndexOptionName,
-                Options.NoSquash);
+                Options.NoSquash,
+                Options);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class SaveLayersOptions : OptionsBase
+public class SaveLayersOptions : PlatformOptionsBase
 {
     public const string LayerIndexOptionName = "--layer-index";
 
@@ -26,6 +26,7 @@ public class SaveLayersOptions : OptionsBase
 
     protected override void GetValues()
     {
+        base.GetValues();
         Image = GetValue(imageArg);
         OutputPath = GetValue(outputPathArg);
         NoSquash = GetValue(noSquashOption);

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -1,6 +1,4 @@
-﻿using System.CommandLine;
-using Valleysoft.DockerRegistryClient;
-using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
@@ -17,29 +15,7 @@ public class ResolveCommand : CommandWithOptions<ResolveOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
-
-            if (manifestInfo.Manifest is ManifestList manifestList)
-            {
-                ManifestReference? manifestRef = manifestList.Manifests
-                    .SingleOrDefault(manifest =>
-                        manifest.Platform?.Os == Options.Os &&
-                        manifest.Platform?.OsVersion == Options.OsVersion &&
-                        manifest.Platform?.Architecture == Options.Architecture);
-                if (manifestRef is null)
-                {
-                    throw new Exception(
-                        $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {ResolveOptions.OsOptionName}, {ResolveOptions.ArchOptionName}, and {ResolveOptions.OsVersionOptionName} (Windows only) to specify the target platform to match.");
-                }
-
-                if (manifestRef.Digest is null)
-                {
-                    throw new Exception($"Digest of resolved manifest is not set.");
-                }
-
-                manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
-            }
-
+            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
             ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
 
             Console.Out.WriteLine(fullyQualifiedDigest.ToString());

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
@@ -2,35 +2,20 @@
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
-public class ResolveOptions : OptionsBase
+public class ResolveOptions : PlatformOptionsBase
 {
-    public const string OsOptionName = "--os";
-    public const string OsVersionOptionName = "--os-version";
-    public const string ArchOptionName = "--arch";
-
     private readonly Argument<string> imageArg;
-    private readonly Option<string> osOpt;
-    private readonly Option<string> osVersionOpt;
-    private readonly Option<string> archOpt;
 
     public string Image { get; set; } = string.Empty;
-    public string? Os { get; set; }
-    public string? OsVersion { get; set; }
-    public string? Architecture { get; set; }
 
     public ResolveOptions()
     {
         imageArg = Add(new Argument<string>("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"));
-        osOpt = Add(new Option<string>(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")"));
-        osVersionOpt = Add(new Option<string>(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")"));
-        archOpt = Add(new Option<string>(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")"));
     }
 
     protected override void GetValues()
     {
+        base.GetValues();
         Image = GetValue(imageArg);
-        Os = GetValue(osOpt);
-        OsVersion = GetValue(osVersionOpt);
-        Architecture = GetValue(archOpt);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/PlatformOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/PlatformOptionsBase.cs
@@ -1,0 +1,32 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands;
+
+public class PlatformOptionsBase : OptionsBase
+{
+    public const string OsOptionName = "--os";
+    public const string OsVersionOptionName = "--os-version";
+    public const string ArchOptionName = "--arch";
+
+    private readonly Option<string> osOpt;
+    private readonly Option<string> osVersionOpt;
+    private readonly Option<string> archOpt;
+
+    public string? Os { get; set; }
+    public string? OsVersion { get; set; }
+    public string? Architecture { get; set; }
+
+    public PlatformOptionsBase()
+    {
+        osOpt = Add(new Option<string>(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")"));
+        osVersionOpt = Add(new Option<string>(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")"));
+        archOpt = Add(new Option<string>(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")"));
+    }
+
+    protected override void GetValues()
+    {
+        Os = GetValue(osOpt);
+        OsVersion = GetValue(osVersionOpt);
+        Architecture = GetValue(archOpt);
+    }
+}

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Text;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
+using Valleysoft.Dredge.Commands;
 
 namespace Valleysoft.Dredge;
 
@@ -16,7 +17,7 @@ internal static class ImageHelper
 
     public static async Task SaveImageLayersToDiskAsync(
         IDockerRegistryClientFactory dockerRegistryClientFactory, string image, string destPath, int? layerIndex,
-        string layerIndexOptionName, bool noSquash)
+        string layerIndexOptionName, bool noSquash, PlatformOptionsBase options)
     {
         // Spec for OCI image layer filesystem changeset: https://github.com/opencontainers/image-spec/blob/main/layer.md
 
@@ -24,8 +25,7 @@ internal static class ImageHelper
 
         ImageName imageName = ImageName.Parse(image);
         IDockerRegistryClient client = await dockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
-
+        ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, options);
         DockerManifestV2 manifest = ManifestHelper.GetManifest(imageName.ToString(), manifestInfo);
 
         int startIndex = 0;

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -1,9 +1,38 @@
-﻿using Valleysoft.DockerRegistryClient.Models;
+﻿using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models;
+using Valleysoft.Dredge.Commands;
 
 namespace Valleysoft.Dredge;
 
 internal static class ManifestHelper
 {
+    public static async Task<ManifestInfo> GetManifestInfoAsync(IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options)
+    {
+        ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+        if (manifestInfo.Manifest is ManifestList manifestList)
+        {
+            ManifestReference? manifestRef = manifestList.Manifests
+            .SingleOrDefault(manifest =>
+                    manifest.Platform?.Os == options.Os &&
+                    manifest.Platform?.OsVersion == options.OsVersion &&
+                    manifest.Platform?.Architecture == options.Architecture);
+            if (manifestRef is null)
+            {
+                throw new Exception(
+                    $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {PlatformOptionsBase.OsOptionName}, {PlatformOptionsBase.ArchOptionName}, and {PlatformOptionsBase.OsVersionOptionName} (Windows only) to specify the target platform to match.");
+            }
+
+            if (manifestRef.Digest is null)
+            {
+                throw new Exception($"Digest of resolved manifest is not set.");
+            }
+
+            manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
+        }
+
+        return manifestInfo;
+    }
+
     public static DockerManifestV2 GetManifest(string image, ManifestInfo manifestInfo)
     {
         if (manifestInfo.Manifest is ManifestList)


### PR DESCRIPTION
This adds the following platform options that will be used to resolve a reference manifest list to an underlying manifest:
* os
* os-version
* arch

These are the same options that already existed for the `manifest resolve` command. But they're now applied to all commands that need to operate on an actual image, allowing the caller to use a multi-arch tag if they choose so and specifying the options to resolve it.