### PR TITLE
Fix Windows base image detection after layer repacking

### DIFF
--- a/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/DockerfileCommandTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json;
 using Spectre.Console;
 using System.Text;
+using System.Text.Json;
 using Valleysoft.DockerRegistryClient.Models.Images;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
@@ -67,18 +67,25 @@ public class DockerfileCommandTests
             .ReturnsAsync(mcrClientMock.Object);
 
         ManifestLayer[] layers = [];
-        Image image = JsonConvert.DeserializeObject<Image>(File.ReadAllText(scenario.ImagePath))!;
+        string imageJson = File.ReadAllText(scenario.ImagePath);
+        Image image = JsonSerializer.Deserialize<Image>(imageJson)!;
         if (image.Os == "windows")
         {
+            image.RootFilesystem = new RootFilesystem
+            {
+                Type = "layers",
+                DiffIds = ["baseDiff0", "baseDiff1", "appDiff"]
+            };
+
             layers =
             [
                 new ManifestLayer
                 {
-                    Digest = "layer0digest"
+                    Digest = "repackedLayer0Digest"
                 },
                 new ManifestLayer
                 {
-                    Digest = "layer1digest"
+                    Digest = "repackedLayer1Digest"
                 }
             ];
 
@@ -87,9 +94,45 @@ public class DockerfileCommandTests
                 .ReturnsAsync(false);
 
             mcrClientMock
-                .Setup(o => o.Blobs.ExistsAsync(
-                    "windows/servercore", It.Is<string>(digest => digest == "layer0digest" || digest == "layer1digest"), It.IsAny<CancellationToken>()))
+                .Setup(o => o.Manifests.ExistsAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            string baseImageTag = $"{image.OsVersion}-{image.Architecture}";
+            mcrClientMock
+                .Setup(o => o.Manifests.ExistsAsync(
+                    "windows/servercore", baseImageTag, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
+
+            const string BaseConfigDigest = "baseConfigDigest";
+            mcrClientMock
+                .Setup(o => o.Manifests.GetAsync(
+                    "windows/servercore", baseImageTag, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ManifestInfo("media-type", "base-manifest-digest",
+                    new DockerManifest
+                    {
+                        Config = new ManifestConfig
+                        {
+                            Digest = BaseConfigDigest
+                        }
+                    }));
+
+            Image baseImage = new()
+            {
+                RootFilesystem = new RootFilesystem
+                {
+                    Type = "layers",
+                    DiffIds = ["baseDiff0", "baseDiff1"]
+                },
+                History = image.History.Take(2).ToArray()
+            };
+            mcrClientMock
+                .Setup(o => o.Blobs.GetAsync(
+                    "windows/servercore", BaseConfigDigest, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(
+                    JsonSerializer.Serialize(baseImage))));
+
+            imageJson = JsonSerializer.Serialize(image);
         }
 
         Mock<IDockerRegistryClient> registryClientMock = new();
@@ -107,7 +150,7 @@ public class DockerfileCommandTests
 
         registryClientMock
             .Setup(o => o.Blobs.GetAsync(RepoName, Digest, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(scenario.ImagePath))));
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(imageJson)));
 
         clientFactoryMock
             .Setup(o => o.GetClientAsync(Registry))

--- a/src/Valleysoft.Dredge.Tests/OsCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/OsCommandTests.cs
@@ -1,0 +1,164 @@
+namespace Valleysoft.Dredge.Tests;
+
+using System.Text;
+using System.Text.Json;
+using Valleysoft.DockerRegistryClient.Models.Images;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.Dredge.Commands.Image;
+
+public class OsCommandTests
+{
+    [Fact]
+    public async Task GetWindowsOsInfoAsyncUsesLongestDiffIdPrefixMatch()
+    {
+        const string OsVersion = "10.0.20348.1366";
+        const string Architecture = "amd64";
+        const string BaseImageTag = $"{OsVersion}-{Architecture}";
+
+        Image targetImage = new()
+        {
+            Os = "windows",
+            OsVersion = OsVersion,
+            Architecture = Architecture,
+            RootFilesystem = new RootFilesystem
+            {
+                Type = "layers",
+                DiffIds = ["baseDiff0", "baseDiff1", "appDiff"]
+            }
+        };
+        DockerManifest targetManifest = new()
+        {
+            Layers =
+            [
+                new ManifestLayer
+                {
+                    Digest = "repackedLayerDigest"
+                }
+            ]
+        };
+
+        Mock<IDockerRegistryClientFactory> clientFactoryMock = new();
+        Mock<IDockerRegistryClient> mcrClientMock = new();
+        clientFactoryMock
+            .Setup(o => o.GetClientAsync(RegistryHelper.McrRegistry))
+            .ReturnsAsync(mcrClientMock.Object);
+        mcrClientMock
+            .Setup(o => o.Blobs.ExistsAsync(
+                It.IsAny<string>(), "repackedLayerDigest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        mcrClientMock
+            .Setup(o => o.Manifests.ExistsAsync(
+                It.IsAny<string>(), BaseImageTag, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        SetupBaseImage(
+            mcrClientMock,
+            "windows/nanoserver",
+            BaseImageTag,
+            "nanoConfig",
+            ["baseDiff0"],
+            historyCount: 1);
+        SetupBaseImage(
+            mcrClientMock,
+            "windows/servercore",
+            BaseImageTag,
+            "serverCoreConfig",
+            ["baseDiff0", "baseDiff1"],
+            historyCount: 2);
+
+        WindowsImageInfo? result = await OsCommand.GetWindowsOsInfoAsync(
+            targetImage, targetManifest, clientFactoryMock.Object);
+
+        Assert.NotNull(result);
+        Assert.Equal(WindowsType.ServerCore, result.Info.Type);
+        Assert.Equal(OsVersion, result.Info.Version);
+        Assert.Equal("windows/servercore", result.Repo);
+        Assert.Equal(2, result.BaseHistoryCount);
+        mcrClientMock.Verify(o => o.Manifests.ExistsAsync(
+            "windows/servercore", BaseImageTag, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetWindowsOsInfoAsyncRetainsLegacyDigestDetection()
+    {
+        Image targetImage = new()
+        {
+            Os = "windows",
+            OsVersion = "10.0.17763.1",
+            Architecture = "amd64"
+        };
+        DockerManifest targetManifest = new()
+        {
+            Layers =
+            [
+                new ManifestLayer { Digest = "baseLayer0" },
+                new ManifestLayer { Digest = "baseLayer1" },
+                new ManifestLayer { Digest = "appLayer" }
+            ]
+        };
+
+        Mock<IDockerRegistryClientFactory> clientFactoryMock = new();
+        Mock<IDockerRegistryClient> mcrClientMock = new();
+        clientFactoryMock
+            .Setup(o => o.GetClientAsync(RegistryHelper.McrRegistry))
+            .ReturnsAsync(mcrClientMock.Object);
+        mcrClientMock
+            .Setup(o => o.Blobs.ExistsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        mcrClientMock
+            .Setup(o => o.Blobs.ExistsAsync(
+                "windows/servercore",
+                It.Is<string>(digest => digest == "baseLayer0" || digest == "baseLayer1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        WindowsImageInfo? result = await OsCommand.GetWindowsOsInfoAsync(
+            targetImage, targetManifest, clientFactoryMock.Object);
+
+        Assert.NotNull(result);
+        Assert.Equal(WindowsType.ServerCore, result.Info.Type);
+        Assert.Equal(2, result.BaseHistoryCount);
+        mcrClientMock.Verify(o => o.Manifests.ExistsAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static void SetupBaseImage(
+        Mock<IDockerRegistryClient> mcrClientMock,
+        string repo,
+        string tag,
+        string configDigest,
+        string[] diffIds,
+        int historyCount)
+    {
+        mcrClientMock
+            .Setup(o => o.Manifests.ExistsAsync(repo, tag, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        mcrClientMock
+            .Setup(o => o.Manifests.GetAsync(repo, tag, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("media-type", "manifest-digest",
+                new DockerManifest
+                {
+                    Config = new ManifestConfig
+                    {
+                        Digest = configDigest
+                    }
+                }));
+
+        Image baseImage = new()
+        {
+            RootFilesystem = new RootFilesystem
+            {
+                Type = "layers",
+                DiffIds = diffIds
+            },
+            History = Enumerable.Range(0, historyCount)
+                .Select(index => new LayerHistory { CreatedBy = $"base instruction {index}" })
+                .ToArray()
+        };
+        mcrClientMock
+            .Setup(o => o.Blobs.GetAsync(repo, configDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(baseImage))));
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -51,9 +51,10 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
 
         if (isWindows)
         {
-            (WindowsOsInfo windowsOsInfo, string repo) = await GetWindowsInfoAsync(manifest, imageConfig);
-            layers = await GetWindowsLayersAsync(imageConfig, manifest, repo);
-            dockerfileLines.Add($"FROM {RegistryHelper.McrRegistry}/{repo}:{windowsOsInfo.Version}-{imageConfig.Architecture}");
+            WindowsImageInfo windowsImageInfo = await GetWindowsInfoAsync(manifest, imageConfig);
+            layers = imageConfig.History.Skip(windowsImageInfo.BaseHistoryCount);
+            dockerfileLines.Add(
+                $"FROM {RegistryHelper.McrRegistry}/{windowsImageInfo.Repo}:{windowsImageInfo.Info.Version}-{imageConfig.Architecture}");
         }
         else
         {
@@ -127,46 +128,16 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
             string.Concat(dockerfile.Items.SelectMany(construct => construct.Tokens)),
             StringComparison.Ordinal);
 
-    private async Task<IEnumerable<LayerHistory>> GetWindowsLayersAsync(ImageConfig imageConfig, IImageManifest manifest, string windowsRepo)
+    private async Task<WindowsImageInfo> GetWindowsInfoAsync(IImageManifest manifest, ImageConfig imageConfig)
     {
-        using IDockerRegistryClient mcrClient =
-            await dockerRegistryClientFactory.GetClientAsync(RegistryHelper.McrRegistry);
-
-        // For Windows images, the layers that we want to generate a Dockerfile from start after the initial set of base
-        // Windows layers. There is no "FROM scratch" possible with Windows images.
-        int i;
-        for (i = 0; i < manifest.Layers.Length; i++)
-        {
-            string? layerDigest = manifest.Layers[i].Digest;
-            if (string.IsNullOrEmpty(layerDigest))
-            {
-                throw new Exception($"No digest information defined for layer index {i} of the Windows image.");
-            }
-            bool exists = await mcrClient.Blobs.ExistsAsync(windowsRepo, layerDigest);
-            if (!exists)
-            {
-                break;
-            }
-        }
-
-        return imageConfig.History.Skip(i);
-    }
-
-    private async Task<(WindowsOsInfo Info, string Repo)> GetWindowsInfoAsync(IImageManifest manifest, ImageConfig imageConfig)
-    {
-        string? initialLayerDigest = manifest.Layers.First().Digest;
-        if (string.IsNullOrEmpty(initialLayerDigest))
-        {
-            throw new Exception("No digest information defined for the initial layer of the Windows image.");
-        }
-        var windowsOsInfo = await OsCommand.GetWindowsOsInfoAsync(
-            imageConfig, initialLayerDigest, dockerRegistryClientFactory) ?? throw new Exception("Could not determine info about the Windows image.");
+        WindowsImageInfo windowsOsInfo = await OsCommand.GetWindowsOsInfoAsync(
+            imageConfig, manifest, dockerRegistryClientFactory) ?? throw new Exception("Could not determine info about the Windows image.");
         if (string.IsNullOrEmpty(windowsOsInfo.Info.Version))
         {
             throw new Exception("No os.version information defined for the Windows image.");
         }
 
-        return (windowsOsInfo.Info, windowsOsInfo.Repo);
+        return windowsOsInfo;
     }
 
     private string GetHistoryLine(string line, ref string? currentShell)

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -11,6 +11,14 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public partial class OsCommand : RegistryCommandBase<OsOptions>
 {
+    private static readonly WindowsImageDefinition[] windowsImageDefinitions =
+    [
+        new(WindowsType.NanoServer, "windows/nanoserver"),
+        new(WindowsType.ServerCore, "windows/servercore"),
+        new(WindowsType.Server, "windows/server"),
+        new(WindowsType.Windows, "windows")
+    ];
+
     private static readonly Regex osReleaseRegex = OsReleaseRegex();
 
     public OsCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
@@ -29,20 +37,20 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
             string? configDigest = (manifest.Config?.Digest) ?? throw new NotSupportedException($"Could not resolve the image config digest of '{Options.Image}'.");
             ImageConfig imageConfig = await client.Blobs.GetImageAsync(imageName.Repo, configDigest);
 
-            IDescriptor baseLayer = manifest.Layers.First();
-            if (baseLayer.Digest is null)
-            {
-                throw new Exception($"No digest was found for the base layer of '{Options.Image}'.");
-            }
-
             object? osInfo;
             if (imageConfig.Os.Equals("windows", StringComparison.OrdinalIgnoreCase))
             {
-                var windowsOsInfo = await GetWindowsOsInfoAsync(imageConfig, baseLayer.Digest, DockerRegistryClientFactory);
+                var windowsOsInfo = await GetWindowsOsInfoAsync(imageConfig, manifest, DockerRegistryClientFactory);
                 osInfo = windowsOsInfo?.Info;
             }
             else
             {
+                IDescriptor baseLayer = manifest.Layers.First();
+                if (baseLayer.Digest is null)
+                {
+                    throw new Exception($"No digest was found for the base layer of '{Options.Image}'.");
+                }
+
                 osInfo = await GetLinuxOsInfoAsync(client, imageName, baseLayer.Digest);
             }
 
@@ -87,39 +95,99 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
         return null;
     }
 
-    internal static async Task<(WindowsOsInfo Info, string Repo)?> GetWindowsOsInfoAsync(ImageConfig imageConfig, string baseLayerDigest,
+    internal static async Task<WindowsImageInfo?> GetWindowsOsInfoAsync(ImageConfig imageConfig, IImageManifest manifest,
         IDockerRegistryClientFactory dockerRegistryClientFactory)
     {
-        const string NanoServerRepo = "windows/nanoserver";
-        const string ServerCoreRepo = "windows/servercore";
-        const string ServerRepo = "windows/server";
-        const string WindowsRepo = "windows";
+        string? baseLayerDigest = manifest.Layers.FirstOrDefault()?.Digest;
+        if (string.IsNullOrEmpty(baseLayerDigest))
+        {
+            throw new Exception("No digest was found for the base layer of the Windows image.");
+        }
 
         using IDockerRegistryClient mcrClient =
             await dockerRegistryClientFactory.GetClientAsync(RegistryHelper.McrRegistry);
 
-        if (await mcrClient.Blobs.ExistsAsync(NanoServerRepo, baseLayerDigest))
+        foreach (WindowsImageDefinition definition in windowsImageDefinitions)
         {
-            return (new(WindowsType.NanoServer, imageConfig.OsVersion), NanoServerRepo);
+            if (await mcrClient.Blobs.ExistsAsync(definition.Repo, baseLayerDigest))
+            {
+                int baseHistoryCount = await GetLegacyBaseHistoryCountAsync(mcrClient, definition.Repo, manifest);
+                return new(new(definition.Type, imageConfig.OsVersion), definition.Repo, baseHistoryCount);
+            }
         }
-        else if (await mcrClient.Blobs.ExistsAsync(ServerCoreRepo, baseLayerDigest))
-        {
-            return (new(WindowsType.ServerCore, imageConfig.OsVersion), ServerCoreRepo);
-        }
-        else if (await mcrClient.Blobs.ExistsAsync(ServerRepo, baseLayerDigest))
-        {
-            return (new(WindowsType.Server, imageConfig.OsVersion), ServerRepo);
-        }
-        else if (await mcrClient.Blobs.ExistsAsync(WindowsRepo, baseLayerDigest))
-        {
-            return (new(WindowsType.Windows, imageConfig.OsVersion), WindowsRepo);
-        }
-        else
+
+        if (string.IsNullOrEmpty(imageConfig.OsVersion) ||
+            string.IsNullOrEmpty(imageConfig.Architecture) ||
+            imageConfig.RootFilesystem?.DiffIds is not { Length: > 0 } targetDiffIds)
         {
             return null;
         }
+
+        string baseImageTag = $"{imageConfig.OsVersion}-{imageConfig.Architecture}";
+        WindowsImageInfo? bestMatch = null;
+        int bestMatchLayerCount = 0;
+
+        foreach (WindowsImageDefinition definition in windowsImageDefinitions)
+        {
+            if (!await mcrClient.Manifests.ExistsAsync(definition.Repo, baseImageTag))
+            {
+                continue;
+            }
+
+            ManifestInfo manifestInfo = await mcrClient.Manifests.GetAsync(definition.Repo, baseImageTag);
+            if (manifestInfo.Manifest is not IImageManifest baseManifest ||
+                string.IsNullOrEmpty(baseManifest.Config?.Digest))
+            {
+                continue;
+            }
+
+            ImageConfig baseImageConfig =
+                await mcrClient.Blobs.GetImageAsync(definition.Repo, baseManifest.Config.Digest);
+            string[]? baseDiffIds = baseImageConfig.RootFilesystem?.DiffIds;
+            if (baseDiffIds is not { Length: > 0 } ||
+                baseDiffIds.Length > targetDiffIds.Length ||
+                !baseDiffIds.SequenceEqual(targetDiffIds.Take(baseDiffIds.Length)) ||
+                baseDiffIds.Length <= bestMatchLayerCount)
+            {
+                continue;
+            }
+
+            bestMatchLayerCount = baseDiffIds.Length;
+            bestMatch = new(
+                new(definition.Type, imageConfig.OsVersion),
+                definition.Repo,
+                baseImageConfig.History.Length);
+        }
+
+        return bestMatch;
+    }
+
+    private static async Task<int> GetLegacyBaseHistoryCountAsync(
+        IDockerRegistryClient mcrClient, string repo, IImageManifest manifest)
+    {
+        int baseLayerCount = 0;
+        foreach (IDescriptor layer in manifest.Layers)
+        {
+            if (string.IsNullOrEmpty(layer.Digest))
+            {
+                throw new Exception($"No digest information defined for layer index {baseLayerCount} of the Windows image.");
+            }
+
+            if (!await mcrClient.Blobs.ExistsAsync(repo, layer.Digest))
+            {
+                break;
+            }
+
+            baseLayerCount++;
+        }
+
+        return baseLayerCount;
     }
 
     [GeneratedRegex(@"(\./)?(etc|usr/lib)/os-release")]
     private static partial Regex OsReleaseRegex();
+
+    private record WindowsImageDefinition(WindowsType Type, string Repo);
 }
+
+internal record WindowsImageInfo(WindowsOsInfo Info, string Repo, int BaseHistoryCount);

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Valleysoft.Dredge.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Spectre.Console" Version="0.57.2" />


### PR DESCRIPTION
Windows base-image detection relied on compressed layer digests remaining identical across registries. Recent Windows images can be repacked when pushed, changing those digests and causing `image os` and `image dockerfile` to fail.

This change preserves the existing digest lookup for legacy images, then falls back to matching the target image's stable uncompressed `rootfs.diff_ids` against exact-version Windows base images in MCR. The shared match also provides the base history length so Dockerfile reconstruction omits the correct base instructions.

Regression tests cover both repacked-layer fallback detection and the legacy digest path.

Fixes: #92