### PR TITLE
Ensure non-zero exit code on error

### DIFF
--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -38,6 +38,7 @@ internal static class CommandHelper
 
             Console.Error.WriteLine(message);
             Console.ForegroundColor = savedColor;
+            Environment.Exit(1);
         }
     }
 }


### PR DESCRIPTION
This fixes an issue where dredge would always return an exit code of 0, even when an error occurred.