### PR TITLE
Support for global platform settings

### DIFF
--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -12,6 +12,9 @@ internal class AppSettings
     [JsonProperty(FileCompareToolName)]
     public FileCompareToolSettings FileCompareTool { get; set; } = new();
 
+    [JsonProperty("platform")]
+    public PlatformSettings Platform { get; set; } = new();
+
     private AppSettings() {}
 
     public static AppSettings Load()
@@ -51,4 +54,16 @@ internal class FileCompareToolSettings
 
     [JsonProperty("args")]
     public string Args { get; set; } = string.Empty;
+}
+
+internal class PlatformSettings
+{
+    [JsonProperty("os")]
+    public string Os { get; set; } = string.Empty;
+
+    [JsonProperty("osVersion")]
+    public string OsVersion { get; set; } = string.Empty;
+
+    [JsonProperty("arch")]
+    public string Architecture { get; set; } = string.Empty;
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -188,8 +188,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
     {
         ImageName imageName = ImageName.Parse(image);
         using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
-        DockerManifestV2 manifest = ManifestHelper.GetManifest(image, manifestInfo);
+        DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
 
         string? digest = manifest.Config?.Digest;
         if (digest is null)

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -40,9 +40,8 @@ public class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
     {
         ImageName imageName = ImageName.Parse(Options.Image);
         using IDockerRegistryClient client = await dockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
+        DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
 
-        DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
         string? digest = manifest.Config?.Digest;
         if (digest is null)
         {

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -17,9 +17,7 @@ public class InspectCommand : RegistryCommandBase<InspectOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
-
-            DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
+            DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
             string? digest = manifest.Config?.Digest;
             if (digest is null)
             {

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -21,9 +21,7 @@ public class OsCommand : RegistryCommandBase<OsOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
-
-            DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
+            DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
 
             string? configDigest = manifest.Config?.Digest;
             if (configDigest is null)

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -16,9 +16,7 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
-
-            DockerManifestV2 manifest = ManifestHelper.GetManifest(Options.Image, manifestInfo);
+            DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
             string? digest = manifest.Config?.Digest;
             if (digest is null)
             {

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -15,7 +15,7 @@ public class ResolveCommand : RegistryCommandBase<SetOptions>
         return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, Options);
+            ManifestInfo manifestInfo = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).ManifestInfo;
             ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
 
             Console.Out.WriteLine(fullyQualifiedDigest.ToString());

--- a/src/Valleysoft.Dredge/Commands/PlatformOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/PlatformOptionsBase.cs
@@ -19,7 +19,7 @@ public class PlatformOptionsBase : OptionsBase
     public PlatformOptionsBase()
     {
         osOpt = Add(new Option<string>(OsOptionName, "Target OS of image (e.g. \"linux\", \"windows\")"));
-        osVersionOpt = Add(new Option<string>(OsVersionOptionName, "Target OS version of image (Windows only, e.g. \"10.0.20348.1129\")"));
+        osVersionOpt = Add(new Option<string>(OsVersionOptionName, "Target OS version of image (e.g. \"10.0.20348.1129\")"));
         archOpt = Add(new Option<string>(ArchOptionName, "Target architecture of image (e.g. \"amd64\", \"arm64\")"));
     }
 

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -25,8 +25,7 @@ internal static class ImageHelper
 
         ImageName imageName = ImageName.Parse(image);
         IDockerRegistryClient client = await dockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        ManifestInfo manifestInfo = await ManifestHelper.GetManifestInfoAsync(client, imageName, options);
-        DockerManifestV2 manifest = ManifestHelper.GetManifest(imageName.ToString(), manifestInfo);
+        DockerManifestV2 manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, options)).Manifest;
 
         int startIndex = 0;
         int layerCount = manifest.Layers.Length;

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -4,23 +4,38 @@ using Valleysoft.Dredge.Commands;
 
 namespace Valleysoft.Dredge;
 
+internal record ResolvedManifest(
+    ManifestInfo ManifestInfo,
+    DockerManifestV2 Manifest);
+
 internal static class ManifestHelper
 {
-    public static async Task<ManifestInfo> GetManifestInfoAsync(IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options)
+    public static async Task<ResolvedManifest> GetResolvedManifestAsync(
+        IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options)
     {
         ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
         if (manifestInfo.Manifest is ManifestList manifestList)
         {
-            ManifestReference? manifestRef = manifestList.Manifests
-            .SingleOrDefault(manifest =>
-                    manifest.Platform?.Os == options.Os &&
-                    manifest.Platform?.OsVersion == options.OsVersion &&
-                    manifest.Platform?.Architecture == options.Architecture);
-            if (manifestRef is null)
+            AppSettings settings = AppSettings.Load();
+            string? os = GetPlatformValue(options.Os, settings.Platform.Os);
+            string? osVersion = GetPlatformValue(options.OsVersion, settings.Platform.OsVersion);
+            string? architecture = GetPlatformValue(options.Architecture, settings.Platform.Architecture);
+
+            IEnumerable<ManifestReference> manifestRefs = manifestList.Manifests
+                .Where(manifest =>
+                    (os is null || manifest.Platform?.Os == os) &&
+                    (osVersion is null || manifest.Platform?.OsVersion == osVersion) &&
+                    (architecture is null || manifest.Platform?.Architecture == architecture));
+
+            int manifestCount = manifestRefs.Count();
+
+            if (manifestCount != 1)
             {
                 throw new Exception(
-                    $"Unable to resolve the manifest list tag to a matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {PlatformOptionsBase.OsOptionName}, {PlatformOptionsBase.ArchOptionName}, and {PlatformOptionsBase.OsVersionOptionName} (Windows only) to specify the target platform to match.");
+                    $"Unable to resolve the manifest list tag to a single matching platform. Run \"dredge manifest get\" to view the underlying manifests of this tag. Use {PlatformOptionsBase.OsOptionName}, {PlatformOptionsBase.ArchOptionName}, and {PlatformOptionsBase.OsVersionOptionName} to specify the target platform to match.");
             }
+
+            ManifestReference manifestRef = manifestRefs.First();
 
             if (manifestRef.Digest is null)
             {
@@ -30,23 +45,26 @@ internal static class ManifestHelper
             manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
         }
 
-        return manifestInfo;
-    }
-
-    public static DockerManifestV2 GetManifest(string image, ManifestInfo manifestInfo)
-    {
-        if (manifestInfo.Manifest is ManifestList)
-        {
-            throw new NotSupportedException(
-                $"The name '{image}' is a manifest list and doesn't directly refer to an image. Resolve the manifest name to an image first by using the \"dredge manifest resolve\" command.");
-        }
-
         if (manifestInfo.Manifest is not DockerManifestV2 manifest)
         {
             throw new NotSupportedException(
-                $"The image name '{image}' has a media type of '{manifestInfo.MediaType}' which is not supported.");
+                $"The image name '{imageName}' has a media type of '{manifestInfo.MediaType}' which is not supported.");
         }
 
-        return manifest;
+        return new ResolvedManifest(manifestInfo, manifest);
+    }
+
+    private static string? GetPlatformValue(string? options, string settings)
+    {
+        if (!string.IsNullOrEmpty(options))
+        {
+            return options;
+        }
+        else if (!string.IsNullOrEmpty(settings))
+        {
+            return settings;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
With these changes the Dredge settings file can be configured with platform settings that define the default platform configuration to use when needing to result a manifest list.

The settings file has this configuration:

```json
{
  "platform": {
    "os": "<os-name>",
    "osVersion": "<os-version>",
    "arch": "<architecture>"
  }
}
```

When any one of these platform values is set, it influences the logic taken in order to resolve a manifest list to an underlying manifest. For example, a call to `dredge image inspect alpine:latest` requires resolving the `latest` tag to an underlying image since `latest` is a manifest list (multi-arch tag).

If the settings file was set as the following:

```json
{
  "platform": {
    "os": "linux",
    "osVersion": "",
    "arch": "amd64"
  }
}
```

It would automatically resolve `alpine:latest` to the associated Linux image with the amd64 architecture. And technically, setting `os` to `linux` wouldn't even be necessary in that case since `alpine:latest` only has Linux images associated with it. But in the case of tags that support both Windows and Linux, it would have an impact. The key point is that these settings help to narrow down the resolution logic to a single manifest/image.

These settings work in conjunction with the platform-related options in many of the Dredge commands. The platform options provided directly in the call to the command override any of global settings defined in the settings file but can also complement it.

For example, let's say the following settings file is defined:

```json
{
  "platform": {
    "os": "linux",
    "osVersion": "",
    "arch": "arm64"
  }
}
```

Then the following command is invoked:

```
dredge image inspect --arch amd64 mcr.microsoft.com/dotnet/sdk:latest
```

The use of `--arch` option overrides the `arch` setting in the settings file. But the presence of `"os": "linux"` is still applied, allowing the resolution to filter out the Windows-based images.