### PR TITLE
Add symlink error handling

### DIFF
--- a/src/Valleysoft.Dredge/FileHelper.cs
+++ b/src/Valleysoft.Dredge/FileHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace Valleysoft.Dredge;
+﻿using System.Runtime.InteropServices;
+
+namespace Valleysoft.Dredge;
 
 internal static class FileHelper
 {
@@ -19,7 +21,7 @@ internal static class FileHelper
 
             if (file.LinkTarget is not null)
             {
-                File.CreateSymbolicLink(targetFilePath, file.LinkTarget);
+                CreateSymbolicLink(targetFilePath, file.LinkTarget);
             }
             else
             {
@@ -31,6 +33,18 @@ internal static class FileHelper
         {
             string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
             CopyDirectory(subDir.FullName, newDestinationDir);
+        }
+    }
+
+    public static void CreateSymbolicLink(string targetFilePath, string linkTarget)
+    {
+        try
+        {
+            File.CreateSymbolicLink(targetFilePath, linkTarget);
+        }
+        catch (IOException ex) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            throw new Exception($"Unable to create symbolic link from '{targetFilePath}' to '{linkTarget}'. Ensure that Windows Developer mode is enabled.\n\nError:\n{ex.Message}", ex);
         }
     }
 }

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -182,7 +182,7 @@ internal static class ImageHelper
                         File.Delete(dest);
                     }
 
-                    File.CreateSymbolicLink(dest, layerFile.LinkTarget);
+                    FileHelper.CreateSymbolicLink(dest, layerFile.LinkTarget);
                 }
                 else
                 {
@@ -209,7 +209,7 @@ internal static class ImageHelper
                 File.Delete(filePath);
             }
 
-            File.CreateSymbolicLink(filePath, entry.TarHeader.LinkName);
+            FileHelper.CreateSymbolicLink(filePath, entry.TarHeader.LinkName);
         }
         else
         {


### PR DESCRIPTION
An exception will occur when attempting to create a symlink on a Windows system that doesn't have Developer Mode enabled. This provides a better error message to the user to let them know.