### PR TITLE
Delay Renovate updates for 10 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:best-practices"
   ],
+  "minimumReleaseAge": "10 days",
   "mode": "full"
 }


### PR DESCRIPTION
New dependency releases can introduce regressions before they have had time to stabilize. Configure Renovate to wait 10 days after a version is released before proposing the update, applying the delay to all dependencies.