### PR TITLE
Add image metadata comparison command

### DIFF
--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -6,6 +6,7 @@ All image commands support [platform resolution](../platform-resolution.md) via 
 |-------------|-------------|
 | [`inspect`](#inspect) | Inspect an image configuration |
 | [`os`](#os) | Show OS information |
+| [`compare metadata`](#compare-metadata) | Compare image configuration and platform metadata |
 | [`compare layers`](#compare-layers) | Compare the layers of two images |
 | [`compare files`](#compare-files) | Compare the file contents of two images |
 | [`save-layers`](#save-layers) | Save image layers to disk |
@@ -80,6 +81,52 @@ dredge image os mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
   "Version": "10.0.20348.1249"
 }
 ```
+
+## Compare metadata
+
+Compares image configuration, manifest descriptors, and platform metadata
+without downloading image layers.
+
+```console
+dredge image compare metadata <base> <target> [--output <format>] [--no-color] [--os <os>] [--arch <arch>] [--os-version <version>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--output` | Output format: `SideBySide` (default), `Inline`, or `Json` |
+| `--no-color` | Disable color output and use text-based diff indicators instead |
+
+The comparison includes:
+
+- Available platforms and their descriptors
+- Manifest media types, annotations, config descriptors, and layer descriptors
+- Image creation, author, operating system, architecture, and root filesystem metadata
+- Entrypoint, command, environment variables, labels, exposed ports, volumes, user, and working directory
+- Image history, including creation time, command, author, comment, and empty-layer status
+
+For a multi-platform reference, Dredge compares the complete platform index.
+The platform options select the per-platform manifests and image configurations
+for the deeper comparison. Dredge uses the configured
+[platform resolution](../platform-resolution.md) defaults when platform options
+are omitted.
+
+Example:
+
+```console
+dredge image compare metadata --output inline mcr.microsoft.com/dotnet/runtime:9.0.0 mcr.microsoft.com/dotnet/runtime:10.0.0 --os linux --arch amd64
+```
+
+```diff
+- Config.environment["DOTNET_VERSION"] = "9.0.0"
++ Config.environment["DOTNET_VERSION"] = "10.0.0"
+```
+
+The command returns the following exit codes:
+
+| Exit code | Meaning |
+|----------:|---------|
+| `0` | The comparison completed, whether the metadata is equal or different |
+| `1` | The command failed before completing the comparison |
 
 ## Compare layers
 

--- a/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
+++ b/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
@@ -1,0 +1,42 @@
+namespace Valleysoft.Dredge.Tests;
+
+using Newtonsoft.Json;
+
+public class AppSettingsTests
+{
+    [Fact]
+    public async Task ConcurrentLoadCreatesValidSettingsFile()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string settingsPath = Path.Combine(tempDir, "settings.json");
+        TaskCompletionSource start = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<AppSettings>[] loadTasks = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(async () =>
+            {
+                await start.Task;
+                return AppSettings.Load(settingsPath);
+            }))
+            .ToArray();
+
+        try
+        {
+            start.SetResult();
+            AppSettings[] settings = await Task.WhenAll(loadTasks);
+
+            Assert.All(settings, value => Assert.NotNull(value.Platform));
+            string persistedContent = await File.ReadAllTextAsync(
+                settingsPath, TestContext.Current.CancellationToken);
+            AppSettings? persistedSettings =
+                JsonConvert.DeserializeObject<AppSettings>(persistedContent);
+            Assert.NotNull(persistedSettings);
+            Assert.NotNull(persistedSettings.Platform);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -3,6 +3,7 @@ namespace Valleysoft.Dredge.Tests;
 using Newtonsoft.Json;
 using Spectre.Console;
 using Spectre.Console.Rendering;
+using System.CommandLine;
 using System.Text;
 using Valleysoft.DockerRegistryClient.Models.Images;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
@@ -17,7 +18,7 @@ public class CompareLayersCommandTests
     private static readonly ImageName baseImageName = ImageName.Parse($"{Registry}/base:latest");
     private static readonly ImageName targetImageName = ImageName.Parse($"{Registry}/target:latest");
 
-    public static IEnumerable<TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object>> GetTestData(CompareLayersOutput format)
+    public static IEnumerable<TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object>> GetTestData(CompareOutput format)
     {
         CommandOptions[] optionsSet =
         [
@@ -52,7 +53,7 @@ public class CompareLayersCommandTests
     private static class Scenarios
     {
         // Identical images
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetEqualImagesTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetEqualImagesTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -86,19 +87,19 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json => new CompareLayersResult(
+                CompareOutput.Json => new CompareLayersResult(
                     new CompareLayersSummary(areEqual: true, targetIncludesAllBaseLayers: true, lastCommonLayerIndex: 1),
                     [
                         new LayerComparison(
                             new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
                             new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
-                            LayerDiff.Equal),
+                            CompareDiff.Equal),
                         new LayerComparison(
                             new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 1 : null),
                             new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 1 : null),
-                            LayerDiff.Equal)
+                            CompareDiff.Equal)
                     ]),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -108,13 +109,13 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory ? $"  b{NL}" : string.Empty)
                         .Append(options.IncludeCompressedSize ? $"  Size (compressed): 1 bytes{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 1 bytes", options),
                         EmptyRow(options),
-                        DigestRow("layer-1", "layer-1", options, LayerDiff.Equal),
+                        DigestRow("layer-1", "layer-1", options, CompareDiff.Equal),
                         HistoryRow("b", "b", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 1 bytes", options)
                     ),
@@ -131,7 +132,7 @@ public class CompareLayersCommandTests
         }
 
         // Same base layer, but next layer differs
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetDifferingImagesTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetDifferingImagesTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -191,20 +192,20 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json =>
+                CompareOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: false, lastCommonLayerIndex: 0),
                         [
                             new LayerComparison(
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
-                                LayerDiff.Equal),
+                                CompareDiff.Equal),
                             new LayerComparison(
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 1 : null),
                                 new LayerInfo("layer-1a", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 2 : null),
-                                LayerDiff.NotEqual)
+                                CompareDiff.NotEqual)
                         ]),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -217,13 +218,13 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory ? $"+ b{NL}" : string.Empty)
                         .Append(options.IncludeCompressedSize ? $"+ Size (compressed): 2 bytes{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 1 bytes", options),
                         EmptyRow(options),
-                        DigestRow("layer-1", "layer-1a", options, LayerDiff.NotEqual),
+                        DigestRow("layer-1", "layer-1a", options, CompareDiff.NotEqual),
                         HistoryRow("b", "b", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 2 bytes", options)
                     ),
@@ -240,7 +241,7 @@ public class CompareLayersCommandTests
         }
 
         // Target removes a layer from base
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetRemovedLayerFromBaseTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetRemovedLayerFromBaseTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -291,20 +292,20 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json =>
+                CompareOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: false, lastCommonLayerIndex: 0),
                         [
                             new LayerComparison(
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1000 : null),
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1000 : null),
-                                LayerDiff.Equal),
+                                CompareDiff.Equal),
                             new LayerComparison(
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 2000 : null),
                                 null,
-                                LayerDiff.Removed)
+                                CompareDiff.Removed)
                         ]),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -314,13 +315,13 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory ? $"- b{NL}" : string.Empty)
                         .Append(options.IncludeCompressedSize ? $"- Size (compressed): 2 KB{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 1 KB", "Size (compressed): 1 KB", options),
                         EmptyRow(options),
-                        DigestRow("layer-1", string.Empty, options, LayerDiff.Removed),
+                        DigestRow("layer-1", string.Empty, options, CompareDiff.Removed),
                         HistoryRow("b", string.Empty, options),
                         CompressedSizeRow("Size (compressed): 2 KB", string.Empty, options)
                     ),
@@ -337,7 +338,7 @@ public class CompareLayersCommandTests
         }
 
         // Target adds a layer
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetAddedLayerTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetAddedLayerTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -388,20 +389,20 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json =>
+                CompareOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(areEqual: false, targetIncludesAllBaseLayers: true, lastCommonLayerIndex: 0),
                         [
                             new LayerComparison(
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1000000 : null),
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1000000 : null),
-                                LayerDiff.Equal),
+                                CompareDiff.Equal),
                             new LayerComparison(
                                 null,
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 2000000 : null),
-                                LayerDiff.Added)
+                                CompareDiff.Added)
                         ]),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -411,13 +412,13 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory ? $"+ b{NL}" : string.Empty)
                         .Append(options.IncludeCompressedSize ? $"+ Size (compressed): 1.9 MB{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 976.6 KB", "Size (compressed): 976.6 KB", options),
                         EmptyRow(options),
-                        DigestRow(string.Empty, "layer-1", options, LayerDiff.Added),
+                        DigestRow(string.Empty, "layer-1", options, CompareDiff.Added),
                         HistoryRow(string.Empty, "b", options),
                         CompressedSizeRow(string.Empty, "Size (compressed): 1.9 MB", options)
                     ),
@@ -434,7 +435,7 @@ public class CompareLayersCommandTests
         }
 
         // The images only differ by history
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetDifferByHistoryOnlyTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetDifferByHistoryOnlyTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -494,7 +495,7 @@ public class CompareLayersCommandTests
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json =>
+                CompareOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(
                             areEqual: !options.IncludeHistory,
@@ -504,13 +505,13 @@ public class CompareLayersCommandTests
                             new LayerComparison(
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
                                 new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
-                                LayerDiff.Equal),
+                                CompareDiff.Equal),
                             new LayerComparison(
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b" : null, options.IncludeCompressedSize ? 2 : null),
                                 new LayerInfo("layer-1", options.IncludeHistory ? "b1" : null, options.IncludeCompressedSize ? 2 : null),
-                                options.IncludeHistory ? LayerDiff.NotEqual : LayerDiff.Equal)
+                                options.IncludeHistory ? CompareDiff.NotEqual : CompareDiff.Equal)
                         ]),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -527,13 +528,13 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory && options.IncludeCompressedSize ? "+ " : "  ")
                         .Append(options.IncludeHistory && options.IncludeCompressedSize ? $"Size (compressed): 2 bytes{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 1 bytes", options),
                         EmptyRow(options),
-                        DigestRow("layer-1", "layer-1", options, options.IncludeHistory ? LayerDiff.NotEqual : LayerDiff.Equal),
+                        DigestRow("layer-1", "layer-1", options, options.IncludeHistory ? CompareDiff.NotEqual : CompareDiff.Equal),
                         HistoryRow("b", "b1", options),
                         CompressedSizeRow("Size (compressed): 2 bytes", "Size (compressed): 2 bytes", options)
                     ),
@@ -550,7 +551,7 @@ public class CompareLayersCommandTests
         }
 
         // The images contain empty layers that differ in their history
-        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetWithHistoryDifferingByEmptyLayersTestData(CompareLayersOutput format, CommandOptions options)
+        public static TheoryDataRow<string, CommandOptions, ImageSetup, ImageSetup, object> GetWithHistoryDifferingByEmptyLayersTestData(CompareOutput format, CommandOptions options)
         {
             ImageSetup baseImageSetup = new(
                 new Image
@@ -623,11 +624,11 @@ public class CompareLayersCommandTests
                 new LayerComparison(
                     new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
                     new LayerInfo("layer-0", options.IncludeHistory ? "a" : null, options.IncludeCompressedSize ? 1 : null),
-                    LayerDiff.Equal),
+                    CompareDiff.Equal),
                 new LayerComparison(
                     new LayerInfo("layer-1", options.IncludeHistory ? "c" : null, options.IncludeCompressedSize ? 2 : null),
                     new LayerInfo("layer-1", options.IncludeHistory ? "c" : null, options.IncludeCompressedSize ? 2 : null),
-                    LayerDiff.Equal)
+                    CompareDiff.Equal)
             ];
 
             if (options.IncludeHistory)
@@ -636,19 +637,19 @@ public class CompareLayersCommandTests
                     new LayerComparison(
                         new LayerInfo(null, "b", options.IncludeCompressedSize ? 0 : null),
                         new LayerInfo(null, "b1", options.IncludeCompressedSize ? 0 : null),
-                        LayerDiff.NotEqual));
+                        CompareDiff.NotEqual));
             }
 
             object expectedResult = format switch
             {
-                CompareLayersOutput.Json =>
+                CompareOutput.Json =>
                     new CompareLayersResult(
                         new CompareLayersSummary(
                             areEqual: !options.IncludeHistory,
                             targetIncludesAllBaseLayers: !options.IncludeHistory,
                             lastCommonLayerIndex: options.IncludeHistory ? 0 : 1),
                         comparisons),
-                CompareLayersOutput.Inline =>
+                CompareOutput.Inline =>
                     new StringBuilder()
                         .AppendLine("  layer-0")
                         .Append(options.IncludeHistory ? $"  a{NL}" : string.Empty)
@@ -665,21 +666,21 @@ public class CompareLayersCommandTests
                         .Append(options.IncludeHistory ? $"  c{NL}" : string.Empty)
                         .Append(options.IncludeCompressedSize ? $"  Size (compressed): 2 bytes{NL}" : string.Empty)
                         .ToString(),
-                CompareLayersOutput.SideBySide =>
+                CompareOutput.SideBySide =>
                     ToArray(
-                        DigestRow("layer-0", "layer-0", options, LayerDiff.Equal),
+                        DigestRow("layer-0", "layer-0", options, CompareDiff.Equal),
                         HistoryRow("a", "a", options),
                         CompressedSizeRow("Size (compressed): 1 bytes", "Size (compressed): 1 bytes", options),
                         EmptyRow(options),
                         options.IncludeHistory ?
-                            DigestRow("<empty layer>", "<empty layer>", options, LayerDiff.NotEqual) :
+                            DigestRow("<empty layer>", "<empty layer>", options, CompareDiff.NotEqual) :
                             null,
                         HistoryRow("b", "b1", options),
                         options.IncludeHistory ?
                             CompressedSizeRow("Size (compressed): 0 bytes", "Size (compressed): 0 bytes", options) :
                             null,
                         options.IncludeHistory ? EmptyRow(options) : null,
-                        DigestRow("layer-1", "layer-1", options, LayerDiff.Equal),
+                        DigestRow("layer-1", "layer-1", options, CompareDiff.Equal),
                         HistoryRow("c", "c", options),
                         CompressedSizeRow("Size (compressed): 2 bytes", "Size (compressed): 2 bytes", options)
                     ),
@@ -723,32 +724,88 @@ public class CompareLayersCommandTests
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareLayersOutput.Json)]
+    [MemberData(nameof(GetTestData), CompareOutput.Json)]
     public async Task Json(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, object expectedResult)
     {
-        Text text = (Text)await ExecuteTestAsync(scenario, CompareLayersOutput.Json, cmdOptions, baseImageSetup, targetImageSetup);
+        Text text = (Text)await ExecuteTestAsync(scenario, CompareOutput.Json, cmdOptions, baseImageSetup, targetImageSetup);
 
         CompareLayersResult actualResult = GetJson<CompareLayersResult>(text.GetSegments(AnsiConsole.Console));
         CompareJson(expectedResult, actualResult);
     }
 
+    [Fact]
+    public async Task JsonCommandInvocationDoesNotWrapLongValues()
+    {
+        string longHistory = new('x', 200);
+        ImageSetup setup = new(
+            new Image
+            {
+                History =
+                [
+                    new LayerHistory
+                    {
+                        CreatedBy = longHistory
+                    }
+                ]
+            },
+            [
+                new ManifestLayer
+                {
+                    Digest = "layer-0",
+                    Size = 1
+                }
+            ]);
+        Mock<IDockerRegistryClient> registryClient = new();
+        SetupDockerRegistryClient(registryClient, baseImageName, setup.Image, setup.Layers);
+        SetupDockerRegistryClient(registryClient, targetImageName, setup.Image, setup.Layers);
+        Mock<IDockerRegistryClientFactory> clientFactory = new();
+        clientFactory
+            .Setup(factory => factory.GetClientAsync(Registry))
+            .ReturnsAsync(registryClient.Object);
+        StringWriter output = new();
+        IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(output),
+            Enrichment = new ProfileEnrichment
+            {
+                UseDefaultEnrichers = false
+            }
+        });
+        CompareLayersCommand command = new(clientFactory.Object, console);
+
+        int exitCode = await command
+            .Parse([
+                baseImageName.ToString(),
+                targetImageName.ToString(),
+                "--output",
+                "Json",
+                "--history"])
+            .InvokeAsync(new InvocationConfiguration(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+        CompareLayersResult? result =
+            JsonConvert.DeserializeObject<CompareLayersResult>(output.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(longHistory, result.LayerComparisons.First().Base!.History);
+    }
+
     [Theory]
-    [MemberData(nameof(GetTestData), CompareLayersOutput.Inline)]
+    [MemberData(nameof(GetTestData), CompareOutput.Inline)]
     public async Task Inline(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, object expectedResult)
     {
-        Rows rows = (Rows)await ExecuteTestAsync(scenario, CompareLayersOutput.Inline, cmdOptions, baseImageSetup, targetImageSetup);
+        Rows rows = (Rows)await ExecuteTestAsync(scenario, CompareOutput.Inline, cmdOptions, baseImageSetup, targetImageSetup);
         string actualResult = TestHelper.GetString(rows.GetSegments(AnsiConsole.Console));
         Assert.Equal(TestHelper.Normalize((string)expectedResult), TestHelper.Normalize(actualResult));
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareLayersOutput.SideBySide)]
+    [MemberData(nameof(GetTestData), CompareOutput.SideBySide)]
     public async Task SideBySide(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, object expectedRows)
     {
-        Table table = (Table)await ExecuteTestAsync(scenario, CompareLayersOutput.SideBySide, cmdOptions, baseImageSetup, targetImageSetup);
+        Table table = (Table)await ExecuteTestAsync(scenario, CompareOutput.SideBySide, cmdOptions, baseImageSetup, targetImageSetup);
 
         Assert.Equal(cmdOptions.IsColorDisabled ? 3 : 2, table.Columns.Count);
         Assert.Equal(baseImageName.ToString(), TestHelper.GetString(table.Columns[0].Header.GetSegments(AnsiConsole.Console)));
@@ -774,13 +831,13 @@ public class CompareLayersCommandTests
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareLayersOutput.SideBySide)]
+    [MemberData(nameof(GetTestData), CompareOutput.SideBySide)]
     public async Task SideBySideWithoutAnsi(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, object expectedRows)
     {
         Table table = (Table)await ExecuteTestAsync(
             scenario,
-            CompareLayersOutput.SideBySide,
+            CompareOutput.SideBySide,
             cmdOptions,
             baseImageSetup,
             targetImageSetup,
@@ -792,13 +849,13 @@ public class CompareLayersCommandTests
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData), CompareLayersOutput.SideBySide)]
+    [MemberData(nameof(GetTestData), CompareOutput.SideBySide)]
     public async Task SideBySideWithoutColorSupport(
         string scenario, CommandOptions cmdOptions, ImageSetup baseImageSetup, ImageSetup targetImageSetup, object expectedRows)
     {
         Table table = (Table)await ExecuteTestAsync(
             scenario,
-            CompareLayersOutput.SideBySide,
+            CompareOutput.SideBySide,
             cmdOptions,
             baseImageSetup,
             targetImageSetup,
@@ -811,7 +868,7 @@ public class CompareLayersCommandTests
 
     private static Task<IRenderable> ExecuteTestAsync(
         string scenario,
-        CompareLayersOutput format,
+        CompareOutput format,
         CommandOptions cmdOptions,
         ImageSetup baseImageSetup,
         ImageSetup targetImageSetup,
@@ -898,7 +955,7 @@ public class CompareLayersCommandTests
             ToArray(string.Empty, options.IsColorDisabled ? string.Empty : null, string.Empty) :
             null;
 
-    private static string[] DigestRow(string baseDigest, string targetDigest, CommandOptions options, LayerDiff diff) =>
+    private static string[] DigestRow(string baseDigest, string targetDigest, CommandOptions options, CompareDiff diff) =>
         ToArray(baseDigest, options.IsColorDisabled ? GetDisplayName(diff) : null, targetDigest);
 
     private static string[]? HistoryRow(string baseHistory, string targetHistory, CommandOptions options) =>
@@ -907,13 +964,13 @@ public class CompareLayersCommandTests
     private static string[]? CompressedSizeRow(string baseSize, string targetSize, CommandOptions options) =>
         options.IncludeCompressedSize ? ToArray(baseSize, options.IsColorDisabled ? string.Empty : null, targetSize) : null;
 
-    private static string GetDisplayName(LayerDiff diff) =>
+    private static string GetDisplayName(CompareDiff diff) =>
         diff switch
         {
-            LayerDiff.Equal => "Equal",
-            LayerDiff.NotEqual => "Not Equal",
-            LayerDiff.Added => "Added",
-            LayerDiff.Removed => "Removed",
+            CompareDiff.Equal => "Equal",
+            CompareDiff.NotEqual => "Not Equal",
+            CompareDiff.Added => "Added",
+            CompareDiff.Removed => "Removed",
             _ => throw new NotSupportedException()
         };
 }

--- a/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
@@ -1,0 +1,611 @@
+namespace Valleysoft.Dredge.Tests;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using System.CommandLine;
+using System.Text;
+using Valleysoft.DockerRegistryClient.Models.Images;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+using Valleysoft.Dredge.Commands.Image;
+using ImageData = Valleysoft.DockerRegistryClient.Models.Images.Image;
+
+public class CompareMetadataCommandTests
+{
+    private const string Registry = "test-registry.io";
+    private const string ManifestMediaType = "application/vnd.oci.image.manifest.v1+json";
+    private const string IndexMediaType = "application/vnd.oci.image.index.v1+json";
+    private const string ConfigMediaType = "application/vnd.oci.image.config.v1+json";
+    private const string LayerMediaType = "application/vnd.oci.image.layer.v1.tar+gzip";
+    private static readonly ImageName baseImageName = ImageName.Parse($"{Registry}/base:latest");
+    private static readonly ImageName targetImageName = ImageName.Parse($"{Registry}/target:latest");
+
+    [Fact]
+    public async Task EqualMetadataIgnoresMapAndSetOrdering()
+    {
+        ImageData baseConfig = CreateImageConfig(
+            environmentVariables: ["B=2", "A=1"],
+            labels: new Dictionary<string, string> { ["second"] = "2", ["first"] = "1" },
+            osFeatures: ["feature-b", "feature-a"]);
+        ImageData targetConfig = CreateImageConfig(
+            environmentVariables: ["A=1", "B=2"],
+            labels: new Dictionary<string, string> { ["first"] = "1", ["second"] = "2" },
+            osFeatures: ["feature-a", "feature-b"]);
+        ImageSetup setup = CreateSingleManifestSetup(baseConfig);
+        ImageSetup targetSetup = CreateSingleManifestSetup(targetConfig);
+        CompareMetadataCommand command = CreateCommand(setup, targetSetup);
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.Summary.AreEqual);
+        Assert.All(result.Comparisons, comparison => Assert.Equal(CompareDiff.Equal, comparison.Diff));
+    }
+
+    [Fact]
+    public async Task ReportsAddedRemovedAndChangedMetadata()
+    {
+        ImageData baseConfig = CreateImageConfig(
+            environmentVariables: ["A=1"],
+            labels: new Dictionary<string, string> { ["removed"] = "value" });
+        ImageData targetConfig = CreateImageConfig(
+            environmentVariables: ["A=2", "ADDED=value"],
+            labels: new Dictionary<string, string>());
+        ImageSetup baseSetup = CreateSingleManifestSetup(baseConfig);
+        ImageSetup targetSetup = CreateSingleManifestSetup(
+            targetConfig,
+            layerDigest: "sha256:changed-layer",
+            manifestAnnotations: new Dictionary<string, string> { ["org.example.annotation"] = "new" });
+        CompareMetadataCommand command = CreateCommand(baseSetup, targetSetup);
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(result.Summary.AreEqual);
+        AssertComparison(result, "Config", "environment[\"A\"]", CompareDiff.NotEqual);
+        AssertComparison(result, "Config", "environment[\"ADDED\"]", CompareDiff.Added);
+        AssertComparison(result, "Config", "labels[\"removed\"]", CompareDiff.Removed);
+        AssertComparison(result, "ResolvedManifest", "layers[0].digest", CompareDiff.NotEqual);
+        AssertComparison(result, "Manifest", "annotations[\"org.example.annotation\"]", CompareDiff.Added);
+    }
+
+    [Fact]
+    public async Task HandlesNullOptionalConfigurationFields()
+    {
+        const string NullConfig = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "os.features": null,
+              "config": {
+                "Env": null,
+                "Entrypoint": null,
+                "Cmd": null,
+                "Labels": null,
+                "ExposedPorts": null,
+                "Volumes": null
+              },
+              "rootfs": {
+                "type": "layers",
+                "diff_ids": []
+              },
+              "history": null
+            }
+            """;
+        const string OmittedConfig = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": {},
+              "rootfs": {
+                "type": "layers",
+                "diff_ids": []
+              }
+            }
+            """;
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(NullConfig),
+            CreateSingleManifestSetup(OmittedConfig));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.Summary.AreEqual);
+    }
+
+    [Fact]
+    public async Task HandlesNullOptionalManifestCollections()
+    {
+        OciImageManifest resolvedManifest = CreateManifest();
+        resolvedManifest.Annotations = null!;
+        resolvedManifest.Config.Annotations = null!;
+        resolvedManifest.Config.Urls = null!;
+        resolvedManifest.Layers[0].Annotations = null!;
+        resolvedManifest.Layers[0].Urls = null!;
+        Valleysoft.DockerRegistryClient.Models.Manifests.Oci.ManifestReference reference =
+            CreateReference("linux", "amd64", "sha256:linux");
+        reference.Annotations = null!;
+        reference.Urls = null!;
+        reference.Platform!.OsFeatures = null!;
+        reference.Platform.Features = null!;
+        ImageSetup setup = CreateIndexSetup(
+            CreateImageConfig(),
+            resolvedManifest,
+            [reference],
+            "sha256:index");
+        ((OciImageIndex)setup.InitialManifest.Manifest).Annotations = null!;
+        CompareMetadataCommand command = CreateCommand(setup, setup);
+        command.Options.Os = "linux";
+        command.Options.Architecture = "amd64";
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.Summary.AreEqual);
+    }
+
+    [Fact]
+    public async Task ComparesConfigurationFieldsNotExposedByTheRegistryClientModel()
+    {
+        const string BaseConfig = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": {
+                "Healthcheck": {
+                  "Test": ["CMD", "base"]
+                }
+              },
+              "rootfs": {
+                "type": "layers",
+                "diff_ids": []
+              }
+            }
+            """;
+        const string TargetConfig = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": {
+                "Healthcheck": {
+                  "Test": ["CMD", "target"]
+                }
+              },
+              "rootfs": {
+                "type": "layers",
+                "diff_ids": []
+              }
+            }
+            """;
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(BaseConfig),
+            CreateSingleManifestSetup(TargetConfig));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "healthcheck[\"Test\"][1]", CompareDiff.NotEqual);
+    }
+
+    [Fact]
+    public async Task PreservesEmptyAnnotationAndLabelValues()
+    {
+        ImageData baseConfig = CreateImageConfig(labels: new Dictionary<string, string>());
+        ImageData targetConfig = CreateImageConfig(
+            labels: new Dictionary<string, string> { ["org.example.empty"] = string.Empty });
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(baseConfig),
+            CreateSingleManifestSetup(
+                targetConfig,
+                manifestAnnotations: new Dictionary<string, string>
+                {
+                    ["org.example.empty"] = string.Empty
+                }));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "labels[\"org.example.empty\"]", CompareDiff.Added);
+        AssertComparison(result, "Manifest", "annotations[\"org.example.empty\"]", CompareDiff.Added);
+    }
+
+    [Fact]
+    public async Task PreservesDateLikeConfigurationStrings()
+    {
+        const string BaseTimestamp = "2024-01-15T10:30:00+01:00";
+        const string TargetTimestamp = "2024-01-15T09:30:00Z";
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateImageConfigJson(BaseTimestamp)),
+            CreateSingleManifestSetup(CreateImageConfigJson(TargetTimestamp)));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        MetadataComparison comparison = FindComparison(
+            result,
+            "Config",
+            "labels[\"org.opencontainers.image.created\"]");
+        Assert.Equal(CompareDiff.NotEqual, comparison.Diff);
+        Assert.Equal(JTokenType.String, comparison.BaseValue!.Type);
+        Assert.Equal(BaseTimestamp, comparison.BaseValue.Value<string>());
+        Assert.Equal(TargetTimestamp, comparison.TargetValue!.Value<string>());
+    }
+
+    [Fact]
+    public async Task TreatsCommandOrderAsSignificant()
+    {
+        ImageData baseConfig = CreateImageConfig();
+        ImageData targetConfig = CreateImageConfig();
+        baseConfig.Config!.CommandArgs = ["first", "second"];
+        targetConfig.Config!.CommandArgs = ["second", "first"];
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(baseConfig),
+            CreateSingleManifestSetup(targetConfig));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "command[0]", CompareDiff.NotEqual);
+        AssertComparison(result, "Config", "command[1]", CompareDiff.NotEqual);
+    }
+
+    [Fact]
+    public async Task ComparesFullPlatformIndexWhileResolvingSelectedPlatform()
+    {
+        ImageData config = CreateImageConfig();
+        OciImageManifest selectedManifest = CreateManifest();
+        ImageSetup baseSetup = CreateIndexSetup(
+            config,
+            selectedManifest,
+            [
+                CreateReference("linux", "amd64", "sha256:linux"),
+                CreateReference("windows", "amd64", "sha256:windows-base", "10.0")
+            ],
+            "sha256:index-base");
+        ImageSetup targetSetup = CreateIndexSetup(
+            config,
+            selectedManifest,
+            [
+                CreateReference("linux", "amd64", "sha256:linux"),
+                CreateReference("windows", "amd64", "sha256:windows-target", "10.0"),
+                CreateReference("linux", "arm64", "sha256:arm64")
+            ],
+            "sha256:index-target");
+        CompareMetadataCommand command = CreateCommand(baseSetup, targetSetup);
+        command.Options.Os = "linux";
+        command.Options.Architecture = "amd64";
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(
+            result,
+            "Platforms",
+            "available[\"windows/amd64/10.0\"].digest",
+            CompareDiff.NotEqual);
+        AssertComparison(
+            result,
+            "Platforms",
+            "available[\"linux/arm64\"].digest",
+            CompareDiff.Added);
+        Assert.Equal(
+            CompareDiff.Equal,
+            FindComparison(result, "ResolvedManifest", "config.digest").Diff);
+    }
+
+    [Theory]
+    [InlineData(CompareOutput.Inline, typeof(Rows))]
+    [InlineData(CompareOutput.SideBySide, typeof(Table))]
+    [InlineData(CompareOutput.Json, typeof(Text))]
+    public async Task SupportsOutputFormats(CompareOutput output, Type expectedType)
+    {
+        ImageSetup baseSetup = CreateSingleManifestSetup(CreateImageConfig(environmentVariables: ["A=1"]));
+        ImageSetup targetSetup = CreateSingleManifestSetup(CreateImageConfig(environmentVariables: ["A=2"]));
+        CompareMetadataCommand command = CreateCommand(baseSetup, targetSetup, output);
+
+        IRenderable rendered = await command.GetOutputAsync(TestContext.Current.CancellationToken);
+
+        Assert.IsType(expectedType, rendered);
+        string text = TestHelper.GetString(rendered.GetSegments(AnsiConsole.Console));
+        Assert.Contains(output == CompareOutput.Json ? "\"areEqual\": false" : "Config.environment[\"A\"]", text);
+    }
+
+    [Fact]
+    public async Task SideBySideUsesComparisonColumnWhenColorIsUnavailable()
+    {
+        ImageSetup setup = CreateSingleManifestSetup(CreateImageConfig());
+        CompareMetadataCommand command = CreateCommand(
+            setup,
+            setup,
+            ansiSupported: false);
+
+        Table output = (Table)await command.GetOutputAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, output.Columns.Count);
+        Assert.Equal("Compare", TestHelper.GetString(output.Columns[2].Header.GetSegments(AnsiConsole.Console)));
+    }
+
+    [Fact]
+    public async Task CommandInvocationReturnsSuccessWhenDifferencesAreFound()
+    {
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateImageConfig(environmentVariables: ["A=1"])),
+            CreateSingleManifestSetup(CreateImageConfig(environmentVariables: ["A=2"])));
+
+        int exitCode = await command
+            .Parse([baseImageName.ToString(), targetImageName.ToString(), "--output", "Json"])
+            .InvokeAsync(new InvocationConfiguration(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task CommandInvocationWritesParseableJsonWithoutWrapping()
+    {
+        string longValue = new('x', 200);
+        StringWriter output = new();
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateImageConfig(labels:
+                new Dictionary<string, string> { ["long"] = longValue })),
+            CreateSingleManifestSetup(CreateImageConfig()),
+            CompareOutput.Json,
+            outputWriter: output);
+
+        int exitCode = await command
+            .Parse([baseImageName.ToString(), targetImageName.ToString(), "--output", "Json"])
+            .InvokeAsync(new InvocationConfiguration(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+        CompareMetadataResult? result =
+            JsonConvert.DeserializeObject<CompareMetadataResult>(output.ToString());
+        Assert.NotNull(result);
+        Assert.Contains(
+            result.Comparisons,
+            comparison => comparison.BaseValue?.Value<string>() == longValue);
+    }
+
+    [Fact]
+    public void IsRegisteredUnderImageCompare()
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+        CompareCommand compareCommand = new(factory.Object);
+
+        Command metadataCommand = Assert.Single(
+            compareCommand.Subcommands,
+            command => command.Name == "metadata");
+
+        Assert.Contains(metadataCommand.Options, option => option.Name == "--output");
+        Assert.Contains(metadataCommand.Options, option => option.Name == "--no-color");
+        Assert.Contains(metadataCommand.Options, option => option.Name == "--os");
+        Assert.Contains(metadataCommand.Options, option => option.Name == "--arch");
+        Assert.Contains(metadataCommand.Options, option => option.Name == "--os-version");
+    }
+
+    private static void AssertComparison(
+        CompareMetadataResult result,
+        string category,
+        string path,
+        CompareDiff expectedDiff) =>
+        Assert.Equal(expectedDiff, FindComparison(result, category, path).Diff);
+
+    private static MetadataComparison FindComparison(
+        CompareMetadataResult result,
+        string category,
+        string path) =>
+        Assert.Single(
+            result.Comparisons,
+            comparison => comparison.Category == category && comparison.Path == path);
+
+    private static CompareMetadataCommand CreateCommand(
+        ImageSetup baseSetup,
+        ImageSetup targetSetup,
+        CompareOutput output = CompareOutput.SideBySide,
+        bool ansiSupported = true,
+        StringWriter? outputWriter = null)
+    {
+        Mock<IDockerRegistryClient> client = new();
+        SetupImage(client, baseImageName, baseSetup);
+        SetupImage(client, targetImageName, targetSetup);
+
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory
+            .Setup(clientFactory => clientFactory.GetClientAsync(Registry))
+            .ReturnsAsync(client.Object);
+
+        CompareMetadataCommand command = new(
+            factory.Object,
+            CreateConsole(ansiSupported, outputWriter),
+            () => new PlatformSettings());
+        command.Options.BaseImage = baseImageName.ToString();
+        command.Options.TargetImage = targetImageName.ToString();
+        command.Options.OutputFormat = output;
+        return command;
+    }
+
+    private static IAnsiConsole CreateConsole(bool ansiSupported = true, StringWriter? output = null) =>
+        AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = ansiSupported ? AnsiSupport.Yes : AnsiSupport.No,
+            ColorSystem = ansiSupported ? ColorSystemSupport.EightBit : ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output ?? new StringWriter()),
+            Enrichment = new ProfileEnrichment
+            {
+                UseDefaultEnrichers = false
+            }
+        });
+
+    private static string CreateImageConfigJson(string created) =>
+        $$"""
+          {
+            "architecture": "amd64",
+            "os": "linux",
+            "config": {
+              "Labels": {
+                "org.opencontainers.image.created": "{{created}}"
+              }
+            },
+            "rootfs": {
+              "type": "layers",
+              "diff_ids": []
+            }
+          }
+          """;
+
+    private static void SetupImage(
+        Mock<IDockerRegistryClient> client,
+        ImageName imageName,
+        ImageSetup setup)
+    {
+        client
+            .Setup(registryClient => registryClient.Manifests.GetAsync(
+                imageName.Repo,
+                imageName.Tag!,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(setup.InitialManifest);
+
+        if (setup.ResolvedManifest is not null)
+        {
+            string resolvedDigest = ((IManifestList)setup.InitialManifest.Manifest).Manifests
+                .Single(reference => reference.Platform?.Os == "linux" && reference.Platform.Architecture == "amd64")
+                .Digest;
+            client
+                .Setup(registryClient => registryClient.Manifests.GetAsync(
+                    imageName.Repo,
+                    resolvedDigest,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(setup.ResolvedManifest);
+        }
+
+        string configDigest = (setup.ResolvedManifest?.Manifest as IImageManifest ??
+            (IImageManifest)setup.InitialManifest.Manifest).Config!.Digest;
+        client
+            .Setup(registryClient => registryClient.Blobs.GetAsync(
+                imageName.Repo,
+                configDigest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(setup.Config)));
+    }
+
+    private static ImageSetup CreateSingleManifestSetup(
+        ImageData config,
+        string layerDigest = "sha256:layer",
+        IDictionary<string, string>? manifestAnnotations = null)
+        => CreateSingleManifestSetup(
+            System.Text.Json.JsonSerializer.Serialize(config),
+            layerDigest,
+            manifestAnnotations);
+
+    private static ImageSetup CreateSingleManifestSetup(
+        string config,
+        string layerDigest = "sha256:layer",
+        IDictionary<string, string>? manifestAnnotations = null)
+    {
+        OciImageManifest manifest = CreateManifest(layerDigest, manifestAnnotations);
+        return new ImageSetup(
+            new ManifestInfo(ManifestMediaType, "sha256:manifest", manifest),
+            null,
+            config);
+    }
+
+    private static ImageSetup CreateIndexSetup(
+        ImageData config,
+        OciImageManifest resolvedManifest,
+        Valleysoft.DockerRegistryClient.Models.Manifests.Oci.ManifestReference[] references,
+        string indexDigest)
+    {
+        OciImageIndex index = new()
+        {
+            SchemaVersion = 2,
+            Manifests = references,
+            Annotations = new Dictionary<string, string> { ["org.example.index"] = "value" }
+        };
+
+        return new ImageSetup(
+            new ManifestInfo(IndexMediaType, indexDigest, index),
+            new ManifestInfo(ManifestMediaType, "sha256:linux", resolvedManifest),
+            System.Text.Json.JsonSerializer.Serialize(config));
+    }
+
+    private static OciImageManifest CreateManifest(
+        string layerDigest = "sha256:layer",
+        IDictionary<string, string>? annotations = null) =>
+        new()
+        {
+            Config = new OciDescriptor
+            {
+                MediaType = ConfigMediaType,
+                Digest = "sha256:config",
+                Size = 100
+            },
+            Layers =
+            [
+                new OciDescriptor
+                {
+                    MediaType = LayerMediaType,
+                    Digest = layerDigest,
+                    Size = 200,
+                    Annotations = new Dictionary<string, string>
+                    {
+                        ["org.example.layer"] = "value"
+                    }
+                }
+            ],
+            Annotations = annotations ?? new Dictionary<string, string>()
+        };
+
+    private static Valleysoft.DockerRegistryClient.Models.Manifests.Oci.ManifestReference CreateReference(
+        string os,
+        string architecture,
+        string digest,
+        string? osVersion = null) =>
+        new()
+        {
+            MediaType = ManifestMediaType,
+            Digest = digest,
+            Size = 300,
+            Platform = new ManifestPlatform
+            {
+                Os = os,
+                Architecture = architecture,
+                OsVersion = osVersion
+            }
+        };
+
+    private static ImageData CreateImageConfig(
+        string[]? environmentVariables = null,
+        IDictionary<string, string>? labels = null,
+        string[]? osFeatures = null) =>
+        new()
+        {
+            Created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            Author = "Dredge",
+            Architecture = "amd64",
+            Os = "linux",
+            OsFeatures = osFeatures ?? [],
+            Config = new ImageConfig
+            {
+                User = "1000",
+                WorkingDir = "/app",
+                EntrypointArgs = ["/app/start"],
+                CommandArgs = ["--serve"],
+                EnvironmentVariables = environmentVariables ?? [],
+                Labels = labels ?? new Dictionary<string, string>(),
+                ExposedPorts = new Dictionary<string, object> { ["8080/tcp"] = new() },
+                Volumes = new Dictionary<string, object> { ["/data"] = new() }
+            },
+            RootFilesystem = new RootFilesystem
+            {
+                Type = "layers",
+                DiffIds = ["sha256:diff"]
+            },
+            History =
+            [
+                new LayerHistory
+                {
+                    Created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                    CreatedBy = "COPY . /app",
+                    Author = "Dredge",
+                    Comment = "build",
+                    IsEmptyLayer = false
+                }
+            ]
+        };
+
+    private sealed record ImageSetup(
+        ManifestInfo InitialManifest,
+        ManifestInfo? ResolvedManifest,
+        string Config);
+}

--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -30,11 +30,11 @@ internal partial class AppSettings
                 AppSettings settings = new();
                 string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
 
-                string dirName = Path.GetDirectoryName(settingsPath)!;
-                if (!Directory.Exists(dirName))
-                {
-                    Directory.CreateDirectory(dirName);
-                }
+string? dirName = Path.GetDirectoryName(settingsPath);
+if (!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
+{
+    Directory.CreateDirectory(dirName);
+}
 
                 File.WriteAllText(settingsPath, settingsStr);
                 return settings;

--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -30,11 +30,11 @@ internal partial class AppSettings
                 AppSettings settings = new();
                 string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
 
-string? dirName = Path.GetDirectoryName(settingsPath);
-if (!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
-{
-    Directory.CreateDirectory(dirName);
-}
+                string? dirName = Path.GetDirectoryName(settingsPath);
+                if (!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
+                {
+                    Directory.CreateDirectory(dirName);
+                }
 
                 File.WriteAllText(settingsPath, settingsStr);
                 return settings;

--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -4,6 +4,8 @@ namespace Valleysoft.Dredge;
 
 internal partial class AppSettings
 {
+    private static readonly object settingsFileLock = new();
+
     public static readonly string SettingsPath =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Valleysoft.Dredge", "settings.json");
 
@@ -17,33 +19,39 @@ internal partial class AppSettings
 
     private AppSettings() {}
 
-    public static AppSettings Load()
-    {
-        if (!File.Exists(SettingsPath))
-        {
-            AppSettings settings = new();
-            string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
+    public static AppSettings Load() => Load(SettingsPath);
 
-            string dirName = Path.GetDirectoryName(SettingsPath)!;
-            if (!Directory.Exists(dirName))
+    internal static AppSettings Load(string settingsPath)
+    {
+        lock (settingsFileLock)
+        {
+            if (!File.Exists(settingsPath))
             {
-                Directory.CreateDirectory(dirName);
+                AppSettings settings = new();
+                string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
+
+                string dirName = Path.GetDirectoryName(settingsPath)!;
+                if (!Directory.Exists(dirName))
+                {
+                    Directory.CreateDirectory(dirName);
+                }
+
+                File.WriteAllText(settingsPath, settingsStr);
+                return settings;
             }
 
-            File.WriteAllText(SettingsPath, settingsStr);
-            return settings;
-        }
-        else
-        {
-            string settings = File.ReadAllText(SettingsPath);
-            return JsonConvert.DeserializeObject<AppSettings>(settings)!;
+            string settingsContent = File.ReadAllText(settingsPath);
+            return JsonConvert.DeserializeObject<AppSettings>(settingsContent)!;
         }
     }
 
     public void Save()
     {
-        string settingsStr = JsonConvert.SerializeObject(this, JsonHelper.Settings);
-        File.WriteAllText(SettingsPath, settingsStr);
+        lock (settingsFileLock)
+        {
+            string settingsStr = JsonConvert.SerializeObject(this, JsonHelper.Settings);
+            File.WriteAllText(SettingsPath, settingsStr);
+        }
     }
 }
 

--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -21,32 +21,37 @@ internal static class CommandHelper
         }
         catch (Exception e)
         {
-            ConsoleColor savedColor = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Red;
-
-            string message = e.Message;
-            if (e is RegistryException dockerRegistryException)
-            {
-                Error? error = dockerRegistryException.Errors.FirstOrDefault();
-                if (error?.Code == "UNAUTHORIZED")
-                {
-                    string loginCommand = "docker login";
-                    if (registry is not null)
-                    {
-                        loginCommand += $" {registry}";
-                    }
-
-                    message = $"The repository does not exist or may require authentication. If authentication is required, ensure that your credentials are stored for the registry by running '{loginCommand}'.";
-                }
-                else
-                {
-                    message = error?.Message ?? message;
-                }
-            }
-
-            (errorWriter ?? Console.Error).WriteLine(message);
-            Console.ForegroundColor = savedColor;
+            WriteError(e, registry, errorWriter);
             Environment.Exit(1);
         }
+    }
+
+    private static void WriteError(Exception e, string? registry, TextWriter? errorWriter)
+    {
+        ConsoleColor savedColor = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+
+        string message = e.Message;
+        if (e is RegistryException dockerRegistryException)
+        {
+            Error? error = dockerRegistryException.Errors.FirstOrDefault();
+            if (error?.Code == "UNAUTHORIZED")
+            {
+                string loginCommand = "docker login";
+                if (registry is not null)
+                {
+                    loginCommand += $" {registry}";
+                }
+
+                message = $"The repository does not exist or may require authentication. If authentication is required, ensure that your credentials are stored for the registry by running '{loginCommand}'.";
+            }
+            else
+            {
+                message = error?.Message ?? message;
+            }
+        }
+
+        (errorWriter ?? Console.Error).WriteLine(message);
+        Console.ForegroundColor = savedColor;
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareCommand.cs
@@ -9,5 +9,6 @@ public class CompareCommand : Command
     {
         Subcommands.Add(new CompareLayersCommand(dockerRegistryClientFactory));
         Subcommands.Add(new CompareFilesCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new CompareMetadataCommand(dockerRegistryClientFactory));
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -27,14 +27,27 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
     {
         return CommandHelper.ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
         {
-            IRenderable output = await GetOutputAsync(ct);
-            ansiConsole.Write(output);
+            CompareLayersResult result = await GetCompareLayersResult(ct);
+            if (Options.OutputFormat == CompareOutput.Json)
+            {
+                ansiConsole.Profile.Out.Writer.WriteLine(
+                    JsonConvert.SerializeObject(result, JsonHelper.Settings));
+            }
+            else
+            {
+                ansiConsole.Write(GetOutput(result));
+            }
         });
     }
 
     public async Task<IRenderable> GetOutputAsync(CancellationToken cancellationToken = default)
     {
         CompareLayersResult result = await GetCompareLayersResult(cancellationToken);
+        return GetOutput(result);
+    }
+
+    private IRenderable GetOutput(CompareLayersResult result)
+    {
         OutputFormatter formatter = OutputFormatter.Create(Options.OutputFormat);
         bool isColorDisabled =
             Options.IsColorDisabled ||
@@ -58,11 +71,11 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
 
     private static CompareLayersSummary GetSummary(List<LayerComparison> layerComparisons)
     {
-        bool areEqual = layerComparisons.All(comparison => comparison.LayerDiff == LayerDiff.Equal);
+        bool areEqual = layerComparisons.All(comparison => comparison.LayerDiff == CompareDiff.Equal);
         bool targetIncludesAllBaseLayers =
             areEqual ||
             !layerComparisons
-                .Any(comparison => comparison.LayerDiff == LayerDiff.NotEqual || comparison.LayerDiff == LayerDiff.Removed);
+                .Any(comparison => comparison.LayerDiff == CompareDiff.NotEqual || comparison.LayerDiff == CompareDiff.Removed);
         int lastCommonLayerIndex = -1;
         if (areEqual)
         {
@@ -71,7 +84,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
         else
         {
             int equalLayerCount = layerComparisons
-                .TakeWhile(comparison => comparison.LayerDiff == LayerDiff.Equal)
+                .TakeWhile(comparison => comparison.LayerDiff == CompareDiff.Equal)
                 .Count();
             if (equalLayerCount >= 0)
             {
@@ -100,14 +113,14 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                 targetLayer = targetLayers[i];
             }
 
-            LayerDiff diff = GetLayerDiff(baseLayer, targetLayer);
+            CompareDiff diff = GetLayerDiff(baseLayer, targetLayer);
             layerComparisons.Add(new LayerComparison(baseLayer, targetLayer, diff));
         }
 
         return layerComparisons;
     }
 
-    private static LayerDiff GetLayerDiff(LayerInfo? baseLayer, LayerInfo? targetLayer)
+    private static CompareDiff GetLayerDiff(LayerInfo? baseLayer, LayerInfo? targetLayer)
     {
         if (baseLayer is null)
         {
@@ -116,46 +129,46 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                 throw new Exception("Unexpected layer result: two null layers");
             }
 
-            return LayerDiff.Added;
+            return CompareDiff.Added;
         }
         else
         {
             if (targetLayer is null)
             {
-                return LayerDiff.Removed;
+                return CompareDiff.Removed;
             }
             else
             {
                 if (string.Equals(baseLayer.Digest, targetLayer.Digest, StringComparison.OrdinalIgnoreCase) &&
                     string.Equals(baseLayer.History, targetLayer.History, StringComparison.Ordinal))
                 {
-                    return LayerDiff.Equal;
+                    return CompareDiff.Equal;
                 }
                 else
                 {
-                    return LayerDiff.NotEqual;
+                    return CompareDiff.NotEqual;
                 }
             }
         }
     }
 
-    private static Color GetLayerDiffColor(LayerDiff diff, bool isBaseLayer, bool isColorDisabled) =>
+    private static Color GetLayerDiffColor(CompareDiff diff, bool isBaseLayer, bool isColorDisabled) =>
         isColorDisabled ? Color.Default : diff switch
         {
-            LayerDiff.Removed => Color.Red,
-            LayerDiff.Added => Color.Green,
-            LayerDiff.NotEqual => isBaseLayer ? Color.Red : Color.Green,
-            LayerDiff.Equal => Color.Default,
+            CompareDiff.Removed => Color.Red,
+            CompareDiff.Added => Color.Green,
+            CompareDiff.NotEqual => isBaseLayer ? Color.Red : Color.Green,
+            CompareDiff.Equal => Color.Default,
             _ => throw new NotImplementedException()
         };
 
-    private static Markup GetLayerDataMarkup(string? layerData, LayerDiff diff, bool isBase, bool isColorDisabled,
+    private static Markup GetLayerDataMarkup(string? layerData, CompareDiff diff, bool isBase, bool isColorDisabled,
         bool isInline) =>
         new(
             Markup.Escape($"{GetTextOffset(diff, isInline, isBase)}{layerData ?? string.Empty}"),
             new Style(GetLayerDiffColor(diff, isBaseLayer: isBase, isColorDisabled)));
 
-    private static Markup GetDigestMarkup(LayerInfo? layer, LayerDiff diff, bool isBase, bool isColorDisabled,
+    private static Markup GetDigestMarkup(LayerInfo? layer, CompareDiff diff, bool isBase, bool isColorDisabled,
         bool includeSupplementalData, bool isInline)
     {
         if (layer is null)
@@ -182,13 +195,13 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
             new Style(GetLayerDiffColor(diff, isBase, isColorDisabled)));
     }
 
-    private static string GetTextOffset(LayerDiff diff, bool isInline, bool isBase) =>
+    private static string GetTextOffset(CompareDiff diff, bool isInline, bool isBase) =>
         !isInline ? string.Empty : diff switch
         {
-            LayerDiff.Added => "+ ",
-            LayerDiff.Equal => "  ",
-            LayerDiff.NotEqual => isBase ? "- " : "+ ",
-            LayerDiff.Removed => "- ",
+            CompareDiff.Added => "+ ",
+            CompareDiff.Equal => "  ",
+            CompareDiff.NotEqual => isBase ? "- " : "+ ",
+            CompareDiff.Removed => "- ",
             _ => throw new NotImplementedException()
         };
 
@@ -274,12 +287,12 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
 
     private abstract class OutputFormatter
     {
-        public static OutputFormatter Create(CompareLayersOutput outputFormat) =>
+        public static OutputFormatter Create(CompareOutput outputFormat) =>
             outputFormat switch
             {
-                CompareLayersOutput.Inline => new InlineFormatter(),
-                CompareLayersOutput.Json => new JsonFormatter(),
-                CompareLayersOutput.SideBySide => new SideBySideFormatter(),
+                CompareOutput.Inline => new InlineFormatter(),
+                CompareOutput.Json => new JsonFormatter(),
+                CompareOutput.SideBySide => new SideBySideFormatter(),
                 _ => throw new NotImplementedException()
             };
 
@@ -380,10 +393,10 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                 return shaCells;
             }
 
-            private static string GetLayerDiffDisplayName(LayerDiff diff) =>
+            private static string GetLayerDiffDisplayName(CompareDiff diff) =>
                 diff switch
                 {
-                    LayerDiff.NotEqual => "Not Equal",
+                    CompareDiff.NotEqual => "Not Equal",
                     _ => diff.ToString(),
                 };
         }
@@ -408,7 +421,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                             options.IncludeCompressedSize);
                     }
 
-                    if (layerComparison.LayerDiff != LayerDiff.Equal && layerComparison.Target is not null)
+                    if (layerComparison.LayerDiff != CompareDiff.Equal && layerComparison.Target is not null)
                     {
                         AddInlineLayerInfo(
                             rows, layerComparison.Target, layerComparison.LayerDiff, isBase: false, isColorDisabled, options.IncludeHistory,
@@ -425,7 +438,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                 return new Rows(rows);
             }
 
-            private static void AddInlineLayerInfo(List<IRenderable> rows, LayerInfo layer, LayerDiff diff, bool isBase,
+            private static void AddInlineLayerInfo(List<IRenderable> rows, LayerInfo layer, CompareDiff diff, bool isBase,
                 bool isColorDisabled, bool includeHistory, bool includeCompressedSize)
             {
                 rows.Add(GetDigestMarkup(layer, diff, isBase, isColorDisabled, includeHistory || includeCompressedSize, isInline: true));

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersOptions.cs
@@ -4,19 +4,19 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class CompareLayersOptions : CompareOptionsBase
 {
-    private readonly Option<CompareLayersOutput> outputOption;
+    private readonly Option<CompareOutput> outputOption;
     private readonly Option<bool> noColorOption;
     private readonly Option<bool> historyOption;
     private readonly Option<bool> compressedSizeOption;
 
-    public CompareLayersOutput OutputFormat { get; set; }
+    public CompareOutput OutputFormat { get; set; }
     public bool IsColorDisabled { get; set; }
     public bool IncludeHistory { get; set; }
     public bool IncludeCompressedSize { get; set; }
 
     public CompareLayersOptions()
     {
-        outputOption = Add(new Option<CompareLayersOutput>("--output") { Description = "Output format", DefaultValueFactory = _ => CompareLayersOutput.SideBySide });
+        outputOption = Add(new Option<CompareOutput>("--output") { Description = "Output format", DefaultValueFactory = _ => CompareOutput.SideBySide });
         noColorOption = Add(new Option<bool>("--no-color") { Description = "Disables dependency on color in comparison results" });
         historyOption = Add(new Option<bool>("--history") { Description = "Include layer history as part of the comparison" });
         compressedSizeOption = Add(new Option<bool>("--compressed-size") { Description = "Show the compressed size of the layer" });

--- a/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
@@ -1,0 +1,634 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions>
+{
+    private static readonly JsonSerializerSettings imageConfigJsonSettings = new()
+    {
+        DateParseHandling = DateParseHandling.None
+    };
+
+    private readonly IAnsiConsole ansiConsole;
+    private readonly Func<PlatformSettings> platformSettingsProvider;
+
+    public CompareMetadataCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IAnsiConsole? ansiConsole = null)
+        : this(dockerRegistryClientFactory, ansiConsole, () => AppSettings.Load().Platform)
+    {
+    }
+
+    internal CompareMetadataCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IAnsiConsole? ansiConsole,
+        Func<PlatformSettings> platformSettingsProvider)
+        : base("metadata", "Compares two images by configuration and platform metadata", dockerRegistryClientFactory)
+    {
+        this.ansiConsole = ansiConsole ?? AnsiConsole.Console;
+        this.platformSettingsProvider = platformSettingsProvider;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        return CommandHelper.ExecuteCommandAsync(
+            registry: null,
+            cancellationToken,
+            async ct =>
+            {
+                CompareMetadataResult result = await GetResultAsync(ct);
+                if (Options.OutputFormat == CompareOutput.Json)
+                {
+                    WriteJson(result);
+                }
+                else
+                {
+                    ansiConsole.Write(GetOutput(result));
+                }
+            });
+    }
+
+    public async Task<CompareMetadataResult> GetResultAsync(CancellationToken cancellationToken = default)
+    {
+        Task<MetadataDocument> baseTask = GetMetadataAsync(Options.BaseImage, cancellationToken);
+        Task<MetadataDocument> targetTask = GetMetadataAsync(Options.TargetImage, cancellationToken);
+        await Task.WhenAll(baseTask, targetTask);
+        MetadataDocument baseDocument = await baseTask;
+        MetadataDocument targetDocument = await targetTask;
+        List<MetadataComparison> comparisons = Compare(baseDocument, targetDocument);
+
+        CompareMetadataSummary summary = new(
+            areEqual: comparisons.All(comparison => comparison.Diff == CompareDiff.Equal),
+            equal: comparisons.Count(comparison => comparison.Diff == CompareDiff.Equal),
+            changed: comparisons.Count(comparison => comparison.Diff == CompareDiff.NotEqual),
+            added: comparisons.Count(comparison => comparison.Diff == CompareDiff.Added),
+            removed: comparisons.Count(comparison => comparison.Diff == CompareDiff.Removed));
+
+        return new CompareMetadataResult(summary, comparisons);
+    }
+
+    public async Task<IRenderable> GetOutputAsync(CancellationToken cancellationToken = default) =>
+        GetOutput(await GetResultAsync(cancellationToken));
+
+    private void WriteJson(CompareMetadataResult result) =>
+        ansiConsole.Profile.Out.Writer.WriteLine(JsonConvert.SerializeObject(result, JsonHelper.Settings));
+
+    private IRenderable GetOutput(CompareMetadataResult result)
+    {
+        bool isColorDisabled =
+            Options.IsColorDisabled ||
+            !ansiConsole.Profile.Capabilities.Ansi ||
+            ansiConsole.Profile.Capabilities.ColorSystem == ColorSystem.NoColors;
+
+        return Options.OutputFormat switch
+        {
+            CompareOutput.SideBySide => GetSideBySideOutput(result, isColorDisabled),
+            CompareOutput.Inline => GetInlineOutput(result, isColorDisabled),
+            CompareOutput.Json => new Text(JsonConvert.SerializeObject(result, JsonHelper.Settings)),
+            _ => throw new NotSupportedException($"Unsupported metadata comparison output format '{Options.OutputFormat}'.")
+        };
+    }
+
+    private Table GetSideBySideOutput(CompareMetadataResult result, bool isColorDisabled)
+    {
+        Table table = new Table()
+            .AddColumn("Metadata")
+            .AddColumn(Options.BaseImage);
+
+        if (isColorDisabled)
+        {
+            table.AddColumn(new TableColumn("Compare") { Alignment = Justify.Center });
+        }
+
+        table.AddColumn(Options.TargetImage);
+
+        foreach (MetadataComparison comparison in result.Comparisons)
+        {
+            List<IRenderable> cells =
+            [
+                new Markup(Markup.Escape($"{comparison.Category}.{comparison.Path}")),
+                GetValueMarkup(comparison.BaseValue, comparison.Diff, isBase: true, isColorDisabled)
+            ];
+
+            if (isColorDisabled)
+            {
+                cells.Add(new Markup(GetDiffDisplayName(comparison.Diff)));
+            }
+
+            cells.Add(GetValueMarkup(comparison.TargetValue, comparison.Diff, isBase: false, isColorDisabled));
+            table.AddRow(cells);
+        }
+
+        return table;
+    }
+
+    private static Rows GetInlineOutput(CompareMetadataResult result, bool isColorDisabled)
+    {
+        List<IRenderable> rows = [];
+
+        foreach (MetadataComparison comparison in result.Comparisons)
+        {
+            string path = $"{comparison.Category}.{comparison.Path}";
+            if (comparison.Diff == CompareDiff.Equal)
+            {
+                rows.Add(GetInlineMarkup("  ", path, comparison.BaseValue, Color.Default));
+                continue;
+            }
+
+            if (comparison.Diff is CompareDiff.NotEqual or CompareDiff.Removed)
+            {
+                rows.Add(GetInlineMarkup(
+                    "- ",
+                    path,
+                    comparison.BaseValue,
+                    isColorDisabled ? Color.Default : Color.Red));
+            }
+
+            if (comparison.Diff is CompareDiff.NotEqual or CompareDiff.Added)
+            {
+                rows.Add(GetInlineMarkup(
+                    "+ ",
+                    path,
+                    comparison.TargetValue,
+                    isColorDisabled ? Color.Default : Color.Green));
+            }
+        }
+
+        return new Rows(rows);
+    }
+
+    private static Markup GetInlineMarkup(string prefix, string path, JToken? value, Color color) =>
+        new(Markup.Escape($"{prefix}{path} = {FormatValue(value)}"), new Style(color));
+
+    private static Markup GetValueMarkup(
+        JToken? value,
+        CompareDiff diff,
+        bool isBase,
+        bool isColorDisabled)
+    {
+        Color color = isColorDisabled ? Color.Default : diff switch
+        {
+            CompareDiff.NotEqual => isBase ? Color.Red : Color.Green,
+            CompareDiff.Added => isBase ? Color.Default : Color.Green,
+            CompareDiff.Removed => isBase ? Color.Red : Color.Default,
+            _ => Color.Default
+        };
+
+        return new Markup(Markup.Escape(FormatValue(value)), new Style(color));
+    }
+
+    private static string FormatValue(JToken? value) =>
+        value is null ? string.Empty : value.ToString(Formatting.None);
+
+    private static string GetDiffDisplayName(CompareDiff diff) =>
+        diff switch
+        {
+            CompareDiff.Equal => "Equal",
+            CompareDiff.NotEqual => "Changed",
+            CompareDiff.Added => "Added",
+            CompareDiff.Removed => "Removed",
+            _ => throw new NotSupportedException()
+        };
+
+    private async Task<MetadataDocument> GetMetadataAsync(string image, CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(image);
+        using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+        // Keep the original manifest because resolving an index discards the platform inventory that must also be compared.
+        ManifestInfo initialManifest = await client.Manifests.GetAsync(
+            imageName.Repo,
+            (imageName.Tag ?? imageName.Digest)!,
+            cancellationToken);
+        ResolvedManifest resolvedManifest = await ManifestHelper.GetResolvedManifestAsync(
+            client,
+            imageName,
+            Options,
+            initialManifest,
+            platformSettingsProvider,
+            cancellationToken);
+
+        string configDigest = resolvedManifest.Manifest.Config?.Digest ??
+            throw new NotSupportedException($"Could not resolve the image config digest of '{image}'.");
+        using Stream configBlob = await client.Blobs.GetAsync(imageName.Repo, configDigest, cancellationToken);
+        using StreamReader configReader = new(configBlob);
+        string configContent = await configReader.ReadToEndAsync(cancellationToken);
+        JObject imageConfig = JsonConvert.DeserializeObject<JObject>(configContent, imageConfigJsonSettings) ??
+            throw new JsonException($"Could not deserialize the image config of '{image}'.");
+
+        MetadataDocument document = new();
+        AddInitialManifest(document, initialManifest);
+        AddResolvedManifest(document, resolvedManifest);
+        AddImageConfig(document, imageConfig);
+        return document;
+    }
+
+    private static void AddInitialManifest(MetadataDocument document, ManifestInfo manifestInfo)
+    {
+        document.Add("Manifest", "schemaVersion", manifestInfo.Manifest.SchemaVersion);
+        document.Add("Manifest", "mediaType", manifestInfo.Manifest.MediaType);
+        document.Add("Manifest", "contentType", manifestInfo.MediaType);
+        document.Add("Manifest", "contentDigest", manifestInfo.DockerContentDigest);
+
+        IEnumerable<KeyValuePair<string, string>>? annotations = manifestInfo.Manifest switch
+        {
+            OciImageIndex index => index.Annotations,
+            OciImageManifest manifest => manifest.Annotations,
+            _ => null
+        };
+        document.AddDictionary("Manifest", "annotations", annotations);
+
+        if (manifestInfo.Manifest is IManifestList manifestList)
+        {
+            AddPlatforms(document, manifestList);
+        }
+    }
+
+    private static void AddPlatforms(MetadataDocument document, IManifestList manifestList)
+    {
+        // Platform identity makes index ordering irrelevant; the suffix keeps duplicate/unknown platform descriptors distinct.
+        foreach (IGrouping<string, IManifestReference> platformGroup in manifestList.Manifests
+            .GroupBy(GetPlatformId)
+            .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            IManifestReference[] references = [.. platformGroup.OrderBy(reference => reference.Digest, StringComparer.Ordinal)];
+            for (int i = 0; i < references.Length; i++)
+            {
+                string id = references.Length == 1 ? platformGroup.Key : $"{platformGroup.Key}#{i + 1}";
+                string path = $"available[{JsonConvert.ToString(id)}]";
+                AddDescriptor(document, "Platforms", path, references[i]);
+                AddPlatform(document, "Platforms", $"{path}.platform", references[i].Platform);
+            }
+        }
+    }
+
+    private static void AddResolvedManifest(MetadataDocument document, ResolvedManifest resolved)
+    {
+        document.Add("ResolvedManifest", "schemaVersion", resolved.Manifest.SchemaVersion);
+        document.Add("ResolvedManifest", "mediaType", resolved.Manifest.MediaType);
+        document.Add("ResolvedManifest", "contentType", resolved.ManifestInfo.MediaType);
+        document.Add("ResolvedManifest", "contentDigest", resolved.ManifestInfo.DockerContentDigest);
+
+        if (resolved.Manifest is OciImageManifest ociManifest)
+        {
+            document.Add("ResolvedManifest", "artifactType", ociManifest.ArtifactType);
+            document.AddDictionary("ResolvedManifest", "annotations", ociManifest.Annotations);
+            if (ociManifest.Subject is not null)
+            {
+                AddDescriptor(document, "ResolvedManifest", "subject", ociManifest.Subject);
+            }
+        }
+
+        if (resolved.Manifest.Config is not null)
+        {
+            AddDescriptor(document, "ResolvedManifest", "config", resolved.Manifest.Config);
+        }
+
+        for (int i = 0; i < resolved.Manifest.Layers.Length; i++)
+        {
+            AddDescriptor(document, "ResolvedManifest", $"layers[{i}]", resolved.Manifest.Layers[i]);
+        }
+    }
+
+    private static void AddDescriptor(
+        MetadataDocument document,
+        string category,
+        string path,
+        IDescriptor descriptor)
+    {
+        document.Add(category, $"{path}.mediaType", descriptor.MediaType);
+        document.Add(category, $"{path}.digest", descriptor.Digest);
+        document.Add(category, $"{path}.size", descriptor.Size);
+
+        if (descriptor is OciDescriptor ociDescriptor)
+        {
+            document.Add(category, $"{path}.artifactType", ociDescriptor.ArtifactType);
+            document.Add(category, $"{path}.data", ociDescriptor.Data);
+            document.AddSet(category, $"{path}.urls", ociDescriptor.Urls);
+            document.AddDictionary(category, $"{path}.annotations", ociDescriptor.Annotations);
+        }
+    }
+
+    private static void AddPlatform(
+        MetadataDocument document,
+        string category,
+        string path,
+        ManifestPlatform? platform)
+    {
+        if (platform is null)
+        {
+            return;
+        }
+
+        document.Add(category, $"{path}.os", platform.Os);
+        document.Add(category, $"{path}.architecture", platform.Architecture);
+        document.Add(category, $"{path}.osVersion", platform.OsVersion);
+        document.Add(category, $"{path}.variant", platform.Variant);
+        document.AddSet(category, $"{path}.osFeatures", platform.OsFeatures);
+        document.AddSet(category, $"{path}.features", platform.Features);
+    }
+
+    private static string GetPlatformId(IManifestReference reference)
+    {
+        ManifestPlatform? platform = reference.Platform;
+        if (platform is null)
+        {
+            return "<unknown>";
+        }
+
+        return string.Join(
+            "/",
+            new[] { platform.Os, platform.Architecture, platform.Variant, platform.OsVersion }
+                .Where(value => !string.IsNullOrEmpty(value)));
+    }
+
+    private static void AddImageConfig(MetadataDocument document, JObject image)
+    {
+        foreach (JProperty property in image.Properties().OrderBy(property => property.Name, StringComparer.Ordinal))
+        {
+            switch (property.Name)
+            {
+                case "config":
+                    AddExecutionConfig(document, property.Value);
+                    break;
+                case "rootfs":
+                    AddRootFilesystem(document, property.Value);
+                    break;
+                case "history":
+                    AddHistory(document, property.Value);
+                    break;
+                case "os.features":
+                    document.AddTokenSet("Image", "osFeatures", property.Value);
+                    break;
+                case "os.version":
+                    document.AddToken("Image", "osVersion", property.Value);
+                    break;
+                default:
+                    document.AddToken("Image", LowerFirstCharacter(property.Name), property.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void AddRootFilesystem(MetadataDocument document, JToken rootFilesystem)
+    {
+        if (rootFilesystem is not JObject rootFilesystemObject)
+        {
+            return;
+        }
+
+        foreach (JProperty property in rootFilesystemObject.Properties()
+            .OrderBy(property => property.Name, StringComparer.Ordinal))
+        {
+            string path = property.Name == "diff_ids" ? "diffIds" : LowerFirstCharacter(property.Name);
+            document.AddToken("RootFilesystem", path, property.Value);
+        }
+    }
+
+    private static void AddHistory(MetadataDocument document, JToken history)
+    {
+        if (history is not JArray historyArray)
+        {
+            return;
+        }
+
+        for (int i = 0; i < historyArray.Count; i++)
+        {
+            if (historyArray[i] is not JObject historyEntry)
+            {
+                document.AddToken("History", $"entries[{i}]", historyArray[i]);
+                continue;
+            }
+
+            foreach (JProperty property in historyEntry.Properties()
+                .OrderBy(property => property.Name, StringComparer.Ordinal))
+            {
+                string propertyName = property.Name switch
+                {
+                    "created_by" => "createdBy",
+                    "empty_layer" => "emptyLayer",
+                    _ => LowerFirstCharacter(property.Name)
+                };
+                document.AddToken("History", $"entries[{i}].{propertyName}", property.Value);
+            }
+        }
+    }
+
+    private static void AddExecutionConfig(MetadataDocument document, JToken config)
+    {
+        if (config is not JObject configObject)
+        {
+            return;
+        }
+
+        foreach (JProperty property in configObject.Properties()
+            .OrderBy(property => property.Name, StringComparer.Ordinal))
+        {
+            switch (property.Name)
+            {
+                case "Env":
+                    AddEnvironment(document, property.Value);
+                    break;
+                case "ExposedPorts":
+                    document.AddObjectKeys("Config", "exposedPorts", property.Value);
+                    break;
+                case "Volumes":
+                    document.AddObjectKeys("Config", "volumes", property.Value);
+                    break;
+                default:
+                    string path = property.Name switch
+                    {
+                        "Cmd" => "command",
+                        "WorkingDir" => "workingDirectory",
+                        _ => LowerFirstCharacter(property.Name)
+                    };
+                    document.AddToken("Config", path, property.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void AddEnvironment(MetadataDocument document, JToken environment)
+    {
+        if (environment is not JArray environmentArray)
+        {
+            return;
+        }
+
+        // Environment order is not significant, but duplicate names remain ordered because the last assignment can affect runtime behavior.
+        foreach (IGrouping<string, string> group in environmentArray
+            .Values<string>()
+            .Where(variable => variable is not null)
+            .Select(variable => ParseEnvironmentVariable(variable!))
+            .GroupBy(variable => variable.Name, variable => variable.Value)
+            .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            string path = $"environment[{JsonConvert.ToString(group.Key)}]";
+            string[] values = [.. group];
+            document.Add(
+                "Config",
+                path,
+                values.Length == 1 ? JValue.CreateString(values[0]) : JArray.FromObject(values));
+        }
+    }
+
+    private static (string Name, string Value) ParseEnvironmentVariable(string variable)
+    {
+        int separatorIndex = variable.IndexOf('=');
+        return separatorIndex < 0
+            ? (variable, string.Empty)
+            : (variable[..separatorIndex], variable[(separatorIndex + 1)..]);
+    }
+
+    private static string LowerFirstCharacter(string value) =>
+        string.IsNullOrEmpty(value) || char.IsLower(value[0])
+            ? value
+            : $"{char.ToLowerInvariant(value[0])}{value[1..]}";
+
+    private static List<MetadataComparison> Compare(MetadataDocument @base, MetadataDocument target)
+    {
+        List<MetadataComparison> comparisons = [];
+        IEnumerable<string> keys = @base.Items.Keys
+            .Union(target.Items.Keys, StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal);
+
+        foreach (string key in keys)
+        {
+            @base.Items.TryGetValue(key, out MetadataItem? baseItem);
+            target.Items.TryGetValue(key, out MetadataItem? targetItem);
+            MetadataItem item = baseItem ?? targetItem!;
+
+            comparisons.Add(new MetadataComparison(
+                item.Category,
+                item.Path,
+                baseItem?.Value,
+                targetItem?.Value,
+                GetDiff(baseItem, targetItem)));
+        }
+
+        return comparisons;
+    }
+
+    private static CompareDiff GetDiff(MetadataItem? baseItem, MetadataItem? targetItem)
+    {
+        if (baseItem is null)
+        {
+            return CompareDiff.Added;
+        }
+
+        if (targetItem is null)
+        {
+            return CompareDiff.Removed;
+        }
+
+        return JToken.DeepEquals(baseItem.Value, targetItem.Value)
+            ? CompareDiff.Equal
+            : CompareDiff.NotEqual;
+    }
+
+    private sealed class MetadataDocument
+    {
+        public SortedDictionary<string, MetadataItem> Items { get; } =
+            new(StringComparer.Ordinal);
+
+        public void Add(string category, string path, object? value)
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            JToken token = value as JToken ?? JToken.FromObject(value);
+            // A null separator cannot collide with the JSON-escaped user keys embedded in paths.
+            Items[$"{category}\0{path}"] = new MetadataItem(category, path, token);
+        }
+
+        public void AddToken(string category, string path, JToken? value)
+        {
+            if (value is null || value.Type is JTokenType.Null or JTokenType.Undefined)
+            {
+                return;
+            }
+
+            if (value is JObject valueObject)
+            {
+                foreach (JProperty property in valueObject.Properties()
+                    .OrderBy(property => property.Name, StringComparer.Ordinal))
+                {
+                    AddToken(category, $"{path}[{JsonConvert.ToString(property.Name)}]", property.Value);
+                }
+            }
+            else if (value is JArray valueArray)
+            {
+                for (int i = 0; i < valueArray.Count; i++)
+                {
+                    AddToken(category, $"{path}[{i}]", valueArray[i]);
+                }
+            }
+            else
+            {
+                Add(category, path, value.DeepClone());
+            }
+        }
+
+        public void AddTokenSet(string category, string path, JToken value)
+        {
+            if (value is not JArray valueArray)
+            {
+                return;
+            }
+
+            AddSet(category, path, valueArray.Values<string>().Where(item => item is not null).Cast<string>());
+        }
+
+        public void AddObjectKeys(string category, string path, JToken value)
+        {
+            if (value is not JObject valueObject)
+            {
+                return;
+            }
+
+            AddKeys(category, path, valueObject.Properties().Select(property => property.Name));
+        }
+
+        public void AddDictionary(
+            string category,
+            string path,
+            IEnumerable<KeyValuePair<string, string>>? values)
+        {
+            if (values is null)
+            {
+                return;
+            }
+
+            foreach ((string key, string value) in values.OrderBy(item => item.Key, StringComparer.Ordinal))
+            {
+                Add(category, $"{path}[{JsonConvert.ToString(key)}]", value);
+            }
+        }
+
+        public void AddSet(string category, string path, IEnumerable<string>? values)
+        {
+            if (values is null)
+            {
+                return;
+            }
+
+            AddKeys(category, path, values.Distinct(StringComparer.Ordinal));
+        }
+
+        private void AddKeys(string category, string path, IEnumerable<string> values)
+        {
+            foreach (string value in values.OrderBy(value => value, StringComparer.Ordinal))
+            {
+                Add(category, $"{path}[{JsonConvert.ToString(value)}]", true);
+            }
+        }
+    }
+
+    private sealed record MetadataItem(string Category, string Path, JToken Value);
+}

--- a/src/Valleysoft.Dredge/Commands/Image/CompareMetadataOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareMetadataOptions.cs
@@ -1,0 +1,32 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class CompareMetadataOptions : CompareOptionsBase
+{
+    private readonly Option<CompareOutput> outputOption;
+    private readonly Option<bool> noColorOption;
+
+    public CompareOutput OutputFormat { get; set; }
+    public bool IsColorDisabled { get; set; }
+
+    public CompareMetadataOptions()
+    {
+        outputOption = Add(new Option<CompareOutput>("--output")
+        {
+            Description = "Output format",
+            DefaultValueFactory = _ => CompareOutput.SideBySide
+        });
+        noColorOption = Add(new Option<bool>("--no-color")
+        {
+            Description = "Disables dependency on color in comparison results"
+        });
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        OutputFormat = GetValue(outputOption);
+        IsColorDisabled = GetValue(noColorOption);
+    }
+}

--- a/src/Valleysoft.Dredge/CompareDiff.cs
+++ b/src/Valleysoft.Dredge/CompareDiff.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace Valleysoft.Dredge;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum CompareDiff
+{
+    [EnumMember(Value = "equal")]
+    Equal,
+    [EnumMember(Value = "notEqual")]
+    NotEqual,
+    [EnumMember(Value = "added")]
+    Added,
+    [EnumMember(Value = "removed")]
+    Removed
+}

--- a/src/Valleysoft.Dredge/CompareLayersResult.cs
+++ b/src/Valleysoft.Dredge/CompareLayersResult.cs
@@ -1,8 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System.Runtime.Serialization;
-
-namespace Valleysoft.Dredge;
+﻿namespace Valleysoft.Dredge;
 
 public class CompareLayersResult
 {
@@ -44,7 +40,7 @@ public class CompareLayersSummary
 
 public class LayerComparison
 {
-    public LayerComparison(LayerInfo? @base, LayerInfo? target, LayerDiff layerDiff)
+    public LayerComparison(LayerInfo? @base, LayerInfo? target, CompareDiff layerDiff)
     {
         Base = @base;
         Target = target;
@@ -53,20 +49,7 @@ public class LayerComparison
 
     public LayerInfo? Base { get; }
     public LayerInfo? Target { get; }
-    public LayerDiff LayerDiff { get; }
-}
-
-[JsonConverter(typeof(StringEnumConverter))]
-public enum LayerDiff
-{
-    [EnumMember(Value = "equal")]
-    Equal,
-    [EnumMember(Value = "notEqual")]
-    NotEqual,
-    [EnumMember(Value = "added")]
-    Added,
-    [EnumMember(Value = "removed")]
-    Removed
+    public CompareDiff LayerDiff { get; }
 }
 
 public class LayerInfo

--- a/src/Valleysoft.Dredge/CompareMetadataResult.cs
+++ b/src/Valleysoft.Dredge/CompareMetadataResult.cs
@@ -1,0 +1,56 @@
+using Newtonsoft.Json.Linq;
+
+namespace Valleysoft.Dredge;
+
+public class CompareMetadataResult
+{
+    public CompareMetadataResult(CompareMetadataSummary summary, IEnumerable<MetadataComparison> comparisons)
+    {
+        Summary = summary;
+        Comparisons = comparisons;
+    }
+
+    public CompareMetadataSummary Summary { get; }
+    public IEnumerable<MetadataComparison> Comparisons { get; }
+}
+
+public class CompareMetadataSummary
+{
+    public CompareMetadataSummary(bool areEqual, int equal, int changed, int added, int removed)
+    {
+        AreEqual = areEqual;
+        Equal = equal;
+        Changed = changed;
+        Added = added;
+        Removed = removed;
+    }
+
+    public bool AreEqual { get; }
+    public int Equal { get; }
+    public int Changed { get; }
+    public int Added { get; }
+    public int Removed { get; }
+}
+
+public class MetadataComparison
+{
+    public MetadataComparison(
+        string category,
+        string path,
+        JToken? baseValue,
+        JToken? targetValue,
+        CompareDiff diff)
+    {
+        Category = category;
+        Path = path;
+        BaseValue = baseValue;
+        TargetValue = targetValue;
+        Diff = diff;
+    }
+
+    public string Category { get; }
+    public string Path { get; }
+    public JToken? BaseValue { get; }
+    public JToken? TargetValue { get; }
+    public CompareDiff Diff { get; }
+}

--- a/src/Valleysoft.Dredge/CompareOutput.cs
+++ b/src/Valleysoft.Dredge/CompareOutput.cs
@@ -1,6 +1,6 @@
 ﻿namespace Valleysoft.Dredge;
 
-public enum CompareLayersOutput
+public enum CompareOutput
 {
     SideBySide,
     Inline,

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -17,12 +17,39 @@ internal static class ManifestHelper
     {
         ManifestInfo manifestInfo = await client.Manifests.GetAsync(
             imageName.Repo, (imageName.Tag ?? imageName.Digest)!, cancellationToken);
+        return await GetResolvedManifestAsync(client, imageName, options, manifestInfo, cancellationToken);
+    }
+
+    public static async Task<ResolvedManifest> GetResolvedManifestAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        PlatformOptionsBase options,
+        ManifestInfo manifestInfo,
+        CancellationToken cancellationToken)
+    {
+        return await GetResolvedManifestAsync(
+            client,
+            imageName,
+            options,
+            manifestInfo,
+            () => AppSettings.Load().Platform,
+            cancellationToken);
+    }
+
+    internal static async Task<ResolvedManifest> GetResolvedManifestAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        PlatformOptionsBase options,
+        ManifestInfo manifestInfo,
+        Func<PlatformSettings> platformSettingsProvider,
+        CancellationToken cancellationToken)
+    {
         if (manifestInfo.Manifest is IManifestList manifestList)
         {
-            AppSettings settings = AppSettings.Load();
-            string? os = GetPlatformValue(options.Os, settings.Platform.Os);
-            string? osVersion = GetPlatformValue(options.OsVersion, settings.Platform.OsVersion);
-            string? architecture = GetPlatformValue(options.Architecture, settings.Platform.Architecture);
+            PlatformSettings settings = platformSettingsProvider();
+            string? os = GetPlatformValue(options.Os, settings.Os);
+            string? osVersion = GetPlatformValue(options.OsVersion, settings.OsVersion);
+            string? architecture = GetPlatformValue(options.Architecture, settings.Architecture);
 
             IEnumerable<IManifestReference> manifestRefs = manifestList.Manifests
                 .Where(manifest =>


### PR DESCRIPTION
Container image comparisons need visibility into platform, manifest, configuration, and history metadata without downloading image layers. This adds `dredge image compare metadata` for inspecting those differences directly.

The command:
- compares complete platform indexes while resolving the selected platform for deeper inspection
- compares manifest descriptors, raw image configuration, and history metadata
- supports side-by-side, inline, and machine-readable JSON output
- preserves raw configuration values and normalizes map/set ordering for stable results
- returns 0 for completed comparisons and 1 for execution failures

The shared comparison output and difference types now serve both layer and metadata comparisons. Registry fetches run concurrently, settings access is synchronized and testable, and JSON output bypasses terminal wrapping.

Fixes: #300