### PR TITLE
Expand test coverage and harden OCI layer handling

### DIFF
--- a/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
+++ b/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
@@ -1,0 +1,34 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+public class AppSettingsTests
+{
+    [Fact]
+    public void GeneratedPropertyAccessors_SetAndGetNestedValues()
+    {
+        AppSettings settings = CreateSettings();
+
+        settings.SetProperty(new Queue<string>(["platform", "arch"]), "arm64");
+        settings.SetProperty(new Queue<string>(["fileCompareTool", "exePath"]), "compare.exe");
+
+        Assert.Equal("arm64", settings.GetProperty(new Queue<string>(["platform", "arch"])));
+        Assert.Equal("compare.exe", settings.GetProperty(new Queue<string>(["fileCompareTool", "exePath"])));
+    }
+
+    [Theory]
+    [InlineData()]
+    [InlineData("unknown")]
+    [InlineData("platform", "unknown")]
+    [InlineData("platform", "arch", "extra")]
+    public void GeneratedPropertyAccessors_WhenPathIsInvalid_Throw(params string[] path)
+    {
+        AppSettings settings = CreateSettings();
+
+        Assert.Throws<ArgumentException>(
+            () => settings.GetProperty(new Queue<string>(path)));
+        Assert.Throws<ArgumentException>(
+            () => settings.SetProperty(new Queue<string>(path), "value"));
+    }
+
+    private static AppSettings CreateSettings() =>
+        (AppSettings)Activator.CreateInstance(typeof(AppSettings), nonPublic: true)!;
+}

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -1,0 +1,100 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Valleysoft.Dredge.Commands;
+using Valleysoft.Dredge.Commands.Image;
+using Valleysoft.Dredge.Commands.Manifest;
+using Valleysoft.Dredge.Commands.Referrer;
+using Valleysoft.Dredge.Commands.Repo;
+using Valleysoft.Dredge.Commands.Settings;
+using Valleysoft.Dredge.Commands.Tag;
+
+public class CommandStructureTests
+{
+    [Fact]
+    public void TopLevelCommands_RegisterExpectedSubcommands()
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+
+        Assert.Equal(
+            ["compare", "inspect", "os", "save-layers", "dockerfile"],
+            new ImageCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(
+            ["get", "digest", "resolve"],
+            new ManifestCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(["list"], new ReferrerCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(["list"], new RepoCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(["list"], new TagCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(
+            ["open", "get", "set", "clear-cache"],
+            new SettingsCommand().Subcommands.Select(command => command.Name));
+    }
+
+    [Fact]
+    public void SaveLayersOptions_BindAllArgumentsAndOptions()
+    {
+        SaveLayersOptions options = Bind(
+            new SaveLayersOptions(),
+            "image:tag",
+            "output",
+            "--no-squash",
+            "--layer-index",
+            "3",
+            "--os",
+            "linux",
+            "--os-version",
+            "1",
+            "--arch",
+            "arm64");
+
+        Assert.Equal("image:tag", options.Image);
+        Assert.Equal("output", options.OutputPath);
+        Assert.True(options.NoSquash);
+        Assert.Equal(3, options.LayerIndex);
+        Assert.Equal("linux", options.Os);
+        Assert.Equal("1", options.OsVersion);
+        Assert.Equal("arm64", options.Architecture);
+    }
+
+    [Fact]
+    public void CompareFilesOptions_BindComparisonSettings()
+    {
+        CompareFilesOptions options = Bind(
+            new CompareFilesOptions(),
+            "base",
+            "target",
+            "--base-layer-index",
+            "1",
+            "--target-layer-index",
+            "2");
+
+        Assert.Equal("base", options.BaseImage);
+        Assert.Equal("target", options.TargetImage);
+        Assert.Equal(1, options.BaseLayerIndex);
+        Assert.Equal(2, options.TargetLayerIndex);
+        Assert.Equal(CompareFilesOutput.ExternalTool, options.OutputType);
+    }
+
+    [Fact]
+    public void CompareLayersOptions_UseExpectedDefaults()
+    {
+        CompareLayersOptions options = Bind(new CompareLayersOptions(), "base", "target");
+
+        Assert.Equal(CompareLayersOutput.SideBySide, options.OutputFormat);
+        Assert.False(options.IsColorDisabled);
+        Assert.False(options.IncludeHistory);
+        Assert.False(options.IncludeCompressedSize);
+    }
+
+    private static TOptions Bind<TOptions>(TOptions options, params string[] args)
+        where TOptions : OptionsBase
+    {
+        Command command = new("test");
+        options.SetCommandOptions(command);
+        ParseResult parseResult = command.Parse(args);
+        Assert.Empty(parseResult.Errors);
+        options.SetParseResult(parseResult);
+        return options;
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/DockerRegistryClientFactoryTests.cs
+++ b/src/Valleysoft.Dredge.Tests/DockerRegistryClientFactoryTests.cs
@@ -1,0 +1,62 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+public class DockerRegistryClientFactoryTests
+{
+    [Fact]
+    public async Task GetClientAsync_WithTokenEnvironmentVariable_CreatesUsableClient()
+    {
+        DictionaryEnvironmentVariableProvider environmentVariableProvider = new(
+            new Dictionary<string, string>
+            {
+                ["DREDGE_TOKEN"] = "test-token"
+            });
+        DockerRegistryClientFactory factory = new(environmentVariableProvider);
+
+        using IDockerRegistryClient client = await factory.GetClientAsync("registry.example");
+
+        Assert.IsType<DockerRegistryClientWrapper>(client);
+        Assert.NotNull(client.Blobs);
+        Assert.NotNull(client.Catalog);
+        Assert.NotNull(client.Manifests);
+        Assert.NotNull(client.Tags);
+        Assert.NotNull(client.Referrers);
+        Assert.Equal(["DREDGE_TOKEN"], environmentVariableProvider.RequestedVariables);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_WithUsernameAndPassword_QueriesCredentialsInPriorityOrder()
+    {
+        DictionaryEnvironmentVariableProvider environmentVariableProvider = new(
+            new Dictionary<string, string>
+            {
+                ["DREDGE_USERNAME"] = "user",
+                ["DREDGE_PASSWORD"] = "password"
+            });
+        DockerRegistryClientFactory factory = new(environmentVariableProvider);
+
+        using IDockerRegistryClient client = await factory.GetClientAsync("registry.example");
+
+        Assert.IsType<DockerRegistryClientWrapper>(client);
+        Assert.Equal(
+            ["DREDGE_TOKEN", "DREDGE_USERNAME", "DREDGE_PASSWORD"],
+            environmentVariableProvider.RequestedVariables);
+    }
+
+    private sealed class DictionaryEnvironmentVariableProvider : IEnvironmentVariableProvider
+    {
+        private readonly IReadOnlyDictionary<string, string> variables;
+
+        public DictionaryEnvironmentVariableProvider(IReadOnlyDictionary<string, string> variables)
+        {
+            this.variables = variables;
+        }
+
+        public List<string> RequestedVariables { get; } = [];
+
+        public string? GetVariable(string name)
+        {
+            RequestedVariables.Add(name);
+            return variables.GetValueOrDefault(name);
+        }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/FileHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/FileHelperTests.cs
@@ -1,0 +1,38 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+public class FileHelperTests
+{
+    [Fact]
+    public void CopyDirectory_CopiesNestedFiles()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"dredge-tests-{Guid.NewGuid():N}");
+        string source = Path.Combine(root, "source");
+        string destination = Path.Combine(root, "destination");
+        Directory.CreateDirectory(Path.Combine(source, "nested"));
+        File.WriteAllText(Path.Combine(source, "root.txt"), "root");
+        File.WriteAllText(Path.Combine(source, "nested", "child.txt"), "child");
+
+        try
+        {
+            FileHelper.CopyDirectory(source, destination);
+
+            Assert.Equal("root", File.ReadAllText(Path.Combine(destination, "root.txt")));
+            Assert.Equal("child", File.ReadAllText(Path.Combine(destination, "nested", "child.txt")));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyDirectory_WhenSourceDoesNotExist_Throws()
+    {
+        string source = Path.Combine(Path.GetTempPath(), $"dredge-missing-{Guid.NewGuid():N}");
+
+        DirectoryNotFoundException exception = Assert.Throws<DirectoryNotFoundException>(
+            () => FileHelper.CopyDirectory(source, Path.Combine(source, "destination")));
+
+        Assert.Contains(Path.GetFullPath(source), exception.Message);
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
@@ -1,0 +1,393 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.Dredge.Commands;
+
+public class ImageHelperTests
+{
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_AppliesLayersAndWhiteouts()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string firstDigest = $"sha256:{id}-first";
+        string secondDigest = $"sha256:{id}-second";
+        string output = Path.Combine(Path.GetTempPath(), $"dredge-output-{id}");
+        string layerCache = Path.Combine(DredgeState.DredgeTempPath, "layers");
+        string firstCache = Path.Combine(layerCache, $"{id}-first");
+        string secondCache = Path.Combine(layerCache, $"{id}-second");
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Layers =
+                    [
+                        new ManifestLayer { Digest = firstDigest },
+                        new ManifestLayer { Digest = secondDigest }
+                    ]
+                }));
+        client
+            .Setup(o => o.Blobs.GetAsync("library/image", firstDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => CreateLayer(
+                ("keep.txt", "old"),
+                ("delete.txt", "delete"),
+                ("colon:name.txt", "delete"),
+                ("nested/delete.txt", "nested delete"),
+                ("removed/child.txt", "removed"),
+                ("opaque/old.txt", "old")));
+        client
+            .Setup(o => o.Blobs.GetAsync("library/image", secondDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => CreateLayer(
+                ("keep.txt", "new"),
+                (".wh.delete.txt", string.Empty),
+                (".wh.colon:name.txt", string.Empty),
+                ("nested/.wh.delete.txt", string.Empty),
+                (".wh.removed", string.Empty),
+                ("opaque/!new.txt", "new"),
+                ("opaque/.wh..wh..opq", string.Empty),
+                ("nested/added.txt", "added")));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            await ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                output,
+                layerIndex: null,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase());
+
+            string colonFileName = OperatingSystem.IsWindows() ? "colon-name.txt" : "colon:name.txt";
+            Assert.Equal("new", File.ReadAllText(Path.Combine(output, "keep.txt")));
+            Assert.False(File.Exists(Path.Combine(output, "delete.txt")));
+            Assert.False(File.Exists(Path.Combine(output, colonFileName)));
+            Assert.False(File.Exists(Path.Combine(output, "nested", "delete.txt")));
+            Assert.False(Directory.Exists(Path.Combine(output, "removed")));
+            Assert.False(File.Exists(Path.Combine(output, "opaque", "old.txt")));
+            Assert.Equal("new", File.ReadAllText(Path.Combine(output, "opaque", "!new.txt")));
+            Assert.Equal("added", File.ReadAllText(Path.Combine(output, "nested", "added.txt")));
+        }
+        finally
+        {
+            if (Directory.Exists(output))
+            {
+                Directory.Delete(output, recursive: true);
+            }
+            if (Directory.Exists(firstCache))
+            {
+                Directory.Delete(firstCache, recursive: true);
+            }
+            if (Directory.Exists(secondCache))
+            {
+                Directory.Delete(secondCache, recursive: true);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public async Task SaveImageLayersToDiskAsync_WhenLayerIndexIsOutOfRange_Throws(int layerIndex)
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Layers =
+                    [
+                        new ManifestLayer { Digest = "sha256:one" },
+                        new ManifestLayer { Digest = "sha256:two" }
+                    ]
+                }));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        Exception exception = await Assert.ThrowsAsync<Exception>(
+            () => ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                "output",
+                layerIndex,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase()));
+
+        Assert.Equal("Value is out of range for the '--layer-index' option.", exception.Message);
+        client.Verify(
+            o => o.Blobs.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenDigestEncodedPortionContainsColon_Throws()
+    {
+        const string Digest = "sha256:C:escape";
+        Mock<IDockerRegistryClient> client = CreateSingleLayerClient(
+            Digest,
+            () => CreateLayer(("file.txt", "content")));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                "output",
+                layerIndex: null,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase()));
+
+        Assert.Equal("Invalid layer digest 'C:escape'.", exception.Message);
+        client.Verify(
+            o => o.Blobs.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenEntryEscapesLayerDirectory_Throws()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string escapedPath = Path.Combine(DredgeState.DredgeTempPath, "layers", $"escaped-{id}.txt");
+        string layerCache = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Layers = [new ManifestLayer { Digest = digest }]
+                }));
+        client
+            .Setup(o => o.Blobs.GetAsync("library/image", digest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => CreateLayer(($"../escaped-{id}.txt", "escaped")));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => ImageHelper.SaveImageLayersToDiskAsync(
+                    factory.Object,
+                    "image",
+                    Path.Combine(Path.GetTempPath(), $"dredge-output-{id}"),
+                    layerIndex: null,
+                    "--layer-index",
+                    noSquash: false,
+                    new PlatformOptionsBase()));
+
+            Assert.Contains($"escaped-{id}.txt", exception.Message);
+            Assert.False(File.Exists(escapedPath));
+        }
+        finally
+        {
+            if (Directory.Exists(layerCache))
+            {
+                Directory.Delete(layerCache, recursive: true);
+            }
+            if (File.Exists(escapedPath))
+            {
+                File.Delete(escapedPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenLinkTargetEscapesLayerDirectory_Throws()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string layerCache = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        Mock<IDockerRegistryClient> client = CreateSingleLayerClient(
+            digest,
+            () => CreateSymbolicLinkLayer("link", "../outside"));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            await Assert.ThrowsAsync<InvalidDataException>(
+                () => ImageHelper.SaveImageLayersToDiskAsync(
+                    factory.Object,
+                    "image",
+                    Path.Combine(Path.GetTempPath(), $"dredge-output-{id}"),
+                    layerIndex: null,
+                    "--layer-index",
+                    noSquash: false,
+                    new PlatformOptionsBase()));
+        }
+        finally
+        {
+            if (Directory.Exists(layerCache))
+            {
+                Directory.Delete(layerCache, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenSymlinkChainEscapesLayerDirectory_Throws()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string layerCache = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        string escapedPath = Path.Combine(DredgeState.DredgeTempPath, "layers", $"escaped-{id}.txt");
+        Mock<IDockerRegistryClient> client = CreateSingleLayerClient(
+            digest,
+            () => CreateSymlinkChainLayer(id));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            await Assert.ThrowsAsync<InvalidDataException>(
+                () => ImageHelper.SaveImageLayersToDiskAsync(
+                    factory.Object,
+                    "image",
+                    Path.Combine(Path.GetTempPath(), $"dredge-output-{id}"),
+                    layerIndex: null,
+                    "--layer-index",
+                    noSquash: false,
+                    new PlatformOptionsBase()));
+
+            Assert.False(File.Exists(escapedPath));
+        }
+        finally
+        {
+            if (Directory.Exists(layerCache))
+            {
+                Directory.Delete(layerCache, recursive: true);
+            }
+            if (File.Exists(escapedPath))
+            {
+                File.Delete(escapedPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(".wh..")]
+    [InlineData(".wh...")]
+    public async Task SaveImageLayersToDiskAsync_WhenWhiteoutTargetIsSpecialPath_Throws(string whiteoutName)
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string layerCache = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        Mock<IDockerRegistryClient> client = CreateSingleLayerClient(
+            digest,
+            () => CreateLayer((whiteoutName, string.Empty)));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+                () => ImageHelper.SaveImageLayersToDiskAsync(
+                    factory.Object,
+                    "image",
+                    Path.Combine(Path.GetTempPath(), $"dredge-output-{id}"),
+                    layerIndex: null,
+                    "--layer-index",
+                    noSquash: false,
+                    new PlatformOptionsBase()));
+
+            Assert.Contains("Invalid whiteout target", exception.Message);
+        }
+        finally
+        {
+            if (Directory.Exists(layerCache))
+            {
+                Directory.Delete(layerCache, recursive: true);
+            }
+        }
+    }
+
+    private static Mock<IDockerRegistryClient> CreateSingleLayerClient(
+        string digest,
+        Func<Stream> createLayer)
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Layers = [new ManifestLayer { Digest = digest }]
+                }));
+        client
+            .Setup(o => o.Blobs.GetAsync("library/image", digest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createLayer);
+        return client;
+    }
+
+    private static Stream CreateLayer(params (string Name, string Content)[] files)
+    {
+        MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, leaveOpen: true))
+        {
+            foreach ((string name, string content) in files)
+            {
+                PaxTarEntry entry = new(TarEntryType.RegularFile, name)
+                {
+                    DataStream = new MemoryStream(Encoding.UTF8.GetBytes(content))
+                };
+                writer.WriteEntry(entry);
+            }
+        }
+        compressed.Position = 0;
+        return compressed;
+    }
+
+    private static Stream CreateSymbolicLinkLayer(string name, string linkTarget)
+    {
+        MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, leaveOpen: true))
+        {
+            PaxTarEntry entry = new(TarEntryType.SymbolicLink, name)
+            {
+                LinkName = linkTarget
+            };
+            writer.WriteEntry(entry);
+        }
+        compressed.Position = 0;
+        return compressed;
+    }
+
+    private static Stream CreateSymlinkChainLayer(string id)
+    {
+        MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, leaveOpen: true))
+        {
+            writer.WriteEntry(new PaxTarEntry(TarEntryType.SymbolicLink, "a") { LinkName = "." });
+            writer.WriteEntry(new PaxTarEntry(TarEntryType.SymbolicLink, "a/b") { LinkName = ".." });
+            writer.WriteEntry(new PaxTarEntry(TarEntryType.RegularFile, $"a/b/escaped-{id}.txt")
+            {
+                DataStream = new MemoryStream(Encoding.UTF8.GetBytes("escaped"))
+            });
+        }
+        compressed.Position = 0;
+        return compressed;
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ImageNameTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageNameTests.cs
@@ -1,0 +1,81 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+public class ImageNameTests
+{
+    [Theory]
+    [InlineData(
+        "ubuntu",
+        null,
+        "library/ubuntu",
+        "latest",
+        null,
+        "library/ubuntu:latest")]
+    [InlineData(
+        "mthalman/dredge",
+        null,
+        "mthalman/dredge",
+        "latest",
+        null,
+        "mthalman/dredge:latest")]
+    [InlineData(
+        "mthalman/dredge:v1",
+        null,
+        "mthalman/dredge",
+        "v1",
+        null,
+        "mthalman/dredge:v1")]
+    [InlineData(
+        "ghcr.io/mthalman/dredge:v1",
+        "ghcr.io",
+        "mthalman/dredge",
+        "v1",
+        null,
+        "ghcr.io/mthalman/dredge:v1")]
+    [InlineData(
+        "localhost:5000/dredge:v1",
+        "localhost:5000",
+        "dredge",
+        "v1",
+        null,
+        "localhost:5000/dredge:v1")]
+    [InlineData(
+        "ghcr.io/mthalman/dredge@sha256:abcdef",
+        "ghcr.io",
+        "mthalman/dredge",
+        null,
+        "sha256:abcdef",
+        "ghcr.io/mthalman/dredge@sha256:abcdef")]
+    public void Parse_ReturnsExpectedComponents(
+        string value,
+        string? expectedRegistry,
+        string expectedRepo,
+        string? expectedTag,
+        string? expectedDigest,
+        string expectedString)
+    {
+        ImageName imageName = ImageName.Parse(value);
+
+        Assert.Equal(expectedRegistry, imageName.Registry);
+        Assert.Equal(expectedRepo, imageName.Repo);
+        Assert.Equal(expectedTag, imageName.Tag);
+        Assert.Equal(expectedDigest, imageName.Digest);
+        Assert.Equal(expectedString, imageName.ToString());
+    }
+
+    [Theory]
+    [InlineData(null, "repo", null, null, "repo")]
+    [InlineData("registry.example", "repo", "tag", null, "registry.example/repo:tag")]
+    [InlineData("registry.example", "repo", null, "digest", "registry.example/repo@digest")]
+    [InlineData("registry.example", "repo", "tag", "digest", "registry.example/repo:tag")]
+    public void ToString_ReturnsExpectedReference(
+        string? registry,
+        string repo,
+        string? tag,
+        string? digest,
+        string expected)
+    {
+        ImageName imageName = new(registry, repo, tag, digest);
+
+        Assert.Equal(expected, imageName.ToString());
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/LinuxOsInfoTests.cs
+++ b/src/Valleysoft.Dredge.Tests/LinuxOsInfoTests.cs
@@ -1,0 +1,62 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+public class LinuxOsInfoTests
+{
+    [Fact]
+    public void Parse_ReturnsAllKnownFields()
+    {
+        const string Content =
+            """
+            PRETTY_NAME="Test Linux 1.0"
+            NAME="Test Linux"
+            ID=test
+            ID_LIKE="debian linux"
+            VERSION="1.0 (Stable)"
+            VERSION_ID="1.0"
+            VERSION_CODENAME=stable
+            BUILD_ID=build
+            IMAGE_ID=image
+            IMAGE_VERSION=2
+            VARIANT=server
+            VARIANT_ID=server
+            HOME_URL="https://example.com"
+            SUPPORT_URL="https://example.com/support"
+            BUG_REPORT_URL="https://example.com/bugs"
+            PRIVACY_POLICY_URL="https://example.com/privacy"
+            CPE_NAME="cpe:/o:example:test:1.0"
+            """;
+
+        LinuxOsInfo result = LinuxOsInfo.Parse(Content);
+
+        Assert.Equal("Test Linux 1.0", result.PrettyName);
+        Assert.Equal("Test Linux", result.Name);
+        Assert.Equal("test", result.Id);
+        Assert.Equal(["debian", "linux"], result.IdLike!);
+        Assert.Equal("1.0 (Stable)", result.Version);
+        Assert.Equal("1.0", result.VersionId);
+        Assert.Equal("stable", result.VersionCodeName);
+        Assert.Equal("build", result.BuildId);
+        Assert.Equal("image", result.ImageId);
+        Assert.Equal("2", result.ImageVersion);
+        Assert.Equal("server", result.Variant);
+        Assert.Equal("server", result.VariantId);
+        Assert.Equal("https://example.com", result.HomeUrl);
+        Assert.Equal("https://example.com/support", result.SupportUrl);
+        Assert.Equal("https://example.com/bugs", result.BugReportUrl);
+        Assert.Equal("https://example.com/privacy", result.PrivacyPolicyUrl);
+        Assert.Equal("cpe:/o:example:test:1.0", result.CpeName);
+    }
+
+    [Fact]
+    public void Parse_WhenOptionalFieldsAreMissing_ReturnsNullProperties()
+    {
+        const string Content = "# generated file\r\nmalformed line\r\nID=test\r\n";
+
+        LinuxOsInfo result = LinuxOsInfo.Parse(Content);
+
+        Assert.Equal("test", result.Id);
+        Assert.Null(result.PrettyName);
+        Assert.Null(result.IdLike);
+        Assert.Null(result.Version);
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ManifestHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ManifestHelperTests.cs
@@ -1,0 +1,139 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.Dredge.Commands;
+using DockerManifestReference = Valleysoft.DockerRegistryClient.Models.Manifests.Docker.ManifestReference;
+
+public class ManifestHelperTests
+{
+    [Fact]
+    public async Task GetResolvedManifestAsync_SelectsMatchingPlatform()
+    {
+        ManifestList manifestList = new()
+        {
+            Manifests =
+            [
+                CreateReference("sha256:amd64", "linux", "amd64", "1"),
+                CreateReference("sha256:arm64", "linux", "arm64", "1")
+            ]
+        };
+        DockerManifest resolvedManifest = new() { Layers = [] };
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/index", "sha256:index", manifestList));
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "sha256:arm64", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/manifest", "sha256:arm64", resolvedManifest));
+
+        ResolvedManifest result = await ManifestHelper.GetResolvedManifestAsync(
+            client.Object,
+            ImageName.Parse("image"),
+            new PlatformOptionsBase
+            {
+                Os = "linux",
+                OsVersion = "1",
+                Architecture = "arm64"
+            });
+
+        Assert.Same(resolvedManifest, result.Manifest);
+        Assert.Equal("sha256:arm64", result.ManifestInfo.DockerContentDigest);
+    }
+
+    [Fact]
+    public async Task GetResolvedManifestAsync_UsesSettingsForMissingPlatformOptions()
+    {
+        ManifestList manifestList = new()
+        {
+            Manifests =
+            [
+                CreateReference("sha256:amd64", "linux", "amd64", "1"),
+                CreateReference("sha256:arm64", "linux", "arm64", "1")
+            ]
+        };
+        DockerManifest resolvedManifest = new() { Layers = [] };
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/index", "sha256:index", manifestList));
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "sha256:arm64", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/manifest", "sha256:arm64", resolvedManifest));
+        AppSettings settings = (AppSettings)Activator.CreateInstance(typeof(AppSettings), nonPublic: true)!;
+        settings.Platform.Architecture = "arm64";
+
+        ResolvedManifest result = await ManifestHelper.GetResolvedManifestAsync(
+            client.Object,
+            ImageName.Parse("image"),
+            new PlatformOptionsBase
+            {
+                Os = "linux",
+                OsVersion = "1"
+            },
+            settings);
+
+        Assert.Same(resolvedManifest, result.Manifest);
+        Assert.Equal("sha256:arm64", result.ManifestInfo.DockerContentDigest);
+    }
+
+    [Fact]
+    public async Task GetResolvedManifestAsync_WhenNoPlatformMatches_Throws()
+    {
+        ManifestList manifestList = new()
+        {
+            Manifests = [CreateReference("sha256:amd64", "linux", "amd64", "1")]
+        };
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/index", "sha256:index", manifestList));
+
+        Exception exception = await Assert.ThrowsAsync<Exception>(
+            () => ManifestHelper.GetResolvedManifestAsync(
+                client.Object,
+                ImageName.Parse("image"),
+                new PlatformOptionsBase
+                {
+                    Os = "linux",
+                    OsVersion = "1",
+                    Architecture = "s390x"
+                }));
+
+        Assert.StartsWith("Unable to resolve the manifest list tag", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetResolvedManifestAsync_WhenResolvedTypeIsNotAnImageManifest_Throws()
+    {
+        Mock<IManifest> manifest = new();
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/unsupported", "sha256:digest", manifest.Object));
+
+        NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ManifestHelper.GetResolvedManifestAsync(
+                client.Object,
+                ImageName.Parse("image"),
+                new PlatformOptionsBase()));
+
+        Assert.Contains("application/unsupported", exception.Message);
+    }
+
+    private static DockerManifestReference CreateReference(
+        string digest,
+        string os,
+        string architecture,
+        string osVersion) =>
+        new()
+        {
+            Digest = digest,
+            Platform = new ManifestPlatform
+            {
+                Os = os,
+                Architecture = architecture,
+                OsVersion = osVersion
+            }
+        };
+}

--- a/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
@@ -1,0 +1,344 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+using Newtonsoft.Json.Linq;
+using System.Text;
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+using Valleysoft.Dredge.Commands.Image;
+using DigestCommand = Valleysoft.Dredge.Commands.Manifest.DigestCommand;
+using DigestOptions = Valleysoft.Dredge.Commands.Manifest.DigestOptions;
+using GetCommand = Valleysoft.Dredge.Commands.Manifest.GetCommand;
+using GetOptions = Valleysoft.Dredge.Commands.Manifest.GetOptions;
+using ReferrerListCommand = Valleysoft.Dredge.Commands.Referrer.ListCommand;
+using ReferrerListOptions = Valleysoft.Dredge.Commands.Referrer.ListOptions;
+using RepoListCommand = Valleysoft.Dredge.Commands.Repo.ListCommand;
+using RepoListOptions = Valleysoft.Dredge.Commands.Repo.ListOptions;
+using ResolveCommand = Valleysoft.Dredge.Commands.Manifest.ResolveCommand;
+using ResolveOptions = Valleysoft.Dredge.Commands.Manifest.SetOptions;
+using TagListCommand = Valleysoft.Dredge.Commands.Tag.ListCommand;
+using TagListOptions = Valleysoft.Dredge.Commands.Tag.ListOptions;
+using OciManifestReference = Valleysoft.DockerRegistryClient.Models.Manifests.Oci.ManifestReference;
+
+public class RegistryCommandTests
+{
+    private const string Registry = "registry.example";
+
+    [Fact]
+    public async Task DigestCommand_WritesManifestDigest()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetDigestAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("sha256:digest");
+        using StringWriter output = new();
+        TestDigestCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new DigestOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal($"sha256:digest{Environment.NewLine}", output.ToString());
+    }
+
+    [Fact]
+    public async Task DigestCommand_WhenExecutionFails_ThrowsInsteadOfTerminatingTestProcess()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetDigestAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("failure"));
+        using StringWriter output = new();
+        TestDigestCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new DigestOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+    }
+
+    [Fact]
+    public async Task GetCommand_WritesManifestJson()
+    {
+        DockerManifest manifest = new()
+        {
+            SchemaVersion = 2,
+            MediaType = "application/test",
+            Layers = []
+        };
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo("application/test", "sha256:digest", manifest));
+        using StringWriter output = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new GetOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        await command.RunAsync();
+        JObject json = JObject.Parse(output.ToString());
+
+        Assert.Equal(2, json["schemaVersion"]);
+        Assert.Equal("application/test", json["mediaType"]);
+    }
+
+    [Fact]
+    public async Task ResolveCommand_WritesFullyQualifiedDigest()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateManifestInfo("sha256:resolved"));
+        using StringWriter output = new();
+        TestResolveCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new ResolveOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal($"{Registry}/repo@sha256:resolved{Environment.NewLine}", output.ToString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_WritesFormattedImageConfiguration()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateManifestInfo("sha256:manifest", "sha256:config"));
+        client
+            .Setup(o => o.Blobs.GetAsync("repo", "sha256:config", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("""{"created":"today","config":{"Env":["A=B"]}}""")));
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new InspectOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        await command.RunAsync();
+        JObject json = JObject.Parse(output.ToString());
+
+        Assert.Equal("today", json["created"]);
+        Assert.Equal("A=B", json["config"]?["Env"]?[0]);
+    }
+
+    [Fact]
+    public async Task RepoListCommand_CombinesPagesAndSortsRepositories()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Catalog.GetAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<Catalog>(
+                new Catalog { RepositoryNames = ["zebra", "alpha"] },
+                "next"));
+        client
+            .Setup(o => o.Catalog.GetNextAsync("next", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<Catalog>(
+                new Catalog { RepositoryNames = ["middle"] },
+                null));
+        using StringWriter output = new();
+        TestRepoListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new RepoListOptions { Registry = Registry }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(["alpha", "middle", "zebra"], JArray.Parse(output.ToString()).Values<string>());
+    }
+
+    [Fact]
+    public async Task TagListCommand_CombinesPagesAndSortsTags()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Tags.GetAsync("library/repo", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<RepositoryTags>(
+                new RepositoryTags { RepositoryName = "library/repo", Tags = ["z", "a"] },
+                "next"));
+        client
+            .Setup(o => o.Tags.GetNextAsync("next", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<RepositoryTags>(
+                new RepositoryTags { RepositoryName = "library/repo", Tags = ["m"] },
+                null));
+        using StringWriter output = new();
+        TestTagListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new TagListOptions { Repo = "repo" }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(["a", "m", "z"], JArray.Parse(output.ToString()).Values<string>());
+    }
+
+    [Fact]
+    public async Task ReferrerListCommand_CombinesAllPages()
+    {
+        OciManifestReference first = new() { Digest = "sha256:first" };
+        OciManifestReference second = new() { Digest = "sha256:second" };
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", "application/test", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex { Manifests = [first] },
+                "next"));
+        client
+            .Setup(o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex { Manifests = [second] },
+                null));
+        using StringWriter output = new();
+        TestReferrerListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new ReferrerListOptions
+            {
+                Image = $"{Registry}/repo@sha256:image",
+                ArtifactType = "application/test"
+            }
+        };
+
+        await command.RunAsync();
+        string[] digests = JObject.Parse(output.ToString())["manifests"]!
+            .Select(manifest => (string)manifest["digest"]!)
+            .ToArray();
+
+        Assert.Equal(["sha256:first", "sha256:second"], digests);
+        client.Verify(o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Mock<IDockerRegistryClient> CreateClient() =>
+        new() { DefaultValue = DefaultValue.Mock };
+
+    private static IDockerRegistryClientFactory CreateFactory(IDockerRegistryClient client)
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(It.IsAny<string?>())).ReturnsAsync(client);
+        return factory.Object;
+    }
+
+    private static ManifestInfo CreateManifestInfo(string manifestDigest, string configDigest = "sha256:config") =>
+        new(
+            "application/test",
+            manifestDigest,
+            new DockerManifest
+            {
+                Config = new ManifestConfig { Digest = configDigest },
+                Layers = []
+            });
+
+    private sealed class TestDigestCommand : DigestCommand
+    {
+        public TestDigestCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestGetCommand : GetCommand
+    {
+        public TestGetCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestResolveCommand : ResolveCommand
+    {
+        public TestResolveCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestInspectCommand : InspectCommand
+    {
+        public TestInspectCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestRepoListCommand : RepoListCommand
+    {
+        public TestRepoListCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestTagListCommand : TagListCommand
+    {
+        public TestTagListCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestReferrerListCommand : ReferrerListCommand
+    {
+        public TestReferrerListCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync();
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class CommandExitException : Exception
+    {
+        public CommandExitException(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/WindowsOsInfoTests.cs
+++ b/src/Valleysoft.Dredge.Tests/WindowsOsInfoTests.cs
@@ -1,0 +1,62 @@
+﻿namespace Valleysoft.Dredge.Tests;
+
+using Valleysoft.DockerRegistryClient.Models.Images;
+using Valleysoft.Dredge.Commands.Image;
+
+public class WindowsOsInfoTests
+{
+    [Theory]
+    [InlineData("windows/nanoserver", WindowsType.NanoServer)]
+    [InlineData("windows/servercore", WindowsType.ServerCore)]
+    [InlineData("windows/server", WindowsType.Server)]
+    [InlineData("windows", WindowsType.Windows)]
+    public async Task GetWindowsOsInfoAsync_WhenLayerExists_ReturnsMatchingWindowsType(
+        string matchingRepo,
+        WindowsType expectedType)
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Blobs.ExistsAsync(
+                It.IsAny<string>(),
+                "sha256:layer",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string repo, string _, CancellationToken _) => repo == matchingRepo);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory
+            .Setup(o => o.GetClientAsync(RegistryHelper.McrRegistry))
+            .ReturnsAsync(client.Object);
+
+        (WindowsOsInfo Info, string Repo)? result = await OsCommand.GetWindowsOsInfoAsync(
+            new Image { OsVersion = "10.0" },
+            "sha256:layer",
+            factory.Object);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedType, result.Value.Info.Type);
+        Assert.Equal("10.0", result.Value.Info.Version);
+        Assert.Equal(matchingRepo, result.Value.Repo);
+    }
+
+    [Fact]
+    public async Task GetWindowsOsInfoAsync_WhenLayerIsUnknown_ReturnsNull()
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Blobs.ExistsAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory
+            .Setup(o => o.GetClientAsync(RegistryHelper.McrRegistry))
+            .ReturnsAsync(client.Object);
+
+        (WindowsOsInfo Info, string Repo)? result = await OsCommand.GetWindowsOsInfoAsync(
+            new Image(),
+            "sha256:layer",
+            factory.Object);
+
+        Assert.Null(result);
+    }
+}

--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -5,7 +5,11 @@ namespace Valleysoft.Dredge;
 
 internal static class CommandHelper
 {
-    public static async Task ExecuteCommandAsync(string? registry, Func<Task> execute)
+    public static async Task ExecuteCommandAsync(
+        string? registry,
+        Func<Task> execute,
+        TextWriter? errorWriter = null,
+        Action<int>? exit = null)
     {
         try
         {
@@ -36,9 +40,9 @@ internal static class CommandHelper
                 }
             }
 
-            Console.Error.WriteLine(message);
+            (errorWriter ?? Console.Error).WriteLine(message);
             Console.ForegroundColor = savedColor;
-            Environment.Exit(1);
+            (exit ?? Environment.Exit)(1);
         }
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -16,7 +16,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
 
     protected override Task ExecuteAsync()
     {
-        return CommandHelper.ExecuteCommandAsync(registry: null, async () =>
+        return ExecuteCommandAsync(registry: null, async () =>
         {
             AppSettings settings = AppSettings.Load();
             if (settings.FileCompareTool is null ||

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -21,7 +21,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
 
     protected override Task ExecuteAsync()
     {
-        return CommandHelper.ExecuteCommandAsync(registry: null, async () =>
+        return ExecuteCommandAsync(registry: null, async () =>
         {
             IRenderable output = await GetOutputAsync();
             AnsiConsole.Write(output);

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -36,7 +36,7 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
     protected override async Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        await CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        await ExecuteCommandAsync(imageName.Registry, async () =>
         {
             Markup markupOutput = new(await GetMarkupStringAsync());
             AnsiConsole.Write(markupOutput);

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -5,15 +5,15 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class InspectCommand : RegistryCommandBase<InspectOptions>
 {
-    public InspectCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("inspect", "Return low-level information on a container image", dockerRegistryClientFactory)
+    public InspectCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("inspect", "Return low-level information on a container image", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
@@ -25,7 +25,7 @@ public class InspectCommand : RegistryCommandBase<InspectOptions>
             object? json = JsonConvert.DeserializeObject(content) ??
                 throw new Exception($"Unable to deserialize content into JSON:\n{content}");
             string output = JsonConvert.SerializeObject(json, JsonHelper.Settings);
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -13,15 +13,15 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
 {
     private static readonly Regex osReleaseRegex = OsReleaseRegex();
 
-    public OsCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("os", "Gets OS info about the container image", dockerRegistryClientFactory)
+    public OsCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("os", "Gets OS info about the container image", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;
@@ -52,7 +52,7 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
             }
 
             string output = JsonConvert.SerializeObject(osInfo, JsonHelper.SettingsNoCamelCase);
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -12,7 +12,7 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             IImageManifest manifest = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).Manifest;

--- a/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/DigestCommand.cs
@@ -4,21 +4,21 @@ namespace Valleysoft.Dredge.Commands.Manifest;
 
 public class DigestCommand : RegistryCommandBase<DigestOptions>
 {
-    public DigestCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("digest", "Queries the digest of a manifest", dockerRegistryClientFactory)
+    public DigestCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("digest", "Queries the digest of a manifest", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
             string digest = await client.Manifests.GetDigestAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
 
-            Console.Out.WriteLine(digest);
+            Output.WriteLine(digest);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
@@ -5,15 +5,15 @@ namespace Valleysoft.Dredge.Commands.Manifest;
 
 public class GetCommand : RegistryCommandBase<GetOptions>
 {
-    public GetCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("get", "Queries a manifest", dockerRegistryClientFactory)
+    public GetCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("get", "Queries a manifest", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
@@ -21,7 +21,7 @@ public class GetCommand : RegistryCommandBase<GetOptions>
 
             string output = JsonConvert.SerializeObject(manifestInfo.Manifest, JsonHelper.Settings);
 
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -4,21 +4,21 @@ namespace Valleysoft.Dredge.Commands.Manifest;
 
 public class ResolveCommand : RegistryCommandBase<SetOptions>
 {
-    public ResolveCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("resolve", "Resolves a manifest to a target platform's fully-qualified image digest", dockerRegistryClientFactory)
+    public ResolveCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("resolve", "Resolves a manifest to a target platform's fully-qualified image digest", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             ManifestInfo manifestInfo = (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options)).ManifestInfo;
             ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
 
-            Console.Out.WriteLine(fullyQualifiedDigest.ToString());
+            Output.WriteLine(fullyQualifiedDigest.ToString());
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -7,15 +7,15 @@ namespace Valleysoft.Dredge.Commands.Referrer;
 
 public class ListCommand : RegistryCommandBase<ListOptions>
 {
-    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("list", "Lists the referrers to a manifest", dockerRegistryClientFactory)
+    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("list", "Lists the referrers to a manifest", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Image);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
@@ -36,17 +36,18 @@ public class ListCommand : RegistryCommandBase<ListOptions>
             initialIndex = indexPage.Value;
             while (indexPage.NextPageLink is not null)
             {
-                Page<OciImageIndex> nextPage = await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType);
+                Page<OciImageIndex> nextPage = await client.Referrers.GetNextAsync(indexPage.NextPageLink);
                 initialIndex.Manifests =
                 [
                     .. initialIndex.Manifests,
                     .. nextPage.Value.Manifests
                 ];
+                indexPage = nextPage;
             }
 
             string output = JsonConvert.SerializeObject(initialIndex, JsonHelper.Settings);
 
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
+++ b/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
@@ -4,10 +4,23 @@ public abstract class RegistryCommandBase<TOptions> : CommandWithOptions<TOption
     where TOptions : OptionsBase, new()
 {
     public IDockerRegistryClientFactory DockerRegistryClientFactory { get; }
+    protected TextWriter Output { get; }
 
-    protected RegistryCommandBase(string name, string description, IDockerRegistryClientFactory dockerRegistryClientFactory)
+    protected RegistryCommandBase(
+        string name,
+        string description,
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        TextWriter? output = null)
         : base(name, description)
     {
         DockerRegistryClientFactory = dockerRegistryClientFactory;
+        Output = output ?? Console.Out;
     }
+
+    protected Task ExecuteCommandAsync(string? registry, Func<Task> execute) =>
+        CommandHelper.ExecuteCommandAsync(registry, execute, Error, Exit);
+
+    protected virtual TextWriter Error => Console.Error;
+
+    protected virtual void Exit(int exitCode) => Environment.Exit(exitCode);
 }

--- a/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
@@ -6,14 +6,14 @@ namespace Valleysoft.Dredge.Commands.Repo;
 
 public class ListCommand : RegistryCommandBase<ListOptions>
 {
-    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("list", "Lists the repositories contained in the container registry", dockerRegistryClientFactory)
+    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("list", "Lists the repositories contained in the container registry", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
-        return CommandHelper.ExecuteCommandAsync(Options.Registry, async () =>
+        return ExecuteCommandAsync(Options.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(Options.Registry);
 
@@ -31,7 +31,7 @@ public class ListCommand : RegistryCommandBase<ListOptions>
 
             string output = JsonConvert.SerializeObject(repoNames, JsonHelper.Settings);
 
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -6,15 +6,15 @@ namespace Valleysoft.Dredge.Commands.Tag;
 
 public class ListCommand : RegistryCommandBase<ListOptions>
 {
-    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
-        : base("list", "Lists the tag contained in the container repository", dockerRegistryClientFactory)
+    public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : base("list", "Lists the tag contained in the container repository", dockerRegistryClientFactory, output)
     {
     }
 
     protected override Task ExecuteAsync()
     {
         ImageName imageName = ImageName.Parse(Options.Repo);
-        return CommandHelper.ExecuteCommandAsync(imageName.Registry, async () =>
+        return ExecuteCommandAsync(imageName.Registry, async () =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
 
@@ -32,7 +32,7 @@ public class ListCommand : RegistryCommandBase<ListOptions>
 
             string output = JsonConvert.SerializeObject(tags, JsonHelper.Settings);
 
-            Console.Out.WriteLine(output);
+            Output.WriteLine(output);
         });
     }
 }

--- a/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
+++ b/src/Valleysoft.Dredge/DockerRegistryClientFactory.cs
@@ -6,6 +6,18 @@ namespace Valleysoft.Dredge;
 
 internal class DockerRegistryClientFactory : IDockerRegistryClientFactory
 {
+    private readonly IEnvironmentVariableProvider environmentVariableProvider;
+
+    public DockerRegistryClientFactory()
+        : this(new EnvironmentVariableProvider())
+    {
+    }
+
+    internal DockerRegistryClientFactory(IEnvironmentVariableProvider environmentVariableProvider)
+    {
+        this.environmentVariableProvider = environmentVariableProvider;
+    }
+
     public async Task<IDockerRegistryClient> GetClientAsync(string? registry)
     {
         IRegistryClientCredentials? clientCreds;
@@ -14,12 +26,12 @@ internal class DockerRegistryClientFactory : IDockerRegistryClientFactory
         string? username;
         string? password;
 
-        if ((accessToken = Environment.GetEnvironmentVariable("DREDGE_TOKEN")) is not null)
+        if ((accessToken = environmentVariableProvider.GetVariable("DREDGE_TOKEN")) is not null)
         {
             clientCreds = new TokenCredentials(accessToken);
         }
-        else if ((username = Environment.GetEnvironmentVariable("DREDGE_USERNAME")) is not null &&
-            (password = Environment.GetEnvironmentVariable("DREDGE_PASSWORD")) is not null)
+        else if ((username = environmentVariableProvider.GetVariable("DREDGE_USERNAME")) is not null &&
+            (password = environmentVariableProvider.GetVariable("DREDGE_PASSWORD")) is not null)
         {
             clientCreds = new BasicAuthenticationCredentials(username, password);
         }

--- a/src/Valleysoft.Dredge/EnvironmentVariableProvider.cs
+++ b/src/Valleysoft.Dredge/EnvironmentVariableProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.Dredge;
+
+internal class EnvironmentVariableProvider : IEnvironmentVariableProvider
+{
+    public string? GetVariable(string name) => Environment.GetEnvironmentVariable(name);
+}

--- a/src/Valleysoft.Dredge/IEnvironmentVariableProvider.cs
+++ b/src/Valleysoft.Dredge/IEnvironmentVariableProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Valleysoft.Dredge;
+
+internal interface IEnvironmentVariableProvider
+{
+    string? GetVariable(string name);
+}

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -55,7 +55,8 @@ internal static class ImageHelper
             Console.Error.WriteLine($"Layer {layer.Digest}");
 
             string layerName = layer.Digest[(layer.Digest.IndexOf(':') + 1)..];
-            string layerDir = Path.Combine(LayersTempPath, layerName);
+            ValidateLayerDigest(layerName);
+            string layerDir = GetContainedPath(LayersTempPath, layerName);
             if (Directory.Exists(layerDir))
             {
                 Console.Error.WriteLine($"\tUsing cached layer on disk...");
@@ -65,7 +66,18 @@ internal static class ImageHelper
                 Console.Error.WriteLine($"\tDownloading layer...");
                 using Stream layerStream = await client.Blobs.GetAsync(imageName.Repo, layer.Digest);
 
-                await ExtractLayerAsync(layerStream, layerDir);
+                try
+                {
+                    await ExtractLayerAsync(layerStream, layerDir);
+                }
+                catch
+                {
+                    if (Directory.Exists(layerDir))
+                    {
+                        Directory.Delete(layerDir, recursive: true);
+                    }
+                    throw;
+                }
             }
 
             if (noSquash)
@@ -84,6 +96,7 @@ internal static class ImageHelper
         Console.Error.WriteLine($"\tExtracting layer...");
 
         Directory.CreateDirectory(layerDir);
+        List<(string Path, string Target)> hardLinks = [];
 
         using GZipStream gZipStream = new(layerStream, CompressionMode.Decompress);
 
@@ -102,7 +115,7 @@ internal static class ImageHelper
 
             if (entry.IsDirectory)
             {
-                string directoryPath = Path.Combine(layerDir, entry.Name);
+                string directoryPath = GetContainedPath(layerDir, entry.Name);
                 if (!Directory.Exists(directoryPath))
                 {
                     Directory.CreateDirectory(directoryPath);
@@ -124,8 +137,37 @@ internal static class ImageHelper
                 entryFileName = entryFileName.Replace(invalidChar, '-');
             }
 
+            if (entryFileName.StartsWith(WhiteoutMarkerPrefix, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(entryFileName, OpaqueWhiteoutMarker, StringComparison.OrdinalIgnoreCase))
+            {
+                ValidatePathSegment(entryFileName[WhiteoutMarkerPrefix.Length..], "whiteout target");
+            }
+
             entryName = Path.Combine(entryDirName, entryFileName);
-            await ExtractTarEntry(layerDir, tarStream, entry, entryName);
+            await ExtractTarEntry(layerDir, tarStream, entry, entryName, hardLinks);
+        }
+
+        while (hardLinks.Count > 0)
+        {
+            int copiedLinkCount = 0;
+            for (int i = hardLinks.Count - 1; i >= 0; i--)
+            {
+                (string path, string target) = hardLinks[i];
+                string targetPath = GetContainedPath(
+                    layerDir,
+                    target.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (File.Exists(targetPath))
+                {
+                    File.Copy(targetPath, path, overwrite: true);
+                    hardLinks.RemoveAt(i);
+                    copiedLinkCount++;
+                }
+            }
+
+            if (copiedLinkCount == 0)
+            {
+                throw new InvalidDataException($"Unable to resolve hard link target '{hardLinks[0].Target}'.");
+            }
         }
     }
 
@@ -133,91 +175,219 @@ internal static class ImageHelper
     {
         Console.Error.WriteLine($"\tApplying layer...");
 
-        FileInfo[] layerFiles = new DirectoryInfo(layerDir).GetFiles("*", SearchOption.AllDirectories);
+        FileInfo[] layerFiles = GetLayerFiles(new DirectoryInfo(layerDir)).ToArray();
 
-        foreach (FileInfo layerFile in layerFiles)
+        foreach (FileInfo layerFile in layerFiles
+            .Where(IsOpaqueWhiteout)
+            .OrderBy(file => Path.GetRelativePath(layerDir, file.FullName).Count(c => c == Path.DirectorySeparatorChar)))
+        {
+            string? layerFileDirName = Path.GetDirectoryName(Path.GetRelativePath(layerDir, layerFile.FullName));
+            if (string.IsNullOrEmpty(layerFileDirName))
+            {
+                throw new Exception("The opaque whiteout file marker should not exist in the root directory.");
+            }
+
+            string fullDirPath = GetContainedPath(workingDir, layerFileDirName);
+            if (Directory.Exists(fullDirPath))
+            {
+                Directory.Delete(fullDirPath, recursive: true);
+            }
+        }
+
+        foreach (FileInfo layerFile in layerFiles.Where(IsWhiteout))
         {
             string layerFileRelativePath = Path.GetRelativePath(layerDir, layerFile.FullName);
-            string? layerfileDirName = Path.GetDirectoryName(layerFileRelativePath);
+            string? layerFileDirName = Path.GetDirectoryName(layerFileRelativePath);
+            string actualFileName = layerFile.Name[WhiteoutMarkerPrefix.Length..];
+            ValidatePathSegment(actualFileName, "whiteout target");
+            string fullPath = GetContainedPath(
+                workingDir,
+                Path.Combine(layerFileDirName ?? string.Empty, actualFileName));
 
-            // If this an OCI opaque whiteout file marker, delete the directory where the file marker
-            // is located.
-            if (string.Equals(layerFile.Name, OpaqueWhiteoutMarker, StringComparison.OrdinalIgnoreCase))
+            if (File.Exists(fullPath))
             {
-                if (string.IsNullOrEmpty(layerfileDirName))
-                {
-                    throw new Exception("The opaque whiteout file marker should not exist in the root directory.");
-                }
-                string fullDirPath = Path.Combine(workingDir, layerfileDirName);
-
-                if (Directory.Exists(fullDirPath))
-                {
-                    Directory.Delete(fullDirPath, recursive: true);
-                }
+                File.Delete(fullPath);
             }
-            // If this is an OCI whiteout file marker, delete the associated file
-            else if (layerFile.Name.StartsWith(WhiteoutMarkerPrefix, StringComparison.OrdinalIgnoreCase))
+            else if (Directory.Exists(fullPath))
             {
-                string actualFileName = layerFile.Name[WhiteoutMarkerPrefix.Length..];
-                string fullFilePath = Path.Combine(
-                    workingDir,
-                    Path.GetDirectoryName(layerfileDirName) ?? string.Empty,
-                    actualFileName);
+                bool isLink = File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
+                Directory.Delete(fullPath, recursive: !isLink);
+            }
+        }
 
-                if (File.Exists(fullFilePath))
+        foreach (FileInfo layerFile in layerFiles.Where(file => !IsOpaqueWhiteout(file) && !IsWhiteout(file)))
+        {
+            string layerFileRelativePath = Path.GetRelativePath(layerDir, layerFile.FullName);
+            string dest = GetContainedPath(workingDir, layerFileRelativePath);
+            string destDir = Path.GetDirectoryName(dest)!;
+            if (!Directory.Exists(destDir))
+            {
+                Directory.CreateDirectory(destDir);
+            }
+
+            if (layerFile.LinkTarget is not null)
+            {
+                if (File.Exists(dest) || Directory.Exists(dest))
                 {
-                    File.Delete(fullFilePath);
+                    File.Delete(dest);
                 }
+
+                string sourceTarget = GetLinkTargetPath(layerDir, layerFile.FullName, layerFile.LinkTarget);
+                string destTarget = GetContainedPath(
+                    workingDir,
+                    Path.GetRelativePath(layerDir, sourceTarget));
+                FileHelper.CreateSymbolicLink(dest, Path.GetRelativePath(destDir, destTarget));
             }
             else
             {
-                string dest = Path.Combine(workingDir, layerFileRelativePath);
-                string destDir = Path.GetDirectoryName(dest)!;
-                if (!Directory.Exists(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                }
-
-                if (layerFile.LinkTarget is not null)
-                {
-                    if (File.Exists(dest))
-                    {
-                        File.Delete(dest);
-                    }
-
-                    FileHelper.CreateSymbolicLink(dest, layerFile.LinkTarget);
-                }
-                else
-                {
-                    File.Copy(layerFile.FullName, dest, overwrite: true);
-                }
+                File.Copy(layerFile.FullName, dest, overwrite: true);
             }
         }
     }
 
-    private static async Task ExtractTarEntry(string workingDir, TarInputStream tarStream, TarEntry entry, string entryName)
+    private static bool IsOpaqueWhiteout(FileInfo file) =>
+        string.Equals(file.Name, OpaqueWhiteoutMarker, StringComparison.OrdinalIgnoreCase);
+
+    private static IEnumerable<FileInfo> GetLayerFiles(DirectoryInfo directory)
     {
-        string filePath = Path.Combine(workingDir, entryName);
+        foreach (FileInfo file in directory.GetFiles())
+        {
+            yield return file;
+        }
+
+        foreach (DirectoryInfo subdirectory in directory.GetDirectories())
+        {
+            if (IsReparsePoint(subdirectory.FullName))
+            {
+                throw new InvalidDataException($"Layer directory '{subdirectory.FullName}' is a symbolic link.");
+            }
+
+            foreach (FileInfo file in GetLayerFiles(subdirectory))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private static bool IsWhiteout(FileInfo file) =>
+        !IsOpaqueWhiteout(file) &&
+        file.Name.StartsWith(WhiteoutMarkerPrefix, StringComparison.OrdinalIgnoreCase);
+
+    private static async Task ExtractTarEntry(
+        string workingDir,
+        TarInputStream tarStream,
+        TarEntry entry,
+        string entryName,
+        List<(string Path, string Target)> hardLinks)
+    {
+        string filePath = GetContainedPath(workingDir, entryName);
         string? directoryPath = Path.GetDirectoryName(filePath);
         if (directoryPath is not null && !Directory.Exists(directoryPath))
         {
             Directory.CreateDirectory(directoryPath);
         }
 
-        if ((entry.TarHeader.TypeFlag == TarHeader.LF_LINK || entry.TarHeader.TypeFlag == TarHeader.LF_SYMLINK) &&
-            !string.IsNullOrEmpty(entry.TarHeader.LinkName))
+        if (entry.TarHeader.TypeFlag == TarHeader.LF_LINK && !string.IsNullOrEmpty(entry.TarHeader.LinkName))
+        {
+            hardLinks.Add((filePath, entry.TarHeader.LinkName));
+        }
+        else if (entry.TarHeader.TypeFlag == TarHeader.LF_SYMLINK && !string.IsNullOrEmpty(entry.TarHeader.LinkName))
         {
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
             }
 
-            FileHelper.CreateSymbolicLink(filePath, entry.TarHeader.LinkName);
+            string targetPath = GetLinkTargetPath(workingDir, filePath, entry.TarHeader.LinkName);
+            string relativeTarget = Path.GetRelativePath(directoryPath!, targetPath);
+            FileHelper.CreateSymbolicLink(filePath, relativeTarget);
         }
         else
         {
             using FileStream outputStream = File.Create(filePath);
             await tarStream.CopyEntryContentsAsync(outputStream, CancellationToken.None);
+        }
+    }
+
+    private static string GetLinkTargetPath(string workingDir, string linkPath, string linkTarget)
+    {
+        string target = Path.IsPathRooted(linkTarget)
+            ? linkTarget.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            : Path.Combine(Path.GetDirectoryName(Path.GetRelativePath(workingDir, linkPath)) ?? string.Empty, linkTarget);
+
+        return GetContainedPath(workingDir, target);
+    }
+
+    private static string GetContainedPath(string rootPath, string relativePath)
+    {
+        string fullRootPath = Path.GetFullPath(rootPath);
+        string fullPath = Path.GetFullPath(Path.Combine(fullRootPath, relativePath));
+        string pathFromRoot = Path.GetRelativePath(fullRootPath, fullPath);
+
+        if (Path.IsPathRooted(pathFromRoot) ||
+            pathFromRoot.Equals("..", StringComparison.Ordinal) ||
+            pathFromRoot.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+            pathFromRoot.StartsWith($"..{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Archive entry path '{relativePath}' is outside the layer directory.");
+        }
+
+        ValidateNoLinkParents(fullRootPath, fullPath);
+        if (IsReparsePoint(fullPath))
+        {
+            throw new InvalidDataException($"Path '{fullPath}' is a symbolic link.");
+        }
+        return fullPath;
+    }
+
+    private static void ValidateNoLinkParents(string rootPath, string fullPath)
+    {
+        string? path = Path.GetDirectoryName(fullPath);
+        while (path is not null && !Path.GetFullPath(path).Equals(rootPath, StringComparison.OrdinalIgnoreCase))
+        {
+            if (IsReparsePoint(path))
+            {
+                throw new InvalidDataException($"Path '{fullPath}' traverses a symbolic link.");
+            }
+
+            path = Path.GetDirectoryName(path);
+        }
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    private static void ValidatePathSegment(string value, string description)
+    {
+        if (string.IsNullOrEmpty(value) ||
+            value is "." or ".." ||
+            Path.IsPathRooted(value) ||
+            value.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]) >= 0)
+        {
+            throw new InvalidDataException($"Invalid {description} '{value}'.");
+        }
+    }
+
+    private static void ValidateLayerDigest(string value)
+    {
+        ValidatePathSegment(value, "layer digest");
+
+        if (value.Contains(':'))
+        {
+            throw new InvalidDataException($"Invalid layer digest '{value}'.");
         }
     }
 }

--- a/src/Valleysoft.Dredge/LinuxOsInfo.cs
+++ b/src/Valleysoft.Dredge/LinuxOsInfo.cs
@@ -59,6 +59,8 @@ public record LinuxOsInfo
     {
         Dictionary<string, string> osFields = new([..osInfoContent
             .Split("\n", StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => !line.StartsWith('#') && line.Contains('='))
             .Select(line =>
             {
                 int index = line.IndexOf('=');

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -10,15 +10,23 @@ internal record ResolvedManifest(
 internal static class ManifestHelper
 {
     public static async Task<ResolvedManifest> GetResolvedManifestAsync(
-        IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options)
+        IDockerRegistryClient client, ImageName imageName, PlatformOptionsBase options, AppSettings? settings = null)
     {
         ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, (imageName.Tag ?? imageName.Digest)!);
         if (manifestInfo.Manifest is IManifestList manifestList)
         {
-            AppSettings settings = AppSettings.Load();
-            string? os = GetPlatformValue(options.Os, settings.Platform.Os);
-            string? osVersion = GetPlatformValue(options.OsVersion, settings.Platform.OsVersion);
-            string? architecture = GetPlatformValue(options.Architecture, settings.Platform.Architecture);
+            string? os = options.Os;
+            string? osVersion = options.OsVersion;
+            string? architecture = options.Architecture;
+            if (string.IsNullOrEmpty(os) ||
+                string.IsNullOrEmpty(osVersion) ||
+                string.IsNullOrEmpty(architecture))
+            {
+                settings ??= AppSettings.Load();
+                os = GetPlatformValue(os, settings.Platform.Os);
+                osVersion = GetPlatformValue(osVersion, settings.Platform.OsVersion);
+                architecture = GetPlatformValue(architecture, settings.Platform.Architecture);
+            }
 
             IEnumerable<IManifestReference> manifestRefs = manifestList.Manifests
                 .Where(manifest =>

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Valleysoft.Dredge.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />


### PR DESCRIPTION
## Summary

Improve confidence in Dredge's command, registry, settings, platform, and image-layer behavior with repository-wide tests that can run safely in parallel. The expanded coverage exposed several production defects, which are fixed as part of this change.

- Add dependency-injection seams for command output, process exit behavior, environment variables, and settings so tests avoid global mutable state.
- Add focused coverage for command registration, registry operations, manifest resolution, image names, platform parsing, settings accessors, filesystem helpers, and OCI layer application.
- Fix referrer pagination and Linux `os-release` parsing.
- Harden OCI extraction and application against path traversal, unsafe links, malformed whiteouts, partial cache entries, and platform-specific digest cache escapes.
- Preserve correct whiteout ordering and support file, directory, nested, opaque, and colon-bearing Unix whiteout targets.

## Testing

- `dotnet test --no-restore -c Release`
- 207 tests pass.