### PR TITLE
Fix Dockerfile instruction quoting

### DIFF
--- a/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/expected-output-format.txt
+++ b/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/expected-output-format.txt
@@ -1,0 +1,5 @@
+[#C285BF]FROM[/] [#96DCFE]scratch[/]
+[#C285BF]LABEL[/] maintainer=Microsoft org.label-schema.schema-version=1.0 org.label-schema.vendor=Microsoft org.label-schema.name=Azure CLI org.label-schema.version=2.60.0 org.label-schema.license=MIT org.label-schema.description=A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure. org.label-schema.url=https://docs.microsoft.com/cli/azure/overview org.label-schema.usage=https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker org.label-schema.build-date=2024-04-24T04:34:45Z org.label-schema.vcs-url=https://github.com/Azure/azure-cli.git org.label-schema.docker.cmd=docker run -v ${HOME}/.azure:/root/.azure -it mcr.microsoft.com/azure-cli:2.60.0-azure
+[#C285BF]ENV[/] A=1 B=hello world C=3
+[#C285BF]RUN[/] [#96DCFE]/bin/sh -c echo done # buildkit
+[/]

--- a/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/expected-output-no-format.txt
+++ b/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/expected-output-no-format.txt
@@ -1,0 +1,5 @@
+[#C285BF]FROM[/] [#96DCFE]scratch[/]
+[#C285BF]LABEL[/] maintainer=Microsoft org.label-schema.schema-version=1.0 org.label-schema.vendor=Microsoft org.label-schema.name=Azure CLI org.label-schema.version=2.60.0 org.label-schema.license=MIT org.label-schema.description=A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure. org.label-schema.url=https://docs.microsoft.com/cli/azure/overview org.label-schema.usage=https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker org.label-schema.build-date=2024-04-24T04:34:45Z org.label-schema.vcs-url=https://github.com/Azure/azure-cli.git org.label-schema.docker.cmd=docker run -v ${HOME}/.azure:/root/.azure -it mcr.microsoft.com/azure-cli:2.60.0-azure
+[#C285BF]ENV[/] A=1 B=hello world C=3
+[#C285BF]RUN[/] [#96DCFE]/bin/sh -c echo done # buildkit
+[/]

--- a/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/image.json
+++ b/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/azure-cli/image.json
@@ -1,0 +1,17 @@
+{
+  "__comment": "Regression coverage for https://github.com/mthalman/dredge/issues/139",
+  "os": "linux",
+  "history": [
+    {
+      "created_by": "LABEL maintainer=Microsoft org.label-schema.schema-version=1.0 org.label-schema.vendor=Microsoft org.label-schema.name=Azure CLI org.label-schema.version=2.60.0 org.label-schema.license=MIT org.label-schema.description=A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure. org.label-schema.url=https://docs.microsoft.com/cli/azure/overview org.label-schema.usage=https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker org.label-schema.build-date=2024-04-24T04:34:45Z org.label-schema.vcs-url=https://github.com/Azure/azure-cli.git org.label-schema.docker.cmd=docker run -v ${HOME}/.azure:/root/.azure -it mcr.microsoft.com/azure-cli:2.60.0-azure",
+      "empty_layer": true
+    },
+    {
+      "created_by": "ENV A=1 B=hello world C=3",
+      "empty_layer": true
+    },
+    {
+      "created_by": "RUN /bin/sh -c echo done # buildkit"
+    }
+  ]
+}

--- a/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/openjdk/expected-output-format.txt
+++ b/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/openjdk/expected-output-format.txt
@@ -3,7 +3,7 @@
 [/][#C285BF]ARG[/] [green]EULA[/][#FAC81F]=[/][#96DCFE]@EULA_FILE@[/]
 [#C285BF]COPY[/] [#96DCFE]file:2c9b9395238ee55ff215d908ee6cf02975b45c4e6c97b276333bcd60ee705729[/] [#96DCFE].[/]
 [#C285BF]LABEL[/] [green]Author[/][#FAC81F]=[/][#96DCFE]Microsoft[/]
-[#C285BF]LABEL[/] [green]Support[/][#FAC81F]=[/][#CA9178]"Microsoft OpenJDK Support <openjdk-support@microsoft.com>"[/]
+[#C285BF]LABEL[/] Support=Microsoft OpenJDK Support <openjdk-support@microsoft.com>
 [#C285BF]COPY[/] [#96DCFE]/staging/[/] [#96DCFE]/[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]
 [#C285BF]COPY[/] [#96DCFE]/usr/jdk/[/] [#96DCFE]/usr/jdk/[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]
 [#C285BF]COPY[/] [#96DCFE]/staging/home/app[/] [#96DCFE]/home/app[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]

--- a/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/openjdk/expected-output-no-format.txt
+++ b/src/Valleysoft.Dredge.Tests/TestData/DockerfileCommand/openjdk/expected-output-no-format.txt
@@ -3,7 +3,7 @@
 [/][#C285BF]ARG[/] [green]EULA[/][#FAC81F]=[/][#96DCFE]@EULA_FILE@[/]
 [#C285BF]COPY[/] [#96DCFE]file:2c9b9395238ee55ff215d908ee6cf02975b45c4e6c97b276333bcd60ee705729[/] [#96DCFE].[/]
 [#C285BF]LABEL[/] [green]Author[/][#FAC81F]=[/][#96DCFE]Microsoft[/]
-[#C285BF]LABEL[/] [green]Support[/][#FAC81F]=[/][#CA9178]"Microsoft OpenJDK Support <openjdk-support@microsoft.com>"[/]
+[#C285BF]LABEL[/] Support=Microsoft OpenJDK Support <openjdk-support@microsoft.com>
 [#C285BF]COPY[/] [#96DCFE]/staging/[/] [#96DCFE]/[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]
 [#C285BF]COPY[/] [#96DCFE]/usr/jdk/[/] [#96DCFE]/usr/jdk/[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]
 [#C285BF]COPY[/] [#96DCFE]/staging/home/app[/] [#96DCFE]/home/app[/] [#96DCFE]#[/] [#96DCFE]buildkit[/]

--- a/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
+++ b/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
@@ -28,6 +28,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="TestData\DockerfileCommand\azure-cli\expected-output-format.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\DockerfileCommand\azure-cli\expected-output-no-format.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\DockerfileCommand\azure-cli\image.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\DockerfileCommand\fedora\expected-output-format.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -18,13 +18,6 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
     private static readonly Color CommentColor = new(109, 154, 88); // green-ish
     private static readonly Color LiteralColor = new(150, 220, 254); // light turquoise
     private static readonly Color IdentifierColor = Color.Green;
-    private static readonly string[] KeyValuePairInstructions =
-    [
-        "ARG",
-        "ENV",
-        "LABEL"
-    ];
-
     private readonly IDockerRegistryClientFactory dockerRegistryClientFactory;
 
     public DockerfileCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
@@ -53,19 +46,19 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, digest);
         bool isWindows = imageConfig.Os.Equals("windows", StringComparison.OrdinalIgnoreCase);
 
-        StringBuilder dockerfileBuilder = new();
+        List<string> dockerfileLines = [];
         IEnumerable<LayerHistory> layers;
 
         if (isWindows)
         {
             (WindowsOsInfo windowsOsInfo, string repo) = await GetWindowsInfoAsync(manifest, imageConfig);
             layers = await GetWindowsLayersAsync(imageConfig, manifest, repo);
-            dockerfileBuilder.AppendLine($"FROM {RegistryHelper.McrRegistry}/{repo}:{windowsOsInfo.Version}-{imageConfig.Architecture}");
+            dockerfileLines.Add($"FROM {RegistryHelper.McrRegistry}/{repo}:{windowsOsInfo.Version}-{imageConfig.Architecture}");
         }
         else
         {
             layers = imageConfig.History;
-            dockerfileBuilder.AppendLine("FROM scratch");
+            dockerfileLines.Add("FROM scratch");
         }
 
         string? currentShell = null;
@@ -74,27 +67,65 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         {
             if (string.IsNullOrEmpty(layerHistory.CreatedBy))
             {
-                dockerfileBuilder.AppendLine("# No instruction info");
+                dockerfileLines.Add("# No instruction info");
                 continue;
             }
 
             string line = GetHistoryLine(layerHistory.CreatedBy, ref currentShell);
-            dockerfileBuilder.AppendLine(line);
+            dockerfileLines.Add(line);
         }
 
         StringBuilder markup = new();
-        Dockerfile fullDockerfile = Dockerfile.Parse(dockerfileBuilder.ToString());
+        foreach (string line in dockerfileLines)
+        {
+            AppendLineMarkup(line, markup);
+        }
 
-        foreach (DockerfileConstruct construct in fullDockerfile.Items)
+        return markup.ToString();
+    }
+
+    private void AppendLineMarkup(string line, StringBuilder markup)
+    {
+        string source = line + Environment.NewLine;
+        Dockerfile dockerfile = Dockerfile.Parse(source);
+
+        if (!IsParseLossless(source, dockerfile))
+        {
+            // Image history can be ambiguous after the builder discards original quoting.
+            // Preserve it verbatim rather than silently dropping text or changing its meaning.
+            KeywordToken? keywordToken = dockerfile.Items
+                .SelectMany(construct => construct.Tokens)
+                .OfType<KeywordToken>()
+                .FirstOrDefault();
+            string? keyword = keywordToken?.ToString();
+            if (keywordToken is not null &&
+                keyword is not null &&
+                line.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                markup.Append(GetTokenMarkup(keywordToken, inRunInstruction: false));
+                markup.AppendLine(Markup.Escape(line[keyword.Length..]));
+            }
+            else
+            {
+                markup.AppendLine(Markup.Escape(line));
+            }
+            return;
+        }
+
+        foreach (DockerfileConstruct construct in dockerfile.Items)
         {
             foreach (Token token in construct.Tokens)
             {
                 markup.Append(GetTokenMarkup(token, construct is RunInstruction));
             }
         }
-
-        return markup.ToString();
     }
+
+    private static bool IsParseLossless(string source, Dockerfile dockerfile) =>
+        string.Equals(
+            source,
+            string.Concat(dockerfile.Items.SelectMany(construct => construct.Tokens)),
+            StringComparison.Ordinal);
 
     private async Task<IEnumerable<LayerHistory>> GetWindowsLayersAsync(ImageConfig imageConfig, IImageManifest manifest, string windowsRepo)
     {
@@ -182,9 +213,10 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
             }
 
             Dockerfile? dockerfile = null;
+            string source = line + Environment.NewLine;
             try
             {
-                dockerfile = Dockerfile.Parse(line);
+                dockerfile = Dockerfile.Parse(source);
             }
             catch (Exception)
             {
@@ -200,7 +232,7 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
                 }
                 else if (dockerfileConstruct is EnvInstruction envInstruction)
                 {
-                    if (!Options.NoFormat)
+                    if (!Options.NoFormat && IsParseLossless(source, dockerfile))
                     {
                         line = FormatEnvInstruction(line, envInstruction);
                     }
@@ -225,12 +257,6 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 
                 line = $"RUN {line}";
             }
-        }
-
-        if (KeyValuePairInstructions.Any(instruction => line.StartsWith(instruction, StringComparison.OrdinalIgnoreCase)))
-        {
-            // Ensure that key-value pair instructions have their values surrounded in quotes to account for any spaces
-            line = MyRegex().Replace(line, "$1\"$3\"");
         }
 
         return line;
@@ -372,9 +398,6 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
             return tokenStr;
         }
     }
-
-    [GeneratedRegex("(^\\S+\\s+[A-Za-z0-9]*(\\s|=)+)(\\S*\\s.*)")]
-    private static partial Regex MyRegex();
 
     [GeneratedRegex(@"[ \t]+&&[ \t]{2,}")]
     private static partial Regex AndBeforeNewLineRegex();


### PR DESCRIPTION
Image history can omit the original quoting needed to distinguish spaces within values from spaces between key/value pairs. Dredge previously guessed by quoting the entire remainder of `ARG`, `ENV`, and `LABEL` instructions, which changed their meaning and could cause a following instruction to be consumed during parsing.

This change removes that synthetic quoting, parses each history entry independently, and preserves the original text whenever DockerfileModel cannot round-trip it without loss. Recognized instruction keywords remain syntax-colored, while ambiguous arguments are emitted verbatim. Regression coverage includes the Azure CLI label from the issue and an ambiguous multi-value `ENV` instruction.

Fixes: #139