### PR TITLE
Ensure layer dir is created

### DIFF
--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -82,6 +82,8 @@ internal static class ImageHelper
     {
         Console.Error.WriteLine($"\tExtracting layer...");
 
+        Directory.CreateDirectory(layerDir);
+
         using GZipStream gZipStream = new(layerStream, CompressionMode.Decompress);
 
         // Can't use System.Formats.Tar.TarReader because it fails to read certain types of tarballs:


### PR DESCRIPTION
For some images, there can be a blob layer which doesn't have any content. This is a good example of this: https://github.com/dotnet/dotnet-docker/blob/f6ec771805d726e08327ce123893f8924539ff90/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile#L54. For such a layer, there's no new content being added but it's still a layer that gets processed.

This currently isn't handled correctly because no files get written to the layers cache directory. That causes a directory not found exception when applying layers.

This is fixed by simply ensuring the layer directory is created.