### PR TITLE
Command to list referrers of a manifest

### DIFF
--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -1,0 +1,31 @@
+# Referrers
+
+Sub-commands:
+
+* [`list`](#query-referrers) - Lists the referrers to a manifest
+
+## Query Referrers
+
+Returns the referrers to the specified manifest.
+
+```console
+> dredge referrer list mcr.microsoft.com/dotnet/core/sdk:latest
+{
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:551e9aa2046071e51b1611a7e85f85af3d2cc6841935cc176a931de4194ecdc1",
+      "size": 788,
+      "urls": [],
+      "annotations": {
+        "org.opencontainers.image.created": "2024-08-13T14:20:19Z",
+        "vnd.microsoft.artifact.lifecycle.end-of-life.date": "2022-12-13"
+      },
+      "artifactType": "application/vnd.microsoft.artifact.lifecycle"
+    }
+  ],
+  "annotations": {},
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json"
+}
+```

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json;
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class ListCommand : RegistryCommandBase<ListOptions>
+{
+    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : base("list", "Lists the referrers to a manifest", dockerRegistryClientFactory)
+    {
+    }
+
+    protected override Task ExecuteAsync()
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        {
+            using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+
+            OciImageIndex initialIndex;
+
+            string digest;
+            if (!string.IsNullOrEmpty(imageName.Digest))
+            {
+                digest = imageName.Digest;
+            }
+            else
+            {
+                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, imageName.Tag!);
+                digest = manifestInfo.DockerContentDigest;
+            }
+
+            Page<OciImageIndex> indexPage = await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType);
+            initialIndex = indexPage.Value;
+            while (indexPage.NextPageLink is not null)
+            {
+                Page<OciImageIndex> nextPage = await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType);
+                initialIndex.Manifests = initialIndex.Manifests
+                    .Concat(nextPage.Value.Manifests)
+                    .ToArray();
+            }
+
+            string output = JsonConvert.SerializeObject(initialIndex, JsonHelper.Settings);
+
+            Console.Out.WriteLine(output);
+        });
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
@@ -1,0 +1,24 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class ListOptions : OptionsBase
+{
+    private readonly Argument<string> imageArg;
+    private readonly Option<string> artifactTypeArg;
+
+    public string Image { get; set; } = string.Empty;
+    public string? ArtifactType { get; set; }
+
+    public ListOptions()
+    {
+        imageArg = Add(new Argument<string>("name", "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)"));
+        artifactTypeArg = Add(new Option<string>("--artifact-type", "Artifact media type to filter by"));
+    }
+
+    protected override void GetValues()
+    {
+        Image = GetValue(imageArg);
+        ArtifactType = GetValue(artifactTypeArg);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
@@ -1,0 +1,12 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class ReferrerCommand : Command
+{
+    public ReferrerCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : base("referrer", "Commands related to referrers")
+    {
+        AddCommand(new ListCommand(dockerRegistryClientFactory));
+    }
+}

--- a/src/Valleysoft.Dredge/DockerRegistryClientWrapper.cs
+++ b/src/Valleysoft.Dredge/DockerRegistryClientWrapper.cs
@@ -19,5 +19,7 @@ internal class DockerRegistryClientWrapper : IDockerRegistryClient
 
     public ITagOperations Tags => dockerRegistryClient.Tags;
 
+    public IReferrerOperations Referrers => dockerRegistryClient.Referrers;
+
     public void Dispose() => dockerRegistryClient.Dispose();
 }

--- a/src/Valleysoft.Dredge/IDockerRegistryClient.cs
+++ b/src/Valleysoft.Dredge/IDockerRegistryClient.cs
@@ -7,5 +7,6 @@ public interface IDockerRegistryClient : IDisposable
     IBlobOperations Blobs { get; }
     ICatalogOperations Catalog { get; }
     IManifestOperations Manifests { get; }
+    IReferrerOperations Referrers { get; }
     ITagOperations Tags { get; }
 }

--- a/src/Valleysoft.Dredge/Program.cs
+++ b/src/Valleysoft.Dredge/Program.cs
@@ -2,6 +2,7 @@
 using Valleysoft.Dredge;
 using Valleysoft.Dredge.Commands.Image;
 using Valleysoft.Dredge.Commands.Manifest;
+using Valleysoft.Dredge.Commands.Referrer;
 using Valleysoft.Dredge.Commands.Repo;
 using Valleysoft.Dredge.Commands.Settings;
 using Valleysoft.Dredge.Commands.Tag;
@@ -11,6 +12,7 @@ RootCommand rootCmd = new("CLI for executing commands on a container registry's 
 {
     new ImageCommand(clientFactory),
     new ManifestCommand(clientFactory),
+    new ReferrerCommand(clientFactory),
     new RepoCommand(clientFactory),
     new TagCommand(clientFactory),
     new SettingsCommand(clientFactory),

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Valleysoft.DockerCredsProvider" Version="2.2.3" />
     <PackageReference Include="Valleysoft.DockerfileModel" Version="1.1.1" />
-    <PackageReference Include="Valleysoft.DockerRegistryClient" Version="5.0.0" />
+    <PackageReference Include="Valleysoft.DockerRegistryClient" Version="5.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This provides a command which queries the [referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) API to find artifacts that refer to the specified manifest.