### PR TITLE
Support cancelling commands

### DIFF
--- a/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
@@ -1,0 +1,78 @@
+using System.CommandLine;
+using Valleysoft.Dredge.Commands;
+
+namespace Valleysoft.Dredge.Tests;
+
+public class CommandCancellationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task CancellationPropagatesFromCommandHelper()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+        cancellationTokenSource.Cancel();
+        bool executed = false;
+        using StringWriter error = new();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CommandHelper.ExecuteCommandAsync(
+                registry: null,
+                cancellationTokenSource.Token,
+                ct =>
+                {
+                    executed = true;
+                    ct.ThrowIfCancellationRequested();
+                    return Task.CompletedTask;
+                },
+                error));
+
+        Assert.True(executed);
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task InvocationTokenIsPassedToCommand()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+        TestCommand command = new();
+
+        Task<int> invocation = command
+            .Parse([])
+            .InvokeAsync(new InvocationConfiguration(), cancellationTokenSource.Token);
+
+        await command.Started.Task.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+        cancellationTokenSource.Cancel();
+
+        int exitCode = await invocation.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.True(command.CancellationToken.IsCancellationRequested);
+    }
+
+    private sealed class TestCommand : CommandWithOptions<TestOptions>
+    {
+        public TestCommand()
+            : base("test", "Test command")
+        {
+        }
+
+        public CancellationToken CancellationToken { get; private set; }
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            CancellationToken = cancellationToken;
+            Started.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+
+    public sealed class TestOptions : OptionsBase
+    {
+        protected override void GetValues()
+        {
+        }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -800,7 +800,7 @@ public class CompareLayersCommandTests
             }
         };
 
-        return cmd.GetOutputAsync();
+        return cmd.GetOutputAsync(TestContext.Current.CancellationToken);
     }
 
     private static void CompareJson<T>(T expected, T actual) =>

--- a/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
@@ -54,6 +54,7 @@ public class DockerfileCommandTests
     [MemberData(nameof(GetTestData))]
     public async Task Test(TestScenario scenario)
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         const string RepoName = "repo";
         const string TagName = "tag";
         const string ImageName = $"{Registry}/{RepoName}:{TagName}";
@@ -83,18 +84,20 @@ public class DockerfileCommandTests
             ];
 
             mcrClientMock
-                .Setup(o => o.Blobs.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(o => o.Blobs.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), cancellationToken))
                 .ReturnsAsync(false);
 
             mcrClientMock
                 .Setup(o => o.Blobs.ExistsAsync(
-                    "windows/servercore", It.Is<string>(digest => digest == "layer0digest" || digest == "layer1digest"), It.IsAny<CancellationToken>()))
+                    "windows/servercore",
+                    It.Is<string>(digest => digest == "layer0digest" || digest == "layer1digest"),
+                    cancellationToken))
                 .ReturnsAsync(true);
         }
 
         Mock<IDockerRegistryClient> registryClientMock = new();
         registryClientMock
-            .Setup(o => o.Manifests.GetAsync(RepoName, TagName, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Manifests.GetAsync(RepoName, TagName, cancellationToken))
             .ReturnsAsync(new ManifestInfo("media-type", "digest",
                 new DockerManifest
                 {
@@ -106,7 +109,7 @@ public class DockerfileCommandTests
                 }));
 
         registryClientMock
-            .Setup(o => o.Blobs.GetAsync(RepoName, Digest, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Blobs.GetAsync(RepoName, Digest, cancellationToken))
             .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(scenario.ImagePath))));
 
         clientFactoryMock
@@ -122,7 +125,7 @@ public class DockerfileCommandTests
             }
         };
 
-        string markupStr = await command.GetMarkupStringAsync();
+        string markupStr = await command.GetMarkupStringAsync(cancellationToken);
 
         string actual = TestHelper.Normalize(markupStr);
         string expected = TestHelper.Normalize(File.ReadAllText(scenario.ExpectedOutputPath));

--- a/src/Valleysoft.Dredge.Tests/FileHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/FileHelperTests.cs
@@ -1,0 +1,124 @@
+namespace Valleysoft.Dredge.Tests;
+
+public class FileHelperTests
+{
+    [Fact]
+    public async Task CopyFileAsyncPreservesMetadata()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string sourcePath = Path.Combine(tempDir, "source.txt");
+        string destinationPath = Path.Combine(tempDir, "destination.txt");
+        DateTime lastWriteTimeUtc = new(2020, 1, 2, 3, 4, 6, DateTimeKind.Utc);
+
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                sourcePath, "content", TestContext.Current.CancellationToken);
+            File.SetLastWriteTimeUtc(sourcePath, lastWriteTimeUtc);
+            File.SetAttributes(sourcePath, FileAttributes.ReadOnly);
+
+            await FileHelper.CopyFileAsync(
+                new FileInfo(sourcePath),
+                destinationPath,
+                overwrite: false,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("content", await File.ReadAllTextAsync(
+                destinationPath, TestContext.Current.CancellationToken));
+            Assert.Equal(lastWriteTimeUtc, File.GetLastWriteTimeUtc(destinationPath));
+            Assert.Equal(FileAttributes.ReadOnly, File.GetAttributes(destinationPath) & FileAttributes.ReadOnly);
+        }
+        finally
+        {
+            if (File.Exists(sourcePath))
+            {
+                File.SetAttributes(sourcePath, FileAttributes.Normal);
+            }
+            if (File.Exists(destinationPath))
+            {
+                File.SetAttributes(destinationPath, FileAttributes.Normal);
+            }
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CopyFileAsyncHonorsOverwrite()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string sourcePath = Path.Combine(tempDir, "source.txt");
+        string destinationPath = Path.Combine(tempDir, "destination.txt");
+
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                sourcePath, "new", TestContext.Current.CancellationToken);
+            await File.WriteAllTextAsync(
+                destinationPath, "old", TestContext.Current.CancellationToken);
+
+            await Assert.ThrowsAsync<IOException>(() =>
+                FileHelper.CopyFileAsync(
+                    new FileInfo(sourcePath),
+                    destinationPath,
+                    overwrite: false,
+                    TestContext.Current.CancellationToken));
+            Assert.Equal("old", await File.ReadAllTextAsync(
+                destinationPath, TestContext.Current.CancellationToken));
+
+            await FileHelper.CopyFileAsync(
+                new FileInfo(sourcePath),
+                destinationPath,
+                overwrite: true,
+                TestContext.Current.CancellationToken);
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                destinationPath, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CopyFileAsyncPreservesUnixFileMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string sourcePath = Path.Combine(tempDir, "source");
+        string destinationPath = Path.Combine(tempDir, "destination");
+        UnixFileMode mode =
+            UnixFileMode.UserRead |
+            UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead |
+            UnixFileMode.OtherRead;
+
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                sourcePath, "content", TestContext.Current.CancellationToken);
+            File.SetUnixFileMode(sourcePath, mode);
+
+            await FileHelper.CopyFileAsync(
+                new FileInfo(sourcePath),
+                destinationPath,
+                overwrite: false,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(mode, File.GetUnixFileMode(destinationPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -5,11 +5,19 @@ namespace Valleysoft.Dredge;
 
 internal static class CommandHelper
 {
-    public static async Task ExecuteCommandAsync(string? registry, Func<Task> execute)
+    public static async Task ExecuteCommandAsync(
+        string? registry,
+        CancellationToken cancellationToken,
+        Func<CancellationToken, Task> execute,
+        TextWriter? errorWriter = null)
     {
         try
         {
-            await execute();
+            await execute(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -36,7 +44,7 @@ internal static class CommandHelper
                 }
             }
 
-            Console.Error.WriteLine(message);
+            (errorWriter ?? Console.Error).WriteLine(message);
             Console.ForegroundColor = savedColor;
             Environment.Exit(1);
         }

--- a/src/Valleysoft.Dredge/Commands/CommandWithOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/CommandWithOptions.cs
@@ -11,12 +11,12 @@ public abstract class CommandWithOptions<TOptions> : Command
         : base(name, description)
     {
         Options.SetCommandOptions(this);
-        this.SetAction(parseResult =>
+        this.SetAction((parseResult, cancellationToken) =>
         {
             Options.SetParseResult(parseResult);
-            return ExecuteAsync();
+            return ExecuteAsync(cancellationToken);
         });
     }
 
-    protected abstract Task ExecuteAsync();
+    protected abstract Task ExecuteAsync(CancellationToken cancellationToken);
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -14,9 +14,9 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return CommandHelper.ExecuteCommandAsync(registry: null, async () =>
+        return CommandHelper.ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
         {
             AppSettings settings = AppSettings.Load();
             if (settings.FileCompareTool is null ||
@@ -27,18 +27,26 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
                     $"This command requires additional configuration.{Environment.NewLine}In order to compare files, you must first set the '{AppSettings.FileCompareToolName}' setting in {AppSettings.SettingsPath}. This is an external tool of your choosing that will be executed to compare two directories containing files of the specified images. Use '{{0}}' and '{{1}}' placeholders in the args to indicate the base and target path locations that will be the inputs to the compare tool.");
             }
 
-            await SaveImageLayersToDiskAsync(Options.BaseImage, BaseOutputDirName, Options.BaseLayerIndex, CompareOptionsBase.BaseArg);
+            await SaveImageLayersToDiskAsync(
+                Options.BaseImage, BaseOutputDirName, Options.BaseLayerIndex, CompareOptionsBase.BaseArg, ct);
             Console.Error.WriteLine();
-            await SaveImageLayersToDiskAsync(Options.TargetImage, TargetOutputDirName, Options.TargetLayerIndex, CompareOptionsBase.TargetArg);
+            await SaveImageLayersToDiskAsync(
+                Options.TargetImage, TargetOutputDirName, Options.TargetLayerIndex, CompareOptionsBase.TargetArg, ct);
 
             string args = settings.FileCompareTool.Args
                 .Replace("{0}", Path.Combine(CompareTempPath, BaseOutputDirName))
                 .Replace("{1}", Path.Combine(CompareTempPath, TargetOutputDirName));
+            ct.ThrowIfCancellationRequested();
             Process.Start(settings.FileCompareTool.ExePath, args);
         });
     }
 
-    private Task SaveImageLayersToDiskAsync(string image, string outputDirName, int? layerIndex, string layerIndexArg)
+    private Task SaveImageLayersToDiskAsync(
+        string image,
+        string outputDirName,
+        int? layerIndex,
+        string layerIndexArg,
+        CancellationToken cancellationToken)
     {
         string workingDir = Path.Combine(CompareTempPath, outputDirName);
         if (Directory.Exists(workingDir))
@@ -53,6 +61,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
             layerIndex,
             layerIndexArg + CompareFilesOptions.LayerIndexSuffix,
             noSquash: false,
-            Options);
+            Options,
+            cancellationToken);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -19,27 +19,27 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return CommandHelper.ExecuteCommandAsync(registry: null, async () =>
+        return CommandHelper.ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
         {
-            IRenderable output = await GetOutputAsync();
+            IRenderable output = await GetOutputAsync(ct);
             AnsiConsole.Write(output);
         });
     }
 
-    public async Task<IRenderable> GetOutputAsync()
+    public async Task<IRenderable> GetOutputAsync(CancellationToken cancellationToken = default)
     {
-        CompareLayersResult result = await GetCompareLayersResult();
+        CompareLayersResult result = await GetCompareLayersResult(cancellationToken);
         OutputFormatter formatter = OutputFormatter.Create(Options.OutputFormat);
         IRenderable output = formatter.GetOutput(result, Options);
         return output;
     }
 
-    private async Task<CompareLayersResult> GetCompareLayersResult()
+    private async Task<CompareLayersResult> GetCompareLayersResult(CancellationToken cancellationToken)
     {
-        IList<LayerInfo> baseLayers = await GetLayersAsync(Options.BaseImage);
-        IList<LayerInfo> targetLayers = await GetLayersAsync(Options.TargetImage);
+        IList<LayerInfo> baseLayers = await GetLayersAsync(Options.BaseImage, cancellationToken);
+        IList<LayerInfo> targetLayers = await GetLayersAsync(Options.TargetImage, cancellationToken);
         List<LayerComparison> layerComparisons = GetLayerComparisons(baseLayers, targetLayers);
         CompareLayersSummary summary = GetSummary(layerComparisons);
 
@@ -184,19 +184,21 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
             _ => throw new NotImplementedException()
         };
 
-    private async Task<IList<LayerInfo>> GetLayersAsync(string image)
+    private async Task<IList<LayerInfo>> GetLayersAsync(string image, CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(image);
         using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
+        IImageManifest manifest =
+            (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, cancellationToken)).Manifest;
 
         string? digest = (manifest.Config?.Digest) ?? throw new NotSupportedException($"Could not resolve the image config digest of '{image}'.");
-        ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, digest);
+        ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, digest, cancellationToken);
 
         List<LayerInfo> layerInfos = [];
         int layerIndex = 0;
         foreach (LayerHistory history in imageConfig.History)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (Options.IncludeHistory || !history.IsEmptyLayer)
             {
                 string? layerDigest = !history.IsEmptyLayer ? manifest.Layers[layerIndex].Digest : null;

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -33,24 +33,26 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         this.dockerRegistryClientFactory = dockerRegistryClientFactory;
     }
 
-    protected override async Task ExecuteAsync()
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        await CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        await CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
-            Markup markupOutput = new(await GetMarkupStringAsync());
+            Markup markupOutput = new(await GetMarkupStringAsync(ct));
             AnsiConsole.Write(markupOutput);
         });
     }
 
-    public async Task<string> GetMarkupStringAsync()
+    public async Task<string> GetMarkupStringAsync(CancellationToken cancellationToken = default)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
         using IDockerRegistryClient client = await dockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
+        IImageManifest manifest =
+            (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, cancellationToken)).Manifest;
 
         string? digest = (manifest.Config?.Digest) ?? throw new NotSupportedException($"Could not resolve the image config digest of '{Options.Image}'.");
-        ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, digest);
+        ImageConfig imageConfig =
+            await client.Blobs.GetImageAsync(imageName.Repo, digest, cancellationToken);
         bool isWindows = imageConfig.Os.Equals("windows", StringComparison.OrdinalIgnoreCase);
 
         StringBuilder dockerfileBuilder = new();
@@ -58,8 +60,9 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 
         if (isWindows)
         {
-            (WindowsOsInfo windowsOsInfo, string repo) = await GetWindowsInfoAsync(manifest, imageConfig);
-            layers = await GetWindowsLayersAsync(imageConfig, manifest, repo);
+            (WindowsOsInfo windowsOsInfo, string repo) =
+                await GetWindowsInfoAsync(manifest, imageConfig, cancellationToken);
+            layers = await GetWindowsLayersAsync(imageConfig, manifest, repo, cancellationToken);
             dockerfileBuilder.AppendLine($"FROM {RegistryHelper.McrRegistry}/{repo}:{windowsOsInfo.Version}-{imageConfig.Architecture}");
         }
         else
@@ -72,6 +75,7 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 
         foreach (LayerHistory layerHistory in layers)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrEmpty(layerHistory.CreatedBy))
             {
                 dockerfileBuilder.AppendLine("# No instruction info");
@@ -87,6 +91,7 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 
         foreach (DockerfileConstruct construct in fullDockerfile.Items)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             foreach (Token token in construct.Tokens)
             {
                 markup.Append(GetTokenMarkup(token, construct is RunInstruction));
@@ -96,7 +101,11 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         return markup.ToString();
     }
 
-    private async Task<IEnumerable<LayerHistory>> GetWindowsLayersAsync(ImageConfig imageConfig, IImageManifest manifest, string windowsRepo)
+    private async Task<IEnumerable<LayerHistory>> GetWindowsLayersAsync(
+        ImageConfig imageConfig,
+        IImageManifest manifest,
+        string windowsRepo,
+        CancellationToken cancellationToken)
     {
         using IDockerRegistryClient mcrClient =
             await dockerRegistryClientFactory.GetClientAsync(RegistryHelper.McrRegistry);
@@ -106,12 +115,13 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         int i;
         for (i = 0; i < manifest.Layers.Length; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             string? layerDigest = manifest.Layers[i].Digest;
             if (string.IsNullOrEmpty(layerDigest))
             {
                 throw new Exception($"No digest information defined for layer index {i} of the Windows image.");
             }
-            bool exists = await mcrClient.Blobs.ExistsAsync(windowsRepo, layerDigest);
+            bool exists = await mcrClient.Blobs.ExistsAsync(windowsRepo, layerDigest, cancellationToken);
             if (!exists)
             {
                 break;
@@ -121,7 +131,10 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         return imageConfig.History.Skip(i);
     }
 
-    private async Task<(WindowsOsInfo Info, string Repo)> GetWindowsInfoAsync(IImageManifest manifest, ImageConfig imageConfig)
+    private async Task<(WindowsOsInfo Info, string Repo)> GetWindowsInfoAsync(
+        IImageManifest manifest,
+        ImageConfig imageConfig,
+        CancellationToken cancellationToken)
     {
         string? initialLayerDigest = manifest.Layers.First().Digest;
         if (string.IsNullOrEmpty(initialLayerDigest))
@@ -129,7 +142,8 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
             throw new Exception("No digest information defined for the initial layer of the Windows image.");
         }
         var windowsOsInfo = await OsCommand.GetWindowsOsInfoAsync(
-            imageConfig, initialLayerDigest, dockerRegistryClientFactory) ?? throw new Exception("Could not determine info about the Windows image.");
+            imageConfig, initialLayerDigest, dockerRegistryClientFactory, cancellationToken) ??
+            throw new Exception("Could not determine info about the Windows image.");
         if (string.IsNullOrEmpty(windowsOsInfo.Info.Version))
         {
             throw new Exception("No os.version information defined for the Windows image.");

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -10,18 +10,19 @@ public class InspectCommand : RegistryCommandBase<InspectOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
+            IImageManifest manifest =
+                (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).Manifest;
             string? digest = (manifest.Config?.Digest) ??
                 throw new NotSupportedException($"Could not resolve the image config digest of '{Options.Image}'.");
-            Stream blob = await client.Blobs.GetAsync(imageName.Repo, digest);
+            Stream blob = await client.Blobs.GetAsync(imageName.Repo, digest, ct);
             using StreamReader reader = new(blob);
-            string content = await reader.ReadToEndAsync();
+            string content = await reader.ReadToEndAsync(ct);
             object? json = JsonConvert.DeserializeObject(content) ??
                 throw new Exception($"Unable to deserialize content into JSON:\n{content}");
             string output = JsonConvert.SerializeObject(json, JsonHelper.Settings);

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -18,16 +18,17 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
+            IImageManifest manifest =
+                (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).Manifest;
 
             string? configDigest = (manifest.Config?.Digest) ?? throw new NotSupportedException($"Could not resolve the image config digest of '{Options.Image}'.");
-            ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, configDigest);
+            ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, configDigest, ct);
 
             IDescriptor baseLayer = manifest.Layers.First();
             if (baseLayer.Digest is null)
@@ -38,12 +39,13 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
             object? osInfo;
             if (imageConfig.Os.Equals("windows", StringComparison.OrdinalIgnoreCase))
             {
-                var windowsOsInfo = await GetWindowsOsInfoAsync(imageConfig, baseLayer.Digest, DockerRegistryClientFactory);
+                var windowsOsInfo =
+                    await GetWindowsOsInfoAsync(imageConfig, baseLayer.Digest, DockerRegistryClientFactory, ct);
                 osInfo = windowsOsInfo?.Info;
             }
             else
             {
-                osInfo = await GetLinuxOsInfoAsync(client, imageName, baseLayer.Digest);
+                osInfo = await GetLinuxOsInfoAsync(client, imageName, baseLayer.Digest, ct);
             }
 
             if (osInfo is null)
@@ -56,9 +58,14 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
         });
     }
 
-    private static async Task<LinuxOsInfo?> GetLinuxOsInfoAsync(IDockerRegistryClient client, ImageName imageName, string baseLayerDigest)
+    private static async Task<LinuxOsInfo?> GetLinuxOsInfoAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        string baseLayerDigest,
+        CancellationToken cancellationToken)
     {
-        using Stream blobStream = await client.Blobs.GetAsync(imageName.Repo, baseLayerDigest);
+        using Stream blobStream =
+            await client.Blobs.GetAsync(imageName.Repo, baseLayerDigest, cancellationToken);
         using GZipStream gZipStream = new(blobStream, CompressionMode.Decompress);
 
         // Can't use System.Formats.Tar.TarReader because it fails to read certain types of tarballs:
@@ -68,6 +75,7 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
         TarEntry? entry = null;
         do
         {
+            cancellationToken.ThrowIfCancellationRequested();
             entry = tarStream.GetNextEntry();
 
             // Look for the os-release file (skip symlinks)
@@ -76,10 +84,10 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
                 (osReleaseRegex.IsMatch(entry.Name)))
             {
                 using MemoryStream memStream = new();
-                tarStream.CopyEntryContents(memStream);
+                await tarStream.CopyEntryContentsAsync(memStream, cancellationToken);
                 memStream.Position = 0;
                 using StreamReader reader = new(memStream);
-                string content = await reader.ReadToEndAsync();
+                string content = await reader.ReadToEndAsync(cancellationToken);
                 return LinuxOsInfo.Parse(content);
             }
         } while (entry is not null);
@@ -88,7 +96,7 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
     }
 
     internal static async Task<(WindowsOsInfo Info, string Repo)?> GetWindowsOsInfoAsync(ImageConfig imageConfig, string baseLayerDigest,
-        IDockerRegistryClientFactory dockerRegistryClientFactory)
+        IDockerRegistryClientFactory dockerRegistryClientFactory, CancellationToken cancellationToken)
     {
         const string NanoServerRepo = "windows/nanoserver";
         const string ServerCoreRepo = "windows/servercore";
@@ -98,19 +106,19 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
         using IDockerRegistryClient mcrClient =
             await dockerRegistryClientFactory.GetClientAsync(RegistryHelper.McrRegistry);
 
-        if (await mcrClient.Blobs.ExistsAsync(NanoServerRepo, baseLayerDigest))
+        if (await mcrClient.Blobs.ExistsAsync(NanoServerRepo, baseLayerDigest, cancellationToken))
         {
             return (new(WindowsType.NanoServer, imageConfig.OsVersion), NanoServerRepo);
         }
-        else if (await mcrClient.Blobs.ExistsAsync(ServerCoreRepo, baseLayerDigest))
+        else if (await mcrClient.Blobs.ExistsAsync(ServerCoreRepo, baseLayerDigest, cancellationToken))
         {
             return (new(WindowsType.ServerCore, imageConfig.OsVersion), ServerCoreRepo);
         }
-        else if (await mcrClient.Blobs.ExistsAsync(ServerRepo, baseLayerDigest))
+        else if (await mcrClient.Blobs.ExistsAsync(ServerRepo, baseLayerDigest, cancellationToken))
         {
             return (new(WindowsType.Server, imageConfig.OsVersion), ServerRepo);
         }
-        else if (await mcrClient.Blobs.ExistsAsync(WindowsRepo, baseLayerDigest))
+        else if (await mcrClient.Blobs.ExistsAsync(WindowsRepo, baseLayerDigest, cancellationToken))
         {
             return (new(WindowsType.Windows, imageConfig.OsVersion), WindowsRepo);
         }

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -9,13 +9,14 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
+            IImageManifest manifest =
+                (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).Manifest;
             string? digest = (manifest.Config?.Digest) ?? throw new NotSupportedException($"Could not resolve the image config digest of '{Options.Image}'.");
             await ImageHelper.SaveImageLayersToDiskAsync(
                 DockerRegistryClientFactory,
@@ -24,7 +25,8 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
                 Options.LayerIndex,
                 SaveLayersOptions.LayerIndexOptionName,
                 Options.NoSquash,
-                Options);
+                Options,
+                ct);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
@@ -9,14 +9,15 @@ public class DigestCommand : RegistryCommandBase<DigestOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
-            string digest = await client.Manifests.GetDigestAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+            string digest = await client.Manifests.GetDigestAsync(
+                imageName.Repo, (imageName.Tag ?? imageName.Digest)!, ct);
 
             Console.Out.WriteLine(digest);
         });

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
@@ -10,14 +10,15 @@ public class GetCommand : RegistryCommandBase<GetOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
-            ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+            ManifestInfo manifestInfo = await client.Manifests.GetAsync(
+                imageName.Repo, (imageName.Tag ?? imageName.Digest)!, ct);
 
             string output = JsonConvert.SerializeObject(manifestInfo.Manifest, JsonHelper.Settings);
 

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -9,13 +9,14 @@ public class ResolveCommand : RegistryCommandBase<SetOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-            ManifestInfo manifestInfo = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).ManifestInfo;
+            ManifestInfo manifestInfo =
+                (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).ManifestInfo;
             ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
 
             Console.Out.WriteLine(fullyQualifiedDigest.ToString());

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -12,10 +12,10 @@ public class ListCommand : RegistryCommandBase<ListOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
@@ -28,15 +28,17 @@ public class ListCommand : RegistryCommandBase<ListOptions>
             }
             else
             {
-                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, imageName.Tag!);
+                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, imageName.Tag!, ct);
                 digest = manifestInfo.DockerContentDigest;
             }
 
-            Page<OciImageIndex> indexPage = await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType);
+            Page<OciImageIndex> indexPage =
+                await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType, ct);
             initialIndex = indexPage.Value;
             while (indexPage.NextPageLink is not null)
             {
-                Page<OciImageIndex> nextPage = await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType);
+                Page<OciImageIndex> nextPage =
+                    await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType, ct);
                 initialIndex.Manifests =
                 [
                     .. initialIndex.Manifests,

--- a/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
@@ -11,19 +11,19 @@ public class ListCommand : RegistryCommandBase<ListOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return CommandHelper.ExecuteCommandAsync(Options.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(Options.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(Options.Registry);
 
             List<string> repoNames = [];
 
-            Page<Catalog> catalogPage = await client.Catalog.GetAsync();
+            Page<Catalog> catalogPage = await client.Catalog.GetAsync(null, ct);
             repoNames.AddRange(catalogPage.Value.RepositoryNames);
             while (catalogPage.NextPageLink is not null)
             {
-                catalogPage = await client.Catalog.GetNextAsync(catalogPage.NextPageLink);
+                catalogPage = await client.Catalog.GetNextAsync(catalogPage.NextPageLink, ct);
                 repoNames.AddRange(catalogPage.Value.RepositoryNames);
             }
 

--- a/src/Valleysoft.Dredge/Commands/Settings/ClearCacheCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/ClearCacheCommand.cs
@@ -7,18 +7,20 @@ public class ClearCacheCommand : Command
     public ClearCacheCommand()
         : base("clear-cache", "Deletes the cached files used by Dredge")
     {
-        this.SetAction(parseResult => ExecuteAsync());
+        this.SetAction((parseResult, cancellationToken) => ExecuteAsync(cancellationToken));
     }
 
-    private Task ExecuteAsync()
+    private Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return CommandHelper.ExecuteCommandAsync(null, () =>
+        return CommandHelper.ExecuteCommandAsync(null, cancellationToken, ct =>
         {
+            ct.ThrowIfCancellationRequested();
             DirectoryInfo dredgeTempDir = new(DredgeState.DredgeTempPath);
 
             if (dredgeTempDir.Exists)
             {
-                long dirSize = DirSize(dredgeTempDir);
+                long dirSize = DirSize(dredgeTempDir, ct);
+                ct.ThrowIfCancellationRequested();
                 dredgeTempDir.Delete(recursive: true);
 
                 Console.WriteLine($"{dirSize:n0} bytes deleted from '{DredgeState.DredgeTempPath}'");
@@ -32,19 +34,18 @@ public class ClearCacheCommand : Command
         });
     }
 
-    private static long DirSize(DirectoryInfo dir)
+    private static long DirSize(DirectoryInfo dir, CancellationToken cancellationToken)
     {
         long size = 0;
-        FileInfo[] files = dir.GetFiles();
-        foreach (FileInfo file in files)
+        foreach (FileInfo file in dir.EnumerateFiles())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             size += file.Length;
         }
 
-        DirectoryInfo[] subDirs = dir.GetDirectories();
-        foreach (DirectoryInfo subDir in subDirs)
+        foreach (DirectoryInfo subDir in dir.EnumerateDirectories())
         {
-            size += DirSize(subDir);
+            size += DirSize(subDir, cancellationToken);
         }
 
         return size;

--- a/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
@@ -9,8 +9,9 @@ internal partial class GetCommand : CommandWithOptions<GetOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         AppSettings settings = AppSettings.Load();
 
         Queue<string> names = new([..Options.Name.Split('.')]);

--- a/src/Valleysoft.Dredge/Commands/Settings/OpenCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/OpenCommand.cs
@@ -8,13 +8,14 @@ public class OpenCommand : Command
     public OpenCommand()
         : base("open", "Opens the Dredge settings file")
     {
-        this.SetAction(parseResult => ExecuteAsync());
+        this.SetAction((parseResult, cancellationToken) => ExecuteAsync(cancellationToken));
     }
 
-    private Task ExecuteAsync()
+    private Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return CommandHelper.ExecuteCommandAsync(null, () =>
+        return CommandHelper.ExecuteCommandAsync(null, cancellationToken, ct =>
         {
+            ct.ThrowIfCancellationRequested();
             // Ensure the settings are loaded which creates a default settings file if necessary
             AppSettings.Load();
 

--- a/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
@@ -7,8 +7,9 @@ internal partial class SetCommand : CommandWithOptions<SetOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         AppSettings settings = AppSettings.Load();
 
         Queue<string> names = new([..Options.Name.Split('.')]);

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -11,20 +11,21 @@ public class ListCommand : RegistryCommandBase<ListOptions>
     {
     }
 
-    protected override Task ExecuteAsync()
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         ImageName imageName = ImageName.Parse(Options.Repo);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return CommandHelper.ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
             List<string> tags = [];
 
-            Page<RepositoryTags> tagsPage = await client.Tags.GetAsync(imageName.Repo);
+            Page<RepositoryTags> tagsPage =
+                await client.Tags.GetAsync(imageName.Repo, null, ct);
             tags.AddRange(tagsPage.Value.Tags);
             while (tagsPage.NextPageLink is not null)
             {
-                tagsPage = await client.Tags.GetNextAsync(tagsPage.NextPageLink);
+                tagsPage = await client.Tags.GetNextAsync(tagsPage.NextPageLink, ct);
                 tags.AddRange(tagsPage.Value.Tags);
             }
 

--- a/src/Valleysoft.Dredge/FileHelper.cs
+++ b/src/Valleysoft.Dredge/FileHelper.cs
@@ -4,8 +4,12 @@ namespace Valleysoft.Dredge;
 
 internal static class FileHelper
 {
-    public static void CopyDirectory(string sourceDir, string destinationDir)
+    public static async Task CopyDirectoryAsync(
+        string sourceDir,
+        string destinationDir,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         DirectoryInfo dir = new(sourceDir);
         if (!dir.Exists)
         {
@@ -14,9 +18,9 @@ internal static class FileHelper
 
         Directory.CreateDirectory(destinationDir);
 
-        DirectoryInfo[] dirs = dir.GetDirectories();
-        foreach (FileInfo file in dir.GetFiles())
+        foreach (FileInfo file in dir.EnumerateFiles())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             string targetFilePath = Path.Combine(destinationDir, file.Name);
 
             if (file.LinkTarget is not null)
@@ -25,14 +29,52 @@ internal static class FileHelper
             }
             else
             {
-                file.CopyTo(targetFilePath);
+                await CopyFileAsync(file, targetFilePath, overwrite: false, cancellationToken);
             }
         }
         
-        foreach (DirectoryInfo subDir in dirs)
+        foreach (DirectoryInfo subDir in dir.EnumerateDirectories())
         {
             string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
-            CopyDirectory(subDir.FullName, newDestinationDir);
+            await CopyDirectoryAsync(subDir.FullName, newDestinationDir, cancellationToken);
+        }
+    }
+
+    public static async Task CopyFileAsync(
+        FileInfo sourceFile,
+        string destinationPath,
+        bool overwrite,
+        CancellationToken cancellationToken)
+    {
+        DateTime creationTimeUtc = sourceFile.CreationTimeUtc;
+        DateTime lastAccessTimeUtc = sourceFile.LastAccessTimeUtc;
+        DateTime lastWriteTimeUtc = sourceFile.LastWriteTimeUtc;
+        FileAttributes attributes = sourceFile.Attributes;
+        UnixFileMode unixFileMode = default;
+        if (!OperatingSystem.IsWindows())
+        {
+            unixFileMode = File.GetUnixFileMode(sourceFile.FullName);
+        }
+
+        await using (FileStream source = sourceFile.OpenRead())
+        await using (FileStream destination = new(
+            destinationPath,
+            overwrite ? FileMode.Create : FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.Asynchronous))
+        {
+            await source.CopyToAsync(destination, cancellationToken);
+        }
+
+        File.SetCreationTimeUtc(destinationPath, creationTimeUtc);
+        File.SetLastAccessTimeUtc(destinationPath, lastAccessTimeUtc);
+        File.SetLastWriteTimeUtc(destinationPath, lastWriteTimeUtc);
+        File.SetAttributes(destinationPath, attributes);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(destinationPath, unixFileMode);
         }
     }
 

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -18,7 +18,7 @@ internal static class ImageHelper
 
     public static async Task SaveImageLayersToDiskAsync(
         IDockerRegistryClientFactory dockerRegistryClientFactory, string image, string destPath, int? layerIndex,
-        string layerIndexOptionName, bool noSquash, PlatformOptionsBase options)
+        string layerIndexOptionName, bool noSquash, PlatformOptionsBase options, CancellationToken cancellationToken)
     {
         // Spec for OCI image layer filesystem changeset: https://github.com/opencontainers/image-spec/blob/main/layer.md
 
@@ -26,7 +26,8 @@ internal static class ImageHelper
 
         ImageName imageName = ImageName.Parse(image);
         IDockerRegistryClient client = await dockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-        IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, options)).Manifest;
+        IImageManifest manifest =
+            (await ManifestHelper.GetResolvedManifestAsync(client, imageName, options, cancellationToken)).Manifest;
 
         int startIndex = 0;
         int layerCount = manifest.Layers.Length;
@@ -46,6 +47,7 @@ internal static class ImageHelper
 
         for (int i = startIndex; i < layerCount; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             IDescriptor layer = manifest.Layers[i];
             if (string.IsNullOrEmpty(layer.Digest))
             {
@@ -63,23 +65,78 @@ internal static class ImageHelper
             else
             {
                 Console.Error.WriteLine($"\tDownloading layer...");
-                using Stream layerStream = await client.Blobs.GetAsync(imageName.Repo, layer.Digest);
+                using Stream layerStream =
+                    await client.Blobs.GetAsync(imageName.Repo, layer.Digest, cancellationToken);
 
-                await ExtractLayerAsync(layerStream, layerDir);
+                await ExtractLayerToCacheAsync(layerStream, layerDir, cancellationToken);
             }
 
             if (noSquash)
             {
-                FileHelper.CopyDirectory(layerDir, Path.Combine(destPath, $"layer{i}-{layerName}"));
+                await FileHelper.CopyDirectoryAsync(
+                    layerDir, Path.Combine(destPath, $"layer{i}-{layerName}"), cancellationToken);
             }
             else
             {
-                ApplyLayer(layerDir, destPath);
+                await ApplyLayerAsync(layerDir, destPath, cancellationToken);
             }
         }
     }
 
-    private static async Task ExtractLayerAsync(Stream layerStream, string layerDir)
+    private static async Task ExtractLayerToCacheAsync(
+        Stream layerStream,
+        string layerDir,
+        CancellationToken cancellationToken)
+    {
+        string tempLayerDir = $"{layerDir}.{Guid.NewGuid():N}.tmp";
+        bool cachePublished = false;
+        bool operationCompleted = false;
+
+        try
+        {
+            await ExtractLayerAsync(layerStream, tempLayerDir, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                Directory.Move(tempLayerDir, layerDir);
+                cachePublished = true;
+            }
+            catch (IOException) when (Directory.Exists(layerDir))
+            {
+                // Another process published the same layer while this one was extracting it.
+            }
+
+            operationCompleted = true;
+        }
+        finally
+        {
+            if (!cachePublished && Directory.Exists(tempLayerDir))
+            {
+                try
+                {
+                    Directory.Delete(tempLayerDir, recursive: true);
+                }
+                catch (IOException e) when (!operationCompleted)
+                {
+                    ReportCleanupFailure(tempLayerDir, e);
+                }
+                catch (UnauthorizedAccessException e) when (!operationCompleted)
+                {
+                    ReportCleanupFailure(tempLayerDir, e);
+                }
+            }
+        }
+    }
+
+    private static void ReportCleanupFailure(string tempLayerDir, Exception exception) =>
+        Console.Error.WriteLine(
+            $"Failed to delete incomplete layer cache directory '{tempLayerDir}': {exception.Message}");
+
+    private static async Task ExtractLayerAsync(
+        Stream layerStream,
+        string layerDir,
+        CancellationToken cancellationToken)
     {
         Console.Error.WriteLine($"\tExtracting layer...");
 
@@ -93,6 +150,7 @@ internal static class ImageHelper
 
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             TarEntry? entry = tarStream.GetNextEntry();
 
             if (entry is null)
@@ -125,18 +183,20 @@ internal static class ImageHelper
             }
 
             entryName = Path.Combine(entryDirName, entryFileName);
-            await ExtractTarEntry(layerDir, tarStream, entry, entryName);
+            await ExtractTarEntry(layerDir, tarStream, entry, entryName, cancellationToken);
         }
     }
 
-    private static void ApplyLayer(string layerDir, string workingDir)
+    private static async Task ApplyLayerAsync(
+        string layerDir,
+        string workingDir,
+        CancellationToken cancellationToken)
     {
         Console.Error.WriteLine($"\tApplying layer...");
 
-        FileInfo[] layerFiles = new DirectoryInfo(layerDir).GetFiles("*", SearchOption.AllDirectories);
-
-        foreach (FileInfo layerFile in layerFiles)
+        foreach (FileInfo layerFile in new DirectoryInfo(layerDir).EnumerateFiles("*", SearchOption.AllDirectories))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             string layerFileRelativePath = Path.GetRelativePath(layerDir, layerFile.FullName);
             string? layerfileDirName = Path.GetDirectoryName(layerFileRelativePath);
 
@@ -189,13 +249,18 @@ internal static class ImageHelper
                 }
                 else
                 {
-                    File.Copy(layerFile.FullName, dest, overwrite: true);
+                    await FileHelper.CopyFileAsync(layerFile, dest, overwrite: true, cancellationToken);
                 }
             }
         }
     }
 
-    private static async Task ExtractTarEntry(string workingDir, TarInputStream tarStream, TarEntry entry, string entryName)
+    private static async Task ExtractTarEntry(
+        string workingDir,
+        TarInputStream tarStream,
+        TarEntry entry,
+        string entryName,
+        CancellationToken cancellationToken)
     {
         string filePath = Path.Combine(workingDir, entryName);
         string? directoryPath = Path.GetDirectoryName(filePath);
@@ -217,7 +282,7 @@ internal static class ImageHelper
         else
         {
             using FileStream outputStream = File.Create(filePath);
-            await tarStream.CopyEntryContentsAsync(outputStream, CancellationToken.None);
+            await tarStream.CopyEntryContentsAsync(outputStream, cancellationToken);
         }
     }
 }

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -10,9 +10,13 @@ internal record ResolvedManifest(
 internal static class ManifestHelper
 {
     public static async Task<ResolvedManifest> GetResolvedManifestAsync(
-        IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options)
+        IDockerRegistryClient client,
+        ImageName imageName,
+        PlatformOptionsBase options,
+        CancellationToken cancellationToken)
     {
-        ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
+        ManifestInfo manifestInfo = await client.Manifests.GetAsync(
+            imageName.Repo, (imageName.Tag ?? imageName.Digest)!, cancellationToken);
         if (manifestInfo.Manifest is IManifestList manifestList)
         {
             AppSettings settings = AppSettings.Load();
@@ -41,7 +45,8 @@ internal static class ManifestHelper
                 throw new Exception($"Digest of resolved manifest is not set.");
             }
 
-            manifestInfo = await client.Manifests.GetAsync(imageName.Repo, manifestRef.Digest);
+            manifestInfo = await client.Manifests.GetAsync(
+                imageName.Repo, manifestRef.Digest, cancellationToken);
         }
 
         if (manifestInfo.Manifest is not IImageManifest manifest)

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Valleysoft.Dredge.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />


### PR DESCRIPTION
Dredge previously relied on process termination when Ctrl+C was pressed, so in-flight registry, stream, extraction, and filesystem work did not receive cancellation and could leave incomplete cached layers behind.

This change propagates System.CommandLine's cancellation token through every command and cancellable operation. Cancellation now unwinds normally without being formatted as a Dredge error. Layer extraction uses temporary directories with atomic cache publication, and cancellable file copies preserve timestamps, attributes, Unix modes, and existing overwrite behavior.

Regression tests cover command token propagation, cancellation error handling, file metadata, Unix permissions, and overwrite semantics.

Fixes: #187