### PR TITLE
Fix compare files to not default to index 0

### DIFF
--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
@@ -6,8 +6,8 @@ public class CompareFilesOptions : CompareOptionsBase
 {
     public const string LayerIndexSuffix = "-layer-index";
 
-    private readonly Option<int> baseLayerIndex;
-    private readonly Option<int> targetLayerIndex;
+    private readonly Option<int?> baseLayerIndex;
+    private readonly Option<int?> targetLayerIndex;
     private readonly Option<CompareFilesOutput> outputOption;
 
     public int? BaseLayerIndex { get; set; }
@@ -16,8 +16,8 @@ public class CompareFilesOptions : CompareOptionsBase
 
     public CompareFilesOptions()
     {
-        baseLayerIndex = Add(new Option<int>($"--{BaseArg}{LayerIndexSuffix}", "Non-empty layer index of the base container image to compare with"));
-        targetLayerIndex = Add(new Option<int>($"--{TargetArg}{LayerIndexSuffix}", "Non-empty layer index of the target container image to compare against"));
+        baseLayerIndex = Add(new Option<int?>($"--{BaseArg}{LayerIndexSuffix}", "Non-empty layer index of the base container image to compare with"));
+        targetLayerIndex = Add(new Option<int?>($"--{TargetArg}{LayerIndexSuffix}", "Non-empty layer index of the target container image to compare against"));
         outputOption = Add(new Option<CompareFilesOutput>("--output", () => CompareFilesOutput.ExternalTool, "Output type"));
     }
 


### PR DESCRIPTION
When running the `image compare files` command, it was always defaulting to comparing the first layer of the images. This is because the `base-layer-index` and `target-layer-index` were being defaulted to `0` instead of `null`.