### PR TITLE
Flow product-version to build/publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Publish
         working-directory: src/Valleysoft.Dredge
+        env:
+          PACKAGE_VERSION: ${{ needs.init.outputs.product-version }}
         run: dotnet publish -f net9.0 -c Release -p:Version=$PACKAGE_VERSION --no-restore -o ${{ github.workspace }}/publish --runtime ${{ matrix.rid }} --no-self-contained
 
       - name: Rename output
@@ -108,6 +110,8 @@ jobs:
         run: dotnet restore
 
       - name: Build
+        env:
+          PACKAGE_VERSION: ${{ needs.init.outputs.product-version }}
         run: dotnet build -c Release -p:Version=$PACKAGE_VERSION --no-restore Valleysoft.Dredge
 
       - name: Pack


### PR DESCRIPTION
The build is failing with:

```
Run dotnet publish -f net9.0 -c Release -p:Version=$PACKAGE_VERSION --no-restore -o /home/runner/work/dredge/dredge/publish --runtime osx-x64 --no-self-contained
/usr/share/dotnet/sdk/9.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(22[6](https://github.com/mthalman/dredge/actions/runs/12733865223/job/35490727565#step:5:7),5): error MSB4044: The "GetAssemblyVersion" task was not given a value for the required parameter "NuGetVersion". [/home/runner/work/dredge/dredge/src/Valleysoft.Dredge.Analyzers/Valleysoft.Dredge.Analyzers.csproj::TargetFramework=netstandard2.0]
```

This is a regression caused by https://github.com/mthalman/dredge/pull/137 because it doesn't have `PACKAGE_VERSION` set. Related to https://github.com/mthalman/dredge/issues/86