### PR TITLE
Add get/set commands for settings

### DIFF
--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -36,6 +36,12 @@ internal class AppSettings
             return JsonConvert.DeserializeObject<AppSettings>(settings);
         }
     }
+
+    public void Save()
+    {
+        string settingsStr = JsonConvert.SerializeObject(this, Formatting.Indented);
+        File.WriteAllText(SettingsPath, settingsStr);
+    }
 }
 
 internal class FileCompareToolSettings

--- a/src/Valleysoft.Dredge/Commands/CommandWithOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/CommandWithOptions.cs
@@ -1,19 +1,16 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 
-namespace Valleysoft.Dredge;
+namespace Valleysoft.Dredge.Commands;
 
 public abstract class CommandWithOptions<TOptions> : Command
     where TOptions : OptionsBase, new()
 {
     public new TOptions Options { get; set; } = new();
 
-    public IDockerRegistryClientFactory DockerRegistryClientFactory { get; }
-
-    protected CommandWithOptions(string name, string description, IDockerRegistryClientFactory dockerRegistryClientFactory)
+    protected CommandWithOptions(string name, string description)
         : base(name, description)
     {
-        DockerRegistryClientFactory = dockerRegistryClientFactory;
         Options.SetCommandOptions(this);
         this.SetHandler(ExecuteAsyncCore);
     }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class CompareFilesCommand : CommandWithOptions<CompareFilesOptions>
+public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
 {
     private const string BaseOutputDirName = "base";
     private const string TargetOutputDirName = "target";

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -9,7 +9,7 @@ using ImageConfig = Valleysoft.DockerRegistryClient.Models.Image;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class CompareLayersCommand : CommandWithOptions<CompareLayersOptions>
+public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
 {
     private static readonly string[] SizeSuffixes =
         { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -9,7 +9,7 @@ using ImageConfig = Valleysoft.DockerRegistryClient.Models.Image;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class DockerfileCommand : CommandWithOptions<DockerfileOptions>
+public class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 {
     private static readonly Color SymbolColor = new(250, 200, 31); // yellow
     private static readonly Color StringColor = new(202, 145, 120); // tan

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -4,7 +4,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class InspectCommand : CommandWithOptions<InspectOptions>
+public class InspectCommand : RegistryCommandBase<InspectOptions>
 {
     public InspectCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("inspect", "Return low-level information on a container image", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -8,7 +8,7 @@ using ImageConfig = Valleysoft.DockerRegistryClient.Models.Image;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class OsCommand : CommandWithOptions<OsOptions>
+public class OsCommand : RegistryCommandBase<OsOptions>
 {
     public OsCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("os", "Gets OS info about the container image", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -3,7 +3,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
-public class SaveLayersCommand : CommandWithOptions<SaveLayersOptions>
+public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
 {
     public SaveLayersCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("save-layers", "Saves an image's extracted layers to disk", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
-public class DigestCommand : CommandWithOptions<DigestOptions>
+public class DigestCommand : RegistryCommandBase<DigestOptions>
 {
     public DigestCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("digest", "Queries the digest of a manifest", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
@@ -4,7 +4,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
-public class GetCommand : CommandWithOptions<GetOptions>
+public class GetCommand : RegistryCommandBase<GetOptions>
 {
     public GetCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("get", "Queries a manifest", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
-public class ResolveCommand : CommandWithOptions<ResolveOptions>
+public class ResolveCommand : RegistryCommandBase<SetOptions>
 {
     public ResolveCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("resolve", "Resolves a manifest to a target platform's fully-qualified image digest", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
@@ -2,13 +2,13 @@
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
-public class ResolveOptions : PlatformOptionsBase
+public class SetOptions : PlatformOptionsBase
 {
     private readonly Argument<string> imageArg;
 
     public string Image { get; set; } = string.Empty;
 
-    public ResolveOptions()
+    public SetOptions()
     {
         imageArg = Add(new Argument<string>("image", "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"));
     }

--- a/src/Valleysoft.Dredge/Commands/OptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/OptionsBase.cs
@@ -2,7 +2,7 @@
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Valleysoft.Dredge;
+namespace Valleysoft.Dredge.Commands;
 
 public abstract class OptionsBase
 {

--- a/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
+++ b/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
@@ -1,0 +1,13 @@
+﻿namespace Valleysoft.Dredge.Commands;
+
+public abstract class RegistryCommandBase<TOptions> : CommandWithOptions<TOptions>
+    where TOptions : OptionsBase, new()
+{
+    public IDockerRegistryClientFactory DockerRegistryClientFactory { get; }
+
+    protected RegistryCommandBase(string name, string description, IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : base(name, description)
+    {
+        DockerRegistryClientFactory = dockerRegistryClientFactory;
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
@@ -4,7 +4,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Repo;
 
-public class ListCommand : CommandWithOptions<ListOptions>
+public class ListCommand : RegistryCommandBase<ListOptions>
 {
     public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("list", "Lists the repositories contained in the container registry", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
@@ -1,0 +1,66 @@
+﻿using Newtonsoft.Json;
+using System.Reflection;
+
+namespace Valleysoft.Dredge.Commands.Settings;
+
+internal partial class GetCommand : CommandWithOptions<GetOptions>
+{
+    public GetCommand()
+        : base("get", "Gets the value of the specified setting")
+    {
+    }
+
+    protected override Task ExecuteAsync()
+    {
+        AppSettings settings = AppSettings.Load();
+
+        Queue<string> names = new(Options.Name.Split('.'));
+
+        object? value = GetSettingProperty(settings, names);
+
+        if (value is not null)
+        {
+            if (value.GetType().IsValueType || value is string)
+            {
+                Console.WriteLine(value);
+            }
+            else
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(value, Formatting.Indented));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private object? GetSettingProperty(object obj, Queue<string> names)
+    {
+        string propertyName = names.Dequeue();
+        PropertyInfo? property = obj.GetType().GetProperties()
+            .FirstOrDefault(prop => prop.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName == propertyName);
+        if (property is null)
+        {
+            throw new Exception($"Could not find property '{propertyName}' in object of type '{obj.GetType()}'");
+        }
+
+        if (names.Any())
+        {
+            object? propertyValue = property.GetValue(obj);
+            if (propertyValue is null)
+            {
+                propertyValue = Activator.CreateInstance(property.PropertyType);
+                if (propertyValue is null)
+                {
+                    throw new Exception($"Unable to create instance of '{property.PropertyType}'.");
+                }
+            }
+            property.SetValue(obj, propertyValue);
+
+            return GetSettingProperty(propertyValue, names);
+        }
+        else
+        {
+            return property.GetValue(obj);
+        }
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Settings/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Settings;
+
+public class GetOptions : OptionsBase
+{
+    private readonly Argument<string> nameArg;
+
+    public string Name { get; set; } = string.Empty;
+
+    public GetOptions()
+    {
+        nameArg = Add(new Argument<string>("name", "Name of the setting to set"));
+    }
+
+    protected override void GetValues()
+    {
+        Name = GetValue(nameArg);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+using System.Reflection;
+
+namespace Valleysoft.Dredge.Commands.Settings;
+
+internal partial class SetCommand : CommandWithOptions<SetOptions>
+{
+    public SetCommand()
+        : base("set", "Sets the specified setting name to a value")
+    {
+    }
+
+    protected override Task ExecuteAsync()
+    {
+        AppSettings settings = AppSettings.Load();
+
+        Queue<string> names = new(Options.Name.Split('.'));
+
+        SetSettingProperty(settings, names, Options.Value);
+        settings.Save();
+        return Task.CompletedTask;
+    }
+
+    private void SetSettingProperty(object obj, Queue<string> names, string value)
+    {
+        string propertyName = names.Dequeue();
+        PropertyInfo? property = obj.GetType().GetProperties()
+            .FirstOrDefault(prop => prop.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName == propertyName);
+        if (property is null)
+        {
+            throw new Exception($"Could not find property '{propertyName}' in object of type '{obj.GetType()}'");
+        }
+
+        if (names.Any())
+        {
+            object? propertyValue = property.GetValue(obj);
+            if (propertyValue is null)
+            {
+                propertyValue = Activator.CreateInstance(property.PropertyType);
+                if (propertyValue is null)
+                {
+                    throw new Exception($"Unable to create instance of '{property.PropertyType}'.");
+                }
+            }
+            property.SetValue(obj, propertyValue);
+
+            SetSettingProperty(propertyValue, names, value);
+        }
+        else
+        {
+            property.SetValue(obj, value);
+        }
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Settings/SetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SetOptions.cs
@@ -1,0 +1,24 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Settings;
+
+public class SetOptions : OptionsBase
+{
+    private readonly Argument<string> nameArg;
+    private readonly Argument<string> valueArg;
+
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+
+    public SetOptions()
+    {
+        nameArg = Add(new Argument<string>("name", "Name of the setting to set"));
+        valueArg = Add(new Argument<string>("value", "Value to assign to the setting"));
+    }
+
+    protected override void GetValues()
+    {
+        Name = GetValue(nameArg);
+        Value = GetValue(valueArg);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Settings/SettingsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SettingsCommand.cs
@@ -4,10 +4,12 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 internal class SettingsCommand : Command
 {
-    public SettingsCommand()
+    public SettingsCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("settings", "Commands related to Dredge settings")
     {
         AddCommand(new OpenCommand());
         AddCommand(new ClearCacheCommand());
+        AddCommand(new SetCommand());
+        AddCommand(new GetCommand());
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -4,7 +4,7 @@ using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Tag;
 
-public class ListCommand : CommandWithOptions<ListOptions>
+public class ListCommand : RegistryCommandBase<ListOptions>
 {
     public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
         : base("list", "Lists the tag contained in the container repository", dockerRegistryClientFactory)

--- a/src/Valleysoft.Dredge/Program.cs
+++ b/src/Valleysoft.Dredge/Program.cs
@@ -13,7 +13,7 @@ RootCommand rootCmd = new("CLI for executing commands on a container registry's 
     new ManifestCommand(clientFactory),
     new RepoCommand(clientFactory),
     new TagCommand(clientFactory),
-    new SettingsCommand(),
+    new SettingsCommand(clientFactory),
 };
 
 return rootCmd.Invoke(args);


### PR DESCRIPTION
Adds a `settings get` and `settings set` command to allow callers to retrieve and set the values of settings.

Because the settings in the settings file are hierarchical and represented as JSON, setting names use a dot-notation to separate the names to access the desired setting. For example: `dredge settings get fileCompareTool.exePath` gets the executable path of the file compare tool from the settings file.

Usage:

```
dredge settings get <name>
```

```
dredge settings set <name> <value>
```