### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices"
   ],
+  "dependencyDashboard": false,
   "minimumReleaseAge": "10 days",
   "mode": "full"
 }


### PR DESCRIPTION
Renovate currently creates a dependency dashboard issue that is not needed for this repository. Disable the dashboard while preserving the existing update configuration.