### PR TITLE
Refactor workflows into reusable parts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  init:
+    uses: ./.github/workflows/init.yml
+
+  docker:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    needs: [ init ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./src
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: >
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.product-version }},
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.product-version-major }},
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            PACKAGE_VERSION=${{ needs.init.outputs.product-version }}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,0 +1,29 @@
+on:
+  workflow_call:
+    outputs:
+      product-version:
+        value: ${{ jobs.init.outputs.product-version }}
+      product-version-major:
+        value: ${{ jobs.init.outputs.product-version-major }}
+
+jobs:
+
+  init:
+    name: Initialize
+    runs-on: ubuntu-latest
+
+    outputs:
+      product-version: ${{ steps.version.outputs.product-version }}
+      product-version-major: ${{ steps.version.outputs.product-version-major }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Version
+        id: version
+        working-directory: ./
+        run: |
+          productVersion=$(cat version.txt)
+          majorVersion=$(echo "$productVersion" | cut -d'.' -f1)
+          echo "product-version=$productVersion" >> $GITHUB_OUTPUT
+          echo "product-version-major=$majorVersion" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ on:
         description: 'Confirm version is set'
         type: boolean
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 defaults:
   run:
     working-directory: src
@@ -18,24 +14,7 @@ defaults:
 jobs:
 
   init:
-    name: Initialize
-    runs-on: ubuntu-latest
-
-    outputs:
-      product-version: ${{ steps.version.outputs.product-version }}
-      product-version-major: ${{ steps.version.outputs.product-version-major }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Get Version
-        id: version
-        working-directory: ./
-        run: |
-          productVersion=$(cat version.txt)
-          majorVersion=$(echo "$productVersion" | cut -d'.' -f1)
-          echo "product-version=$productVersion" >> $GITHUB_OUTPUT
-          echo "product-version-major=$majorVersion" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/init.yml
 
   exe:
     name: Build executables
@@ -145,35 +124,5 @@ jobs:
         run: dotnet nuget push "Valleysoft.Dredge/bin/Release/*.nupkg" -k ${{secrets.NUGET_ORG_API_KEY}} -s https://nuget.org
 
   docker:
-    name: Publish Docker Image
-    runs-on: ubuntu-latest
-    needs: [ init, nuget ]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: ./src
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: >
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.product-version }},
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.product-version-major }},
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          build-args: |
-            PACKAGE_VERSION=${{ needs.init.outputs.product-version }}
+    uses: ./.github/workflows/docker-publish.yml
+    needs: [ nuget ]


### PR DESCRIPTION
This factors out Docker publishing into a reusable workflow so that it can be executed independently of the overall release workflow. This allows for rebuilding of the image outside the context of releases, so that base image updates can be incorporated.