### PR TITLE
Switch to framework-dependent deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish
         working-directory: src/Valleysoft.Dredge
-        run: dotnet publish -f net8.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }}
+        run: dotnet publish -f net8.0 -c Release --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --no-self-contained
 
       - name: Rename output
         run: |

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,10 +11,10 @@ RUN dotnet restore -a $TARGETARCH Valleysoft.Dredge/*.csproj
 
 COPY Valleysoft.Dredge/ Valleysoft.Dredge/
 COPY Valleysoft.Dredge.Analyzers/ Valleysoft.Dredge.Analyzers/
-RUN dotnet publish Valleysoft.Dredge/*.csproj -f net8.0 -o /app -a $TARGETARCH --self-contained /p:Version=$PACKAGE_VERSION --no-restore
+RUN dotnet publish Valleysoft.Dredge/*.csproj -f net8.0 -o /app -a $TARGETARCH --no-self-contained /p:Version=$PACKAGE_VERSION --no-restore
 
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled
+FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["./dredge"]

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -11,10 +11,7 @@
 
   <PropertyGroup Condition=" '$(IsPack)' != 'true' ">
     <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishSelfContained>true</PublishSelfContained>
-    <TrimMode>partial</TrimMode>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
To better utilize shared installation of .NET, I'm switching from a self-contained deployment to framework-dependent deployment. This will require an existing installation of the .NET runtime in order to run the executable.