### PR TITLE
Exclude publish options when generating package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Pack
         env:
           PACKAGE_VERSION: ${{ github.event.inputs.packageVersion }}
-        run: dotnet pack -c Release -p:Version=$PACKAGE_VERSION Valleysoft.Dredge
+        run: dotnet pack -c Release -p:Version=$PACKAGE_VERSION Valleysoft.Dredge -p:IsPack=true
       
       - name: Publish Package
         run: dotnet nuget push "Valleysoft.Dredge/bin/Release/*.nupkg" -k ${{secrets.NUGET_ORG_API_KEY}} -s https://nuget.org

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(IsPack)' != 'true' ">
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>


### PR DESCRIPTION
When generating a NuGet package, the package needs portable assets. But the default publish options in the project make it RID-specific and generally not what is needed for a portable package. This updates the project config to only use those settings outside the context of generating a package.