### PR TITLE
Improve repository documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,18 @@
 # Contributing
 
-Contributions are welcome. Submit a pull request or open an issue as necessary.
+Contributions are welcome. Open an issue to report a problem or submit a pull
+request with a proposed change.
 
-## Developer Prerequisites
+## Prerequisites
 
-* [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-* [Docker](https://docs.docker.com/get-docker/) (optional, for container builds)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [Docker](https://docs.docker.com/get-docker/) if you need to build the
+  container image
 
-## Build and Test
+## Build and test
 
-All commands are run from the `src/` directory:
+From the repository's `src` directory, restore dependencies, build the
+solution, and run the test suite:
 
 ```shell
 dotnet restore
@@ -17,8 +20,14 @@ dotnet build -c Release --no-restore
 dotnet test --no-restore -v normal -c Release
 ```
 
-To run a single test class:
+To run one test class:
 
 ```shell
 dotnet test --no-restore --filter "ClassName=Valleysoft.Dredge.Tests.CompareLayersCommandTests"
+```
+
+To run tests whose fully qualified names contain a specific value:
+
+```shell
+dotnet test --no-restore --filter "FullyQualifiedName~Valleysoft.Dredge.Tests.CompareLayersCommandTests.Verify"
 ```

--- a/README.md
+++ b/README.md
@@ -1,28 +1,40 @@
-<img src="dredge-logo.png" width="250" />
+<img src="dredge-logo.png" width="250" alt="Dredge">
 
 # Dredge
 
-A .NET CLI for querying container registry HTTP APIs ([OCI Distribution Spec](https://github.com/opencontainers/distribution-spec)). All operations are read-only.
+Dredge is a .NET command-line tool for querying container registry HTTP APIs
+defined by the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec).
+Dredge does not modify registry content.
 
 ## Features
 
-* Query raw JSON data from registry APIs — [manifests](docs/commands/manifests.md), [tags](docs/commands/tags.md), [repositories](docs/commands/repositories.md), and [referrers](docs/commands/referrers.md).
-* Inspect [image configuration](docs/commands/images.md#inspect) and [OS information](docs/commands/images.md#os).
-* Compare image [layers](docs/commands/images.md#compare-layers) and [files](docs/commands/images.md#compare-files) across versions.
-* [Generate Dockerfiles](docs/commands/images.md#dockerfile) from existing images.
-* [Save image layers](docs/commands/images.md#save-layers) to disk (squashed or individual).
-* [Platform resolution](docs/platform-resolution.md) for multi-arch images.
+- Query raw JSON data for [manifests](docs/commands/manifests.md),
+  [tags](docs/commands/tags.md), [repositories](docs/commands/repositories.md),
+  and [referrers](docs/commands/referrers.md).
+- Inspect an image's [configuration](docs/commands/images.md#inspect) and
+  [operating system information](docs/commands/images.md#os).
+- Compare [layers](docs/commands/images.md#compare-layers) or
+  [files](docs/commands/images.md#compare-files) between images.
+- [Generate a Dockerfile](docs/commands/images.md#dockerfile) from an image.
+- [Save image layers](docs/commands/images.md#save-layers) as a merged
+  filesystem or as separate directories.
+- Select a platform from a multi-platform image through
+  [platform resolution](docs/platform-resolution.md).
 
-📖 Full documentation is in the [docs](docs) directory.
+See the [Dredge documentation](docs/README.md) for the complete command
+reference and configuration guides.
 
-## Install
+## Install Dredge
 
-### Standalone executable
+Choose one installation method.
+
+### Release executable
 
 Download from the [release page](https://github.com/mthalman/dredge/releases).
+Select the executable for your operating system and architecture.
 
-Prerequisites:
-* [.NET 10 runtime](https://dotnet.microsoft.com/download/dotnet/10.0)
+The release executable requires the
+[.NET 10 runtime](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 ### Container
 
@@ -30,8 +42,23 @@ Prerequisites:
 docker run --rm ghcr.io/mthalman/dredge --help
 ```
 
+When following command examples, replace `dredge` with
+`docker run --rm ghcr.io/mthalman/dredge`.
+
 ### .NET global tool
 
 ```console
 dotnet tool install -g Valleysoft.Dredge
 ```
+
+## Query a registry
+
+Run a read-only command against a public image:
+
+```console
+dredge manifest digest alpine:latest
+sha256:...
+```
+
+If the registry requires credentials, see
+[Authenticate to a registry](docs/authentication.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,19 @@
-# Dredge Documentation
+# Dredge documentation
 
-## Commands
+Use the command reference to look up syntax and options. Use the guides to
+configure authentication, settings, and platform selection.
 
-* [`image`](commands/images.md) — Inspect, compare, and export container images
-* [`manifest`](commands/manifests.md) — Query and resolve manifests
-* [`referrer`](commands/referrers.md) — List referrers to a manifest
-* [`repo`](commands/repositories.md) — List repositories in a registry
-* [`tag`](commands/tags.md) — List tags in a repository
-* [`settings`](commands/settings.md) — Manage Dredge configuration
+## Command reference
+
+- [`image`](commands/images.md) — Inspect, compare, and export container images
+- [`manifest`](commands/manifests.md) — Query and resolve manifests
+- [`referrer`](commands/referrers.md) — List referrers to a manifest
+- [`repo`](commands/repositories.md) — List repositories in a registry
+- [`tag`](commands/tags.md) — List tags in a repository
+- [`settings`](commands/settings.md) — Manage Dredge configuration
 
 ## Guides
 
-* [Authentication](authentication.md)
-* [Settings file](settings.md)
-* [Platform resolution](platform-resolution.md)
+- [Authenticate to a registry](authentication.md)
+- [Configure Dredge](settings.md)
+- [Resolve a platform-specific image](platform-resolution.md)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,25 +1,50 @@
-# Authentication
+# Authenticate to a registry
 
-For registries that require authentication, Dredge resolves credentials in the following order:
+For each registry request, Dredge selects credentials in this order:
 
-1. **`DREDGE_TOKEN` environment variable** — OAuth bearer token for the registry.
-2. **`DREDGE_USERNAME` and `DREDGE_PASSWORD` environment variables** — Basic credentials.
-3. **Docker credential store** — Credentials stored via `docker login`.
+1. The `DREDGE_TOKEN` environment variable.
+2. The `DREDGE_USERNAME` and `DREDGE_PASSWORD` environment variables. Dredge
+   uses these credentials only when both variables are set.
+3. Credentials saved by `docker login`.
+4. Anonymous access when no credentials are available.
 
-If none of these are available, Dredge attempts anonymous access.
+`DREDGE_TOKEN` takes precedence over every other credential source.
 
-## Examples
+## Use an access token
 
-### Using an environment variable
+Set `DREDGE_TOKEN` to a registry access token, and then run Dredge in the same
+shell.
 
 ```shell
 export DREDGE_TOKEN="your-oauth-token"
 dredge manifest get myregistry.azurecr.io/myimage:latest
 ```
 
-### Using Docker credentials
+In PowerShell:
+
+```powershell
+$env:DREDGE_TOKEN = "your-oauth-token"
+dredge manifest get myregistry.azurecr.io/myimage:latest
+```
+
+## Use a username and password
+
+Set both environment variables in the shell that runs Dredge:
+
+```shell
+export DREDGE_USERNAME="your-username"
+export DREDGE_PASSWORD="your-password"
+dredge manifest get myregistry.example.com/myimage:latest
+```
+
+## Use saved Docker credentials
+
+Authenticate with Docker before running Dredge:
 
 ```shell
 docker login myregistry.azurecr.io
 dredge manifest get myregistry.azurecr.io/myimage:latest
 ```
+
+Dredge reads the credential store configured by Docker. You do not need to
+keep Docker running.

--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -1,4 +1,4 @@
-# Image Commands
+# Image commands
 
 All image commands support [platform resolution](../platform-resolution.md) via `--os`, `--arch`, and `--os-version` options.
 
@@ -81,7 +81,7 @@ dredge image os mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
 }
 ```
 
-## Compare Layers
+## Compare layers
 
 Compares the layers of two images.
 
@@ -111,7 +111,7 @@ dredge image compare layers --output inline amd64/node:19.1-alpine amd64/node:19
 
 ### Side-by-side output with history example
 
-```
+```console
 dredge image compare layers --history --no-color mcr.microsoft.com/dotnet/runtime:6.0.5-jammy-amd64 mcr.microsoft.com/dotnet/runtime:6.0.6-jammy-amd64
 ┌──────────────────────────────────────────────────────────────────────────┬───────────┬─────────────────────────────────────────────────────────────────────────┐
 │ mcr.microsoft.com/dotnet/runtime:6.0.5-jammy-amd64                       │  Compare  │ mcr.microsoft.com/dotnet/runtime:6.0.6-jammy-amd64                      │
@@ -147,29 +147,24 @@ dredge image compare layers --history --no-color mcr.microsoft.com/dotnet/runtim
 └──────────────────────────────────────────────────────────────────────────┴───────────┴─────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Compare Files
+## Compare files
 
-Compares the file contents of two images by downloading and squashing their layers into local filesystem representations, then launching an external diff tool.
+Compares the files in two images. Dredge downloads each image, applies its
+layers to a temporary directory, and starts the configured external comparison
+tool.
+
+Before running this command, [configure the file comparison
+tool](../settings.md#configure-the-file-comparison-tool).
 
 ```console
-dredge image compare files <base> <target> [--base-layer-index <n>] [--target-layer-index <n>] [--os <os>] [--arch <arch>] [--os-version <version>]
+dredge image compare files <base> <target> [--base-layer-index <n>] [--target-layer-index <n>] [--output <type>] [--os <os>] [--arch <arch>] [--os-version <version>]
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--base-layer-index` | Only apply layers up to this index for the base image |
-| `--target-layer-index` | Only apply layers up to this index for the target image |
-
-The external comparison tool is configured in the [settings file](../settings.md):
-
-```json
-{
-  "fileCompareTool": {
-    "exePath": "C:\\Program Files\\Beyond Compare 4\\BCompare.exe",
-    "args": "{0} {1}"
-  }
-}
-```
+| `--base-layer-index` | Apply base-image layers from index `0` through this zero-based index |
+| `--target-layer-index` | Apply target-image layers from index `0` through this zero-based index |
+| `--output` | Output type. The supported and default value is `ExternalTool` |
 
 Example — compare two images:
 
@@ -189,7 +184,7 @@ Example — compare layers within a single image (difference between the 2nd and
 dredge image compare files amd64/node:19.1-alpine amd64/node:19.1-alpine --base-layer-index 1 --target-layer-index 2
 ```
 
-## Save Layers
+## Save layers
 
 Saves the extracted layers of an image to disk.
 
@@ -199,8 +194,8 @@ dredge image save-layers <image> <output-path> [--no-squash] [--layer-index <n>]
 
 | Option | Description |
 |--------|-------------|
-| `--no-squash` | Save layers as individual directories instead of squashing |
-| `--layer-index` | Only save the specified layer (includes dependent layers when squashing) |
+| `--no-squash` | Save each selected layer in a separate directory instead of merging the layers |
+| `--layer-index` | Select a zero-based layer index. With squashing, Dredge applies layers `0` through this index. With `--no-squash`, Dredge saves only this layer |
 
 Example:
 

--- a/docs/commands/manifests.md
+++ b/docs/commands/manifests.md
@@ -1,4 +1,4 @@
-# Manifest Commands
+# Manifest commands
 
 | Sub-command | Description |
 |-------------|-------------|

--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -1,4 +1,4 @@
-# Referrer Commands
+# Referrer commands
 
 | Sub-command | Description |
 |-------------|-------------|

--- a/docs/commands/repositories.md
+++ b/docs/commands/repositories.md
@@ -1,4 +1,4 @@
-# Repository Commands
+# Repository commands
 
 | Sub-command | Description |
 |-------------|-------------|

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -1,4 +1,4 @@
-# Settings Commands
+# Settings commands
 
 | Sub-command | Description |
 |-------------|-------------|
@@ -43,7 +43,7 @@ Example:
 dredge settings set platform.os linux
 ```
 
-## Clear Cache
+## Clear cache
 
 Deletes the local cache of layer data stored in the temporary directory. This cache is created by commands like [`image compare files`](images.md#compare-files) and [`image save-layers`](images.md#save-layers).
 

--- a/docs/commands/tags.md
+++ b/docs/commands/tags.md
@@ -1,4 +1,4 @@
-# Tag Commands
+# Tag commands
 
 | Sub-command | Description |
 |-------------|-------------|

--- a/docs/platform-resolution.md
+++ b/docs/platform-resolution.md
@@ -1,32 +1,42 @@
-# Platform Resolution
+# Resolve a platform-specific image
 
-For [certain operations](#operations-that-use-platform-resolution), Dredge needs to resolve a platform to a specific image manifest if a multi-arch/multi-platform tag is provided as input.
-For example, the `alpine:latest` tag points to different images for different architectures.
-For these commands, Dredge needs to know which image to use for the operation.
-If it's unable to resolve the platform, it will fail with an error.
-You can influence the platform resolution by setting the command's platform options or by setting the global platform settings.
+An image tag can identify a manifest list that contains images for multiple
+operating systems or architectures. Commands that operate on one image must
+select exactly one manifest from that list.
 
-## Operations that use platform resolution
+Dredge filters the manifest list by the platform values you provide. Resolution
+succeeds only when exactly one manifest matches. If no manifests or multiple
+manifests match, Dredge reports an error and suggests running
+`dredge manifest get` to inspect the available platforms.
 
-The following operations make use of platform resolution:
+## Commands that resolve platforms
 
-* [`manifest resolve`](commands/manifests.md#resolve)
-* All [`image`](commands/images.md) sub-commands
+The following commands use platform resolution:
 
-## Platform options
+- [`manifest resolve`](commands/manifests.md#resolve)
+- Every [`image`](commands/images.md) subcommand
 
-The following platform options can be used to influence platform resolution:
+## Select a platform
 
-* `--os`: The operating system of the platform ("linux" or "windows").
-* `--os-version`: The operating system version of the platform. This is usually only relevant for Windows images but may be relevant for Linux images in some rare cases.
-* `--arch`: The architecture of the platform (e.g. "amd64", "arm", "arm64").
+Pass one or more platform options to a command:
 
-## Global platform settings
+- `--os`: Operating system, such as `linux` or `windows`.
+- `--os-version`: Operating system version, such as `10.0.20348.1129`.
+- `--arch`: Architecture, such as `amd64`, `arm`, or `arm64`.
 
-Global platform settings allow you to statically define platform settings in the [Dredge settings file](settings.md) that will be used for all operations that use platform resolution.
-The same platform options can be used as described in the previous section.
+For example:
 
-Here's the configuration of these global platform settings:
+```console
+dredge manifest resolve alpine:latest --os linux --arch amd64
+```
+
+You do not need to specify every value. Provide enough values to leave one
+matching manifest.
+
+## Set default platform values
+
+To reuse platform values across commands, save them in the
+[Dredge settings file](settings.md):
 
 ```json
 {
@@ -38,23 +48,15 @@ Here's the configuration of these global platform settings:
 }
 ```
 
-You can set these values by using the [`settings set`](commands/settings.md#set) command:
-
-Example:
+Set each value with [`dredge settings set`](commands/settings.md#set):
 
 ```console
 dredge settings set platform.os linux
+dredge settings set platform.arch amd64
 ```
 
-## Platform resolution order
+## Precedence
 
-Since the platform options and global platform settings can be used to influence platform resolution, it's important to understand the order in which these settings are applied.
-
-Platform options provided in the call to the command take precedence over global platform settings.
-If a platform option is not provided in the call to the command, the global platform setting is used.
-
-It's not always necessary to set all of the platform values in order to successfully resolve the platform.
-For example, many images are only available for Linux.
-In that case, it's not necessary to set the `os` value because it doesn't reduce the amount of available platforms.
-For Linux, it's often enough to just set the `arch` value.
-As long as the provided platform values reduce the number of available platforms to a single platform, the platform resolution will succeed.
+For each platform value, a command-line option takes precedence over the
+corresponding saved setting. If you omit an option, Dredge uses its saved
+setting. If both values are empty, Dredge does not filter on that field.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,16 +1,52 @@
-# Settings File
+# Configure Dredge
 
-Dredge uses a settings file to store configuration information. The settings file is a JSON file named `settings.json` that is located in the following location:
+Dredge stores persistent configuration in `settings.json`. Dredge creates the
+file when a command first loads or changes settings.
 
-* Windows: `%LOCALAPPDATA%\Valleysoft.Dredge\settings.json`
-* Linux: `$HOME/.local/share/Valleysoft.Dredge/settings.json`
-* Mac: `$HOME/Library/Application Support/Valleysoft.Dredge/settings.json`
+The default path depends on the operating system:
 
- Dredge will create the settings file automatically when it's needed.
+- Windows: `%LOCALAPPDATA%\Valleysoft.Dredge\settings.json`
+- Linux: `$HOME/.local/share/Valleysoft.Dredge/settings.json`
+- macOS: `$HOME/Library/Application Support/Valleysoft.Dredge/settings.json`
 
-The [`settings`](commands/settings.md) command can be used to manipulate the settings file.
+Run `dredge settings open` to open the file in its associated application. If
+Dredge cannot open the file, the command prints its path.
 
-## Schema
+## Available settings
+
+Setting names use dot notation with `dredge settings get` and
+`dredge settings set`.
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `fileCompareTool.exePath` | Empty | Executable that `image compare files` starts |
+| `fileCompareTool.args` | Empty | Arguments passed to the comparison executable |
+| `platform.os` | Empty | Operating system used for platform resolution |
+| `platform.osVersion` | Empty | Operating system version used for platform resolution |
+| `platform.arch` | Empty | Architecture used for platform resolution |
+
+An empty platform setting does not filter candidate manifests. Command-line
+platform options take precedence over the corresponding settings. See
+[Resolve a platform-specific image](platform-resolution.md).
+
+## Configure the file comparison tool
+
+The `image compare files` command requires both `fileCompareTool` settings.
+Set `exePath` to a program that compares two directories. In `args`, use `{0}`
+for the extracted base image path and `{1}` for the extracted target image
+path.
+
+For example:
+
+```console
+dredge settings set fileCompareTool.exePath "C:\Program Files\Beyond Compare 4\BCompare.exe"
+dredge settings set fileCompareTool.args "{0} {1}"
+```
+
+Quote the placeholders in `fileCompareTool.args` if the comparison program
+requires quoted paths.
+
+## Settings file schema
 
 ```json
 {
@@ -26,6 +62,5 @@ The [`settings`](commands/settings.md) command can be used to manipulate the set
 }
 ```
 
-See [`image compare files`](commands/images.md#compare-files) for more information about the `fileCompareTool` setting.
-
-See [platform resolution](platform-resolution.md) for more information about the `platform` setting.
+Use the [`settings` commands](commands/settings.md) to read or change individual
+values.


### PR DESCRIPTION
The existing documentation omitted some supported behavior and made common setup tasks harder to understand on the first read. This update aligns the docs with the current CLI and gives users a clearer path from installation to their first registry query.

- Clarifies installation, container usage, authentication precedence, and contributor commands.
- Documents settings defaults, file comparison tool configuration, and platform resolution precedence.
- Adds the missing `image compare files --output` option and precise zero-based layer-index behavior.
- Improves navigation, heading consistency, link text, and command-reference structure.