### PR TITLE
Add commands for inspecting OCI artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Dredge does not modify registry content.
 
 - Query raw JSON data for [manifests](docs/commands/manifests.md),
   [tags](docs/commands/tags.md), [repositories](docs/commands/repositories.md),
-  and [referrers](docs/commands/referrers.md).
+  and [referrers](docs/commands/referrers.md), including OCI artifact inspection
+  and payload retrieval.
 - Inspect an image's [configuration](docs/commands/images.md#inspect) and
   [operating system information](docs/commands/images.md#os).
 - Compare [layers](docs/commands/images.md#compare-layers) or

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ configure authentication, settings, and platform selection.
 
 - [`image`](commands/images.md) — Inspect, compare, and export container images
 - [`manifest`](commands/manifests.md) — Query and resolve manifests
-- [`referrer`](commands/referrers.md) — List referrers to a manifest
+- [`referrer`](commands/referrers.md) — List and inspect referrers and retrieve artifact payloads
 - [`repo`](commands/repositories.md) — List repositories in a registry
 - [`tag`](commands/tags.md) — List tags in a repository
 - [`settings`](commands/settings.md) — Manage Dredge configuration

--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -3,6 +3,8 @@
 | Sub-command | Description |
 |-------------|-------------|
 | [`list`](#list) | List the referrers to a manifest |
+| [`inspect`](#inspect) | Inspect an OCI artifact referenced by an image |
+| [`get`](#get) | Retrieve an OCI artifact payload |
 
 ## List
 
@@ -38,4 +40,72 @@ dredge referrer list mcr.microsoft.com/dotnet/core/sdk:latest
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json"
 }
+```
+
+## Inspect
+
+Displays metadata and payload information for an OCI artifact referenced by an
+image.
+
+```console
+dredge referrer inspect <name> <artifact-digest> [--output <format>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--output` | Output format: `summary` (default) or `json` |
+
+The summary always includes the artifact type, subject, annotations, config,
+and each payload's zero-based index, digest, media type, and size. SPDX,
+CycloneDX, in-toto, DSSE, and Notary Project signature payloads also include
+format-specific details. Other artifact types retain the generic summary and
+remain retrievable.
+
+Use JSON output for automation or to access the complete artifact manifest:
+
+```console
+dredge referrer inspect registry.example/repo:tag sha256:abc123 --output json
+```
+
+For example, inspect a Notary Project signature for the Windows CSSC Python
+image:
+
+```console
+dredge referrer inspect mcr.microsoft.com/windows-cssc/python:3.13-windows-ltsc2019 sha256:852619682b24fac4bf675a911d0c0d8b1b64e6cd742873137ad6998000f8a847
+Image: mcr.microsoft.com/windows-cssc/python:3.13-windows-ltsc2019
+Artifact digest: sha256:852619682b24fac4bf675a911d0c0d8b1b64e6cd742873137ad6998000f8a847
+Artifact type: application/vnd.cncf.notary.signature
+Manifest media type: application/vnd.oci.image.manifest.v1+json
+Subject digest: sha256:6f9f8b9a4fea0766f34c7c93deac4468ea2ed8ad26284b21a6a8ccca13a4ad1d
+Config: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (application/vnd.oci.empty.v1+json, 2 bytes)
+Annotations:
+  io.cncf.notary.x509chain.thumbprint#S256: ["303d73d0e9b4efe97e04bd58ad55423669f2a77c36e44408cc516388afbb18eb","9b1894f223d934cbd6575af3c6e1f6096b9221a7da132185f5a5cdc92235b5dc","23ffe2b8bdb9a1711515d4cffda04bc7f793d513c76c243f1020507d8669b7db"]
+  org.opencontainers.image.created: 2026-08-13T09:51:15Z
+Payloads:
+  [0] sha256:dd27519d8486110d4e3c652fa1807862e8209fd7ae83fa9f8cfdc0effbd449d0
+      Media type: application/cose
+      Size: 10995 bytes
+      Format: Notary signature
+      Envelope format: COSE
+```
+
+## Get
+
+Streams an artifact payload without modifying registry content.
+
+```console
+dredge referrer get <name> <artifact-digest> [--payload <index-or-digest>] [--output <path>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--payload` | Payload index or digest. Optional for a single-payload artifact and required when multiple payloads exist |
+| `--output` | Write the payload to this file instead of standard output |
+
+Without `--output`, Dredge writes the exact payload bytes to standard output,
+which supports binary data and shell redirection. Use `inspect` to find the
+index or digest for artifacts with multiple payloads.
+
+```console
+dredge referrer get registry.example/repo:tag sha256:abc123 --payload 0 --output sbom.json
 ```

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -9,6 +9,8 @@ using Valleysoft.Dredge.Commands.Referrer;
 using Valleysoft.Dredge.Commands.Repo;
 using Valleysoft.Dredge.Commands.Settings;
 using Valleysoft.Dredge.Commands.Tag;
+using ReferrerGetOptions = Valleysoft.Dredge.Commands.Referrer.GetOptions;
+using ReferrerInspectOptions = Valleysoft.Dredge.Commands.Referrer.InspectOptions;
 
 public class CommandStructureTests
 {
@@ -23,7 +25,9 @@ public class CommandStructureTests
         Assert.Equal(
             ["get", "digest", "resolve"],
             new ManifestCommand(factory.Object).Subcommands.Select(command => command.Name));
-        Assert.Equal(["list"], new ReferrerCommand(factory.Object).Subcommands.Select(command => command.Name));
+        Assert.Equal(
+            ["list", "inspect", "get"],
+            new ReferrerCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(["list"], new RepoCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(["list"], new TagCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(
@@ -85,6 +89,51 @@ public class CommandStructureTests
         Assert.False(options.IsColorDisabled);
         Assert.False(options.IncludeHistory);
         Assert.False(options.IncludeCompressedSize);
+    }
+
+    [Fact]
+    public void ReferrerInspectOptions_BindArgumentsAndOutput()
+    {
+        ReferrerInspectOptions options = Bind(
+            new ReferrerInspectOptions(),
+            "registry.example/repo:tag",
+            "sha256:artifact",
+            "--output",
+            "Json");
+
+        Assert.Equal("registry.example/repo:tag", options.Image);
+        Assert.Equal("sha256:artifact", options.ArtifactDigest);
+        Assert.Equal(ArtifactInspectOutput.Json, options.OutputFormat);
+    }
+
+    [Fact]
+    public void ReferrerGetOptions_BindArgumentsAndOptions()
+    {
+        ReferrerGetOptions options = Bind(
+            new ReferrerGetOptions(),
+            "registry.example/repo:tag",
+            "sha256:artifact",
+            "--payload",
+            "2",
+            "--output",
+            "artifact.json");
+
+        Assert.Equal("registry.example/repo:tag", options.Image);
+        Assert.Equal("sha256:artifact", options.ArtifactDigest);
+        Assert.Equal("2", options.Payload);
+        Assert.Equal("artifact.json", options.OutputPath);
+    }
+
+    [Fact]
+    public void ReferrerArtifactOptions_UseNameArgument()
+    {
+        Command inspect = new("inspect");
+        new ReferrerInspectOptions().SetCommandOptions(inspect);
+        Command get = new("get");
+        new ReferrerGetOptions().SetCommandOptions(get);
+
+        Assert.Equal(["name", "artifact-digest"], inspect.Arguments.Select(argument => argument.Name));
+        Assert.Equal(["name", "artifact-digest"], get.Arguments.Select(argument => argument.Name));
     }
 
     private static TOptions Bind<TOptions>(TOptions options, params string[] args)

--- a/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
@@ -1,0 +1,818 @@
+namespace Valleysoft.Dredge.Tests;
+
+using System.Text;
+using System.Text.Json;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+using Valleysoft.Dredge.Commands.Referrer;
+using ReferrerGetCommand = Valleysoft.Dredge.Commands.Referrer.GetCommand;
+using ReferrerInspectCommand = Valleysoft.Dredge.Commands.Referrer.InspectCommand;
+
+public class ReferrerArtifactCommandTests
+{
+    private const string Registry = "registry.example";
+    private const string Repository = "repo";
+    private const string SubjectDigest = "sha256:subject";
+    private const string ArtifactDigest = "sha256:artifact";
+
+    [Fact]
+    public async Task InspectCommand_WritesGenericSummaryWithoutReadingUnknownPayload()
+    {
+        OciDescriptor payload = CreatePayload("sha256:unknown", "application/example", 42);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions()
+        };
+
+        await command.RunAsync();
+
+        string text = output.ToString();
+        Assert.Contains($"Artifact digest: {ArtifactDigest}", text);
+        Assert.Contains($"Subject digest: {SubjectDigest}", text);
+        Assert.Contains("[0] sha256:unknown", text);
+        Assert.Contains("Media type: application/example", text);
+        client.Verify(
+            instance => instance.Blobs.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InspectCommand_AcceptsUnknownJsonArray()
+    {
+        const string content = """[{"value":1}]""";
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload("sha256:json", "application/json", content.Length)));
+        SetupBlob(client, "sha256:json", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions()
+        };
+
+        await command.RunAsync();
+
+        string text = output.ToString();
+        Assert.Contains("[0] sha256:json", text);
+        Assert.DoesNotContain("Format:", text);
+    }
+
+    [Fact]
+    public async Task InspectCommand_WritesSpdxSummary()
+    {
+        const string content = """
+            {
+              "spdxVersion": "SPDX-2.3",
+              "name": "sample",
+              "documentNamespace": "https://example.test/spdx",
+              "creationInfo": {
+                "created": "2026-08-31T00:00:00Z",
+                "creators": ["Tool: test"]
+              },
+              "packages": [{}, {}],
+              "files": [{}],
+              "relationships": [{}, {}, {}]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload("sha256:spdx", "application/json", content.Length)));
+        SetupBlob(client, "sha256:spdx", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions()
+        };
+
+        await command.RunAsync();
+
+        string text = output.ToString();
+        Assert.Contains("Format: SPDX", text);
+        Assert.Contains("SPDX version: SPDX-2.3", text);
+        Assert.Contains("Packages: 2", text);
+        Assert.Contains("Files: 1", text);
+        Assert.Contains("Relationships: 3", text);
+    }
+
+    [Fact]
+    public async Task InspectCommand_WritesCycloneDxJsonSummaryAndManifest()
+    {
+        const string content = """
+            {
+              "bomFormat": "CycloneDX",
+              "specVersion": "1.6",
+              "serialNumber": "urn:uuid:test",
+              "version": 2,
+              "metadata": {
+                "timestamp": "2026-08-31T00:00:00Z",
+                "component": { "type": "application", "name": "sample", "version": "1.0" }
+              },
+              "components": [{}, {}],
+              "services": [{}],
+              "vulnerabilities": [{}]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload(
+                "sha256:cyclonedx",
+                "application/vnd.cyclonedx+json",
+                content.Length)));
+        SetupBlob(client, "sha256:cyclonedx", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement root = document.RootElement;
+        Assert.Equal(ArtifactDigest, root.GetProperty("artifactDigest").GetString());
+        Assert.Equal(
+            SubjectDigest,
+            root.GetProperty("manifest").GetProperty("subject").GetProperty("digest").GetString());
+        JsonElement payload = root.GetProperty("payloads")[0];
+        Assert.Equal("CycloneDX", payload.GetProperty("format").GetString());
+        Assert.Equal(2, payload.GetProperty("summary").GetProperty("componentCount").GetInt32());
+        Assert.Equal(
+            "sample",
+            payload.GetProperty("summary").GetProperty("component").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_DoesNotApplyArtifactTypeToEveryPayload()
+    {
+        const string content = """{"bomFormat":"CycloneDX","specVersion":"1.6"}""";
+        OciImageManifest manifest = CreateArtifact(
+            CreatePayload(
+                "sha256:cyclonedx",
+                "application/vnd.cyclonedx+json",
+                content.Length),
+            CreatePayload("sha256:binary", "application/octet-stream", 4));
+        manifest.ArtifactType = "application/vnd.cyclonedx+json";
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        SetupBlob(client, "sha256:cyclonedx", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payloads = document.RootElement.GetProperty("payloads");
+        Assert.Equal("CycloneDX", payloads[0].GetProperty("format").GetString());
+        Assert.False(payloads[1].TryGetProperty("format", out _));
+        client.Verify(
+            instance => instance.Blobs.GetAsync(
+                Repository,
+                "sha256:binary",
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InspectCommand_UsesConfigMediaTypeForLegacyArtifact()
+    {
+        const string content = """{"bomFormat":"CycloneDX","specVersion":"1.6"}""";
+        OciImageManifest manifest = CreateArtifact(
+            CreatePayload("sha256:cyclonedx", "application/json", content.Length));
+        manifest.ArtifactType = null;
+        manifest.Config.MediaType = "application/vnd.cyclonedx+json";
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        SetupBlob(client, "sha256:cyclonedx", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement root = document.RootElement;
+        Assert.Equal(
+            "application/vnd.cyclonedx+json",
+            root.GetProperty("artifactType").GetString());
+        Assert.Equal(
+            "CycloneDX",
+            root.GetProperty("payloads")[0].GetProperty("format").GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_ParsesDsseWrappedInTotoStatement()
+    {
+        const string statement = """
+            {
+              "_type": "https://in-toto.io/Statement/v0.1",
+              "subject": [{ "name": "sample", "digest": { "sha256": "abc123" } }],
+              "predicateType": "https://slsa.dev/provenance/v1",
+              "predicate": {
+                "buildDefinition": { "buildType": "https://example.test/build" },
+                "runDetails": { "builder": { "id": "https://example.test/builder" } }
+              }
+            }
+            """;
+        string encodedStatement = Convert.ToBase64String(Encoding.UTF8.GetBytes(statement))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        string envelope = $$"""
+            {
+              "payloadType": "application/vnd.in-toto+json",
+              "payload": "{{encodedStatement}}",
+              "signatures": [{ "sig": "" }]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload(
+                "sha256:attestation",
+                "application/vnd.dsse.envelope.v1+json",
+                envelope.Length)));
+        SetupBlob(client, "sha256:attestation", envelope);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement summary =
+            document.RootElement.GetProperty("payloads")[0].GetProperty("summary");
+        Assert.Equal("application/vnd.in-toto+json", summary.GetProperty("payloadType").GetString());
+        JsonElement parsedStatement = summary.GetProperty("statement");
+        Assert.Equal(
+            "https://in-toto.io/Statement/v0.1",
+            parsedStatement.GetProperty("statementType").GetString());
+        Assert.Equal(
+            "https://slsa.dev/provenance/v1",
+            parsedStatement.GetProperty("predicateType").GetString());
+        Assert.Equal(
+            "https://example.test/builder",
+            parsedStatement.GetProperty("builderId").GetString());
+        Assert.Equal(
+            "https://example.test/build",
+            parsedStatement.GetProperty("buildType").GetString());
+        Assert.Equal("sample", parsedStatement.GetProperty("subjectNames")[0].GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_ParsesInTotoStatementV01()
+    {
+        const string statement = """
+            {
+              "_type": "https://in-toto.io/Statement/v0.1",
+              "subject": [{ "name": "sample", "digest": { "sha256": "abc123" } }],
+              "predicateType": "https://spdx.dev/Document",
+              "predicate": {}
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload(
+                "sha256:statement",
+                "application/vnd.in-toto+json",
+                statement.Length)));
+        SetupBlob(client, "sha256:statement", statement);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.Equal("in-toto", payload.GetProperty("format").GetString());
+        Assert.Equal(
+            "https://in-toto.io/Statement/v0.1",
+            payload.GetProperty("summary").GetProperty("statementType").GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_ParsesPredicateSpecificInTotoAttestation()
+    {
+        const string statement = """
+            {
+              "_type": "https://in-toto.io/Statement/v1",
+              "subject": [{ "name": "sample", "digest": { "sha256": "abc123" } }],
+              "predicateType": "https://slsa.dev/provenance/v1",
+              "predicate": {}
+            }
+            """;
+        string envelope = $$"""
+            {
+              "payloadType": "application/vnd.in-toto.provenance+json",
+              "payload": "{{Convert.ToBase64String(Encoding.UTF8.GetBytes(statement))}}",
+              "signatures": [{ "sig": "" }]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload(
+                "sha256:provenance",
+                "application/vnd.in-toto.provenance+dsse",
+                envelope.Length)));
+        SetupBlob(client, "sha256:provenance", envelope);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.Equal("DSSE", payload.GetProperty("format").GetString());
+        JsonElement summary = payload.GetProperty("summary");
+        Assert.Equal(
+            "application/vnd.in-toto.provenance+json",
+            summary.GetProperty("payloadType").GetString());
+        Assert.Equal(
+            "https://slsa.dev/provenance/v1",
+            summary.GetProperty("statement").GetProperty("predicateType").GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_RejectsLegacyPredicateSpecificDsseWithNonInTotoPayload()
+    {
+        string envelope = $$"""
+            {
+              "payloadType": "application/octet-stream",
+              "payload": "{{Convert.ToBase64String([0, 1, 2])}}",
+              "signatures": [{ "sig": "" }]
+            }
+            """;
+        OciImageManifest manifest = CreateArtifact(
+            CreatePayload("sha256:legacy-provenance", "application/json", envelope.Length));
+        manifest.ArtifactType = null;
+        manifest.Config.MediaType = "application/vnd.in-toto.provenance+dsse";
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        SetupBlob(client, "sha256:legacy-provenance", envelope);
+        using StringWriter output = new();
+        using StringWriter error = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output, error)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+        Assert.Contains(
+            "must use an in-toto JSON payload type",
+            error.ToString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_DoesNotMisclassifyGenericJsonLookalike()
+    {
+        const string content = """
+            {
+              "_type": "https://in-toto.io/Statement/v1",
+              "predicateType": "https://example.test/predicate",
+              "subject": [{ "digest": {} }],
+              "payloadType": "application/example",
+              "payload": "value"
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload("sha256:lookalike", "application/json", content.Length)));
+        SetupBlob(client, "sha256:lookalike", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.False(payload.TryGetProperty("format", out _));
+        Assert.False(payload.TryGetProperty("summary", out _));
+    }
+
+    [Fact]
+    public async Task InspectCommand_FallsBackToGenericForMalformedDetectedDsse()
+    {
+        const string content = """
+            {
+              "payloadType": "application/octet-stream",
+              "payload": "not base64!",
+              "signatures": [{ "sig": "" }]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload("sha256:lookalike", "application/json", content.Length)));
+        SetupBlob(client, "sha256:lookalike", content);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.False(payload.TryGetProperty("format", out _));
+        Assert.False(payload.TryGetProperty("summary", out _));
+    }
+
+    [Theory]
+    [InlineData("application/jose+json", "JWS", false)]
+    [InlineData("application/cose", "COSE", false)]
+    [InlineData("application/jose+json", "JWS", true)]
+    public async Task InspectCommand_RecognizesNotarySignature(
+        string envelopeMediaType,
+        string expectedEnvelopeFormat,
+        bool useLegacyConfigMediaType)
+    {
+        OciImageManifest manifest = CreateArtifact(
+            CreatePayload("sha256:signature", envelopeMediaType, 42));
+        if (useLegacyConfigMediaType)
+        {
+            manifest.ArtifactType = null;
+            manifest.Config.MediaType = "application/vnd.cncf.notary.signature";
+        }
+        else
+        {
+            manifest.ArtifactType = "application/vnd.cncf.notary.signature";
+        }
+
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.Equal("Notary signature", payload.GetProperty("format").GetString());
+        Assert.Equal(
+            expectedEnvelopeFormat,
+            payload.GetProperty("summary").GetProperty("envelopeFormat").GetString());
+    }
+
+    [Fact]
+    public async Task InspectCommand_SummarizesDsseWithUnknownBinaryPayload()
+    {
+        string envelope = $$"""
+            {
+              "payloadType": "application/octet-stream",
+              "payload": "{{Convert.ToBase64String([0, 1, 2, 255])}}",
+              "signatures": [{ "keyid": "test", "sig": "dmFsdWU=" }]
+            }
+            """;
+        Mock<IDockerRegistryClient> client = CreateClient(
+            CreateArtifact(CreatePayload(
+                "sha256:dsse",
+                "application/vnd.dsse.envelope.v1+json",
+                envelope.Length)));
+        SetupBlob(client, "sha256:dsse", envelope);
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateInspectOptions(ArtifactInspectOutput.Json)
+        };
+
+        await command.RunAsync();
+        using JsonDocument document = JsonDocument.Parse(output.ToString());
+
+        JsonElement payload = document.RootElement.GetProperty("payloads")[0];
+        Assert.Equal("DSSE", payload.GetProperty("format").GetString());
+        JsonElement summary = payload.GetProperty("summary");
+        Assert.Equal("application/octet-stream", summary.GetProperty("payloadType").GetString());
+        Assert.Equal(1, summary.GetProperty("signatureCount").GetInt32());
+        Assert.False(summary.TryGetProperty("statement", out _));
+    }
+
+    [Fact]
+    public async Task InspectCommand_RejectsArtifactForDifferentSubject()
+    {
+        OciImageManifest manifest = CreateArtifact(CreatePayload(
+            "sha256:payload",
+            "application/example",
+            1));
+        manifest.Subject!.Digest = "sha256:different";
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        using StringWriter output = new();
+        using StringWriter error = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output, error)
+        {
+            Options = CreateInspectOptions()
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+        Assert.Contains("references subject 'sha256:different'", error.ToString());
+    }
+
+    [Fact]
+    public async Task GetCommand_StreamsBinaryPayloadToStandardOutput()
+    {
+        byte[] content = [0, 1, 2, 127, 128, 255];
+        OciDescriptor payload = CreatePayload("sha256:binary", "application/octet-stream", content.Length);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        client
+            .Setup(instance => instance.Blobs.GetAsync(
+                Repository,
+                payload.Digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(content));
+        using MemoryStream output = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateGetOptions()
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(content, output.ToArray());
+    }
+
+    [Fact]
+    public async Task GetCommand_ReadsEmbeddedPayloadData()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("embedded");
+        OciDescriptor payload = CreatePayload("sha256:embedded", "text/plain", content.Length);
+        payload.Data = Convert.ToBase64String(content);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        using MemoryStream output = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateGetOptions()
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(content, output.ToArray());
+        client.Verify(
+            instance => instance.Blobs.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCommand_SelectsPayloadByIndex()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("second");
+        OciDescriptor first = CreatePayload("sha256:first", "text/plain", 5);
+        OciDescriptor second = CreatePayload("sha256:second", "text/plain", content.Length);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(first, second));
+        client
+            .Setup(instance => instance.Blobs.GetAsync(
+                Repository,
+                second.Digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(content));
+        using MemoryStream output = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateGetOptions("1")
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(content, output.ToArray());
+    }
+
+    [Fact]
+    public async Task GetCommand_SelectsPayloadByDigest()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("second");
+        OciDescriptor first = CreatePayload("sha256:first", "text/plain", 5);
+        OciDescriptor second = CreatePayload("sha256:second", "text/plain", content.Length);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(first, second));
+        client
+            .Setup(instance => instance.Blobs.GetAsync(
+                Repository,
+                second.Digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(content));
+        using MemoryStream output = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = CreateGetOptions(second.Digest)
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(content, output.ToArray());
+    }
+
+    [Fact]
+    public async Task GetCommand_RequiresSelectorForMultiplePayloads()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(
+            CreatePayload("sha256:first", "text/plain", 5),
+            CreatePayload("sha256:second", "text/plain", 6)));
+        using MemoryStream output = new();
+        using StringWriter error = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output, error)
+        {
+            Options = CreateGetOptions()
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+        Assert.Contains("contains multiple payloads", error.ToString());
+    }
+
+    [Fact]
+    public async Task GetCommand_WritesPayloadToFile()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("file output");
+        OciDescriptor payload = CreatePayload("sha256:file", "text/plain", content.Length);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        client
+            .Setup(instance => instance.Blobs.GetAsync(
+                Repository,
+                payload.Digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(content));
+        string path = Path.GetTempFileName();
+
+        try
+        {
+            using MemoryStream output = new();
+            TestGetCommand command = new(CreateFactory(client.Object), output)
+            {
+                Options = CreateGetOptions(outputPath: path)
+            };
+
+            await command.RunAsync();
+
+            Assert.Equal(content, await File.ReadAllBytesAsync(
+                path,
+                TestContext.Current.CancellationToken));
+            Assert.Empty(output.ToArray());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ResolvesTaggedSubjectDigest()
+    {
+        OciImageManifest manifest = CreateArtifact(CreatePayload(
+            "sha256:payload",
+            "application/example",
+            1));
+        Mock<IDockerRegistryClient> client = CreateClient(manifest);
+        client
+            .Setup(instance => instance.Manifests.GetDigestAsync(
+                Repository,
+                "tag",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubjectDigest);
+
+        ResolvedArtifact artifact = await ArtifactHelper.ResolveAsync(
+            client.Object,
+            ImageName.Parse($"{Registry}/{Repository}:tag"),
+            ArtifactDigest,
+            TestContext.Current.CancellationToken);
+
+        Assert.Same(manifest, artifact.Manifest);
+    }
+
+    private static InspectOptions CreateInspectOptions(
+        ArtifactInspectOutput output = ArtifactInspectOutput.Summary) =>
+        new()
+        {
+            Image = $"{Registry}/{Repository}@{SubjectDigest}",
+            ArtifactDigest = ArtifactDigest,
+            OutputFormat = output
+        };
+
+    private static GetOptions CreateGetOptions(
+        string? payload = null,
+        string? outputPath = null) =>
+        new()
+        {
+            Image = $"{Registry}/{Repository}@{SubjectDigest}",
+            ArtifactDigest = ArtifactDigest,
+            Payload = payload,
+            OutputPath = outputPath
+        };
+
+    private static OciImageManifest CreateArtifact(params OciDescriptor[] payloads) =>
+        new()
+        {
+            ArtifactType = "application/example",
+            Config = CreatePayload("sha256:config", "application/vnd.oci.empty.v1+json", 2),
+            Subject = CreatePayload(
+                SubjectDigest,
+                "application/vnd.oci.image.manifest.v1+json",
+                100),
+            Layers = payloads
+        };
+
+    private static OciDescriptor CreatePayload(string digest, string mediaType, long size) =>
+        new()
+        {
+            Digest = digest,
+            MediaType = mediaType,
+            Size = size
+        };
+
+    private static Mock<IDockerRegistryClient> CreateClient(OciImageManifest manifest)
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(instance => instance.Manifests.GetAsync(
+                Repository,
+                ArtifactDigest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/vnd.oci.image.manifest.v1+json",
+                ArtifactDigest,
+                manifest));
+        return client;
+    }
+
+    private static void SetupBlob(
+        Mock<IDockerRegistryClient> client,
+        string digest,
+        string content) =>
+        client
+            .Setup(instance => instance.Blobs.GetAsync(
+                Repository,
+                digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(content)));
+
+    private static IDockerRegistryClientFactory CreateFactory(IDockerRegistryClient client)
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(instance => instance.GetClientAsync(Registry)).ReturnsAsync(client);
+        return factory.Object;
+    }
+
+    private sealed class TestInspectCommand : ReferrerInspectCommand
+    {
+        private readonly TextWriter error;
+
+        public TestInspectCommand(
+            IDockerRegistryClientFactory factory,
+            TextWriter output,
+            TextWriter? error = null)
+            : base(factory, output)
+        {
+            this.error = error ?? TextWriter.Null;
+        }
+
+        public Task RunAsync() => ExecuteAsync(TestContext.Current.CancellationToken);
+
+        protected override TextWriter Error => error;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class TestGetCommand : ReferrerGetCommand
+    {
+        private readonly TextWriter error;
+
+        public TestGetCommand(
+            IDockerRegistryClientFactory factory,
+            Stream output,
+            TextWriter? error = null)
+            : base(factory, output)
+        {
+            this.error = error ?? TextWriter.Null;
+        }
+
+        public Task RunAsync() => ExecuteAsync(TestContext.Current.CancellationToken);
+
+        protected override TextWriter Error => error;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class CommandExitException : Exception
+    {
+        public CommandExitException(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
@@ -1,5 +1,6 @@
 namespace Valleysoft.Dredge.Tests;
 
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
@@ -547,7 +548,10 @@ public class ReferrerArtifactCommandTests
     public async Task GetCommand_ReadsEmbeddedPayloadData()
     {
         byte[] content = Encoding.UTF8.GetBytes("embedded");
-        OciDescriptor payload = CreatePayload("sha256:embedded", "text/plain", content.Length);
+        OciDescriptor payload = CreatePayload(
+            $"sha256:{Convert.ToHexStringLower(SHA256.HashData(content))}",
+            "text/plain",
+            content.Length);
         payload.Data = Convert.ToBase64String(content);
         Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
         using MemoryStream output = new();
@@ -565,6 +569,37 @@ public class ReferrerArtifactCommandTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetCommand_RejectsEmbeddedPayloadDescriptorMismatch(bool mismatchDigest)
+    {
+        byte[] content = Encoding.UTF8.GetBytes("embedded");
+        string digest = mismatchDigest
+            ? $"sha256:{new string('0', 64)}"
+            : $"sha256:{Convert.ToHexStringLower(SHA256.HashData(content))}";
+        OciDescriptor payload = CreatePayload(
+            digest,
+            "text/plain",
+            mismatchDigest ? content.Length : content.Length + 1);
+        payload.Data = Convert.ToBase64String(content);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        using MemoryStream output = new();
+        using StringWriter error = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output, error)
+        {
+            Options = CreateGetOptions()
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+        Assert.Contains(
+            mismatchDigest ? "does not match payload digest" : "descriptor declares",
+            error.ToString());
+        Assert.Empty(output.ToArray());
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
@@ -603,6 +603,27 @@ public class ReferrerArtifactCommandTests
     }
 
     [Fact]
+    public async Task GetCommand_RejectsUnsupportedEmbeddedPayloadDigestAlgorithm()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("embedded");
+        OciDescriptor payload = CreatePayload("unknown:value", "text/plain", content.Length);
+        payload.Data = Convert.ToBase64String(content);
+        Mock<IDockerRegistryClient> client = CreateClient(CreateArtifact(payload));
+        using MemoryStream output = new();
+        using StringWriter error = new();
+        TestGetCommand command = new(CreateFactory(client.Object), output, error)
+        {
+            Options = CreateGetOptions()
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+        Assert.Contains("digest algorithm 'unknown' is not supported", error.ToString());
+        Assert.Empty(output.ToArray());
+    }
+
+    [Fact]
     public async Task GetCommand_SelectsPayloadByIndex()
     {
         byte[] content = Encoding.UTF8.GetBytes("second");

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
@@ -122,12 +122,12 @@ internal static class ArtifactHelper
             throw new InvalidDataException($"Payload digest '{digest}' is not valid.");
         }
 
-        string algorithm = digest[..separatorIndex];
-        byte[]? hash = algorithm.ToLowerInvariant() switch
+        byte[] hash = algorithm.ToLowerInvariant() switch
         {
             "sha256" => SHA256.HashData(content),
             "sha512" => SHA512.HashData(content),
-            _ => null
+            _ => throw new InvalidDataException(
+                $"Payload digest algorithm '{algorithm}' is not supported for embedded payload verification.")
         };
 
         if (hash is not null &&

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
@@ -87,10 +88,10 @@ internal static class ArtifactHelper
     {
         if (payload.Data is not null)
         {
+            byte[] content;
             try
             {
-                return Task.FromResult<Stream>(
-                    new MemoryStream(Convert.FromBase64String(payload.Data), writable: false));
+                content = Convert.FromBase64String(payload.Data);
             }
             catch (FormatException ex)
             {
@@ -98,9 +99,45 @@ internal static class ArtifactHelper
                     $"Embedded data for payload '{payload.Digest}' is not valid base64.",
                     ex);
             }
+
+            if (content.LongLength != payload.Size)
+            {
+                throw new InvalidDataException(
+                    $"Embedded data for payload '{payload.Digest}' has size {content.LongLength}, " +
+                    $"but its descriptor declares {payload.Size}.");
+            }
+
+            VerifyDigest(content, payload.Digest);
+            return Task.FromResult<Stream>(new MemoryStream(content, writable: false));
         }
 
         return client.Blobs.GetAsync(repository, payload.Digest, cancellationToken);
+    }
+
+    private static void VerifyDigest(byte[] content, string digest)
+    {
+        int separatorIndex = digest.IndexOf(':');
+        if (separatorIndex < 1 || separatorIndex == digest.Length - 1)
+        {
+            throw new InvalidDataException($"Payload digest '{digest}' is not valid.");
+        }
+
+        string algorithm = digest[..separatorIndex];
+        byte[]? hash = algorithm.ToLowerInvariant() switch
+        {
+            "sha256" => SHA256.HashData(content),
+            "sha512" => SHA512.HashData(content),
+            _ => null
+        };
+
+        if (hash is not null &&
+            !Convert.ToHexString(hash).Equals(
+                digest[(separatorIndex + 1)..],
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"Embedded data does not match payload digest '{digest}'.");
+        }
     }
 }
 

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
@@ -122,6 +122,7 @@ internal static class ArtifactHelper
             throw new InvalidDataException($"Payload digest '{digest}' is not valid.");
         }
 
+        string algorithm = digest[..separatorIndex];
         byte[] hash = algorithm.ToLowerInvariant() switch
         {
             "sha256" => SHA256.HashData(content),
@@ -130,8 +131,7 @@ internal static class ArtifactHelper
                 $"Payload digest algorithm '{algorithm}' is not supported for embedded payload verification.")
         };
 
-        if (hash is not null &&
-            !Convert.ToHexString(hash).Equals(
+        if (!Convert.ToHexString(hash).Equals(
                 digest[(separatorIndex + 1)..],
                 StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactHelper.cs
@@ -1,0 +1,110 @@
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+internal static class ArtifactHelper
+{
+    public static async Task<ResolvedArtifact> ResolveAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        string artifactDigest,
+        CancellationToken cancellationToken)
+    {
+        string subjectDigest = imageName.Digest ??
+            await client.Manifests.GetDigestAsync(imageName.Repo, imageName.Tag!, cancellationToken);
+        ManifestInfo manifestInfo =
+            await client.Manifests.GetAsync(imageName.Repo, artifactDigest, cancellationToken);
+
+        if (manifestInfo.Manifest is not OciImageManifest manifest)
+        {
+            throw new NotSupportedException(
+                $"Manifest '{artifactDigest}' is not an OCI artifact manifest.");
+        }
+
+        if (manifest.Subject is null)
+        {
+            throw new InvalidOperationException(
+                $"Artifact manifest '{artifactDigest}' does not define a subject.");
+        }
+
+        if (!string.Equals(manifest.Subject.Digest, subjectDigest, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Artifact manifest '{artifactDigest}' references subject '{manifest.Subject.Digest}', " +
+                $"not '{subjectDigest}'.");
+        }
+
+        return new ResolvedArtifact(imageName, manifestInfo, manifest);
+    }
+
+    public static OciDescriptor SelectPayload(
+        IReadOnlyList<OciDescriptor> payloads,
+        string? selector)
+    {
+        if (payloads.Count == 0)
+        {
+            throw new InvalidOperationException("The artifact manifest does not contain any payloads.");
+        }
+
+        if (selector is null)
+        {
+            if (payloads.Count == 1)
+            {
+                return payloads[0];
+            }
+
+            throw new InvalidOperationException(
+                "The artifact contains multiple payloads. Use 'referrer inspect' to list them, " +
+                "then specify one with '--payload <index-or-digest>'.");
+        }
+
+        if (int.TryParse(selector, out int index))
+        {
+            if (index >= 0 && index < payloads.Count)
+            {
+                return payloads[index];
+            }
+
+            throw new ArgumentOutOfRangeException(
+                nameof(selector),
+                selector,
+                $"Payload index must be between 0 and {payloads.Count - 1}.");
+        }
+
+        OciDescriptor? payload = payloads.FirstOrDefault(
+            candidate => string.Equals(candidate.Digest, selector, StringComparison.OrdinalIgnoreCase));
+        return payload ?? throw new ArgumentException(
+            $"The artifact does not contain a payload with digest '{selector}'.",
+            nameof(selector));
+    }
+
+    public static Task<Stream> OpenPayloadAsync(
+        IDockerRegistryClient client,
+        string repository,
+        OciDescriptor payload,
+        CancellationToken cancellationToken)
+    {
+        if (payload.Data is not null)
+        {
+            try
+            {
+                return Task.FromResult<Stream>(
+                    new MemoryStream(Convert.FromBase64String(payload.Data), writable: false));
+            }
+            catch (FormatException ex)
+            {
+                throw new InvalidDataException(
+                    $"Embedded data for payload '{payload.Digest}' is not valid base64.",
+                    ex);
+            }
+        }
+
+        return client.Blobs.GetAsync(repository, payload.Digest, cancellationToken);
+    }
+}
+
+internal sealed record ResolvedArtifact(
+    ImageName Image,
+    ManifestInfo ManifestInfo,
+    OciImageManifest Manifest);

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactInspectOutput.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactInspectOutput.cs
@@ -1,0 +1,7 @@
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public enum ArtifactInspectOutput
+{
+    Summary,
+    Json
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactInspection.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactInspection.cs
@@ -1,0 +1,595 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+internal sealed record ArtifactInspection(
+    string Image,
+    string ArtifactDigest,
+    string? ArtifactType,
+    OciImageManifest Manifest,
+    IReadOnlyList<ArtifactPayloadInspection> Payloads);
+
+internal sealed record ArtifactPayloadInspection(
+    int Index,
+    string Digest,
+    string MediaType,
+    long Size,
+    string? Format,
+    object? Summary);
+
+internal sealed record SpdxSummary(
+    string? SpdxVersion,
+    string? Name,
+    string? DocumentNamespace,
+    string? DataLicense,
+    string? Created,
+    IReadOnlyList<string> Creators,
+    int PackageCount,
+    int FileCount,
+    int RelationshipCount);
+
+internal sealed record CycloneDxSummary(
+    string? SpecVersion,
+    string? SerialNumber,
+    int? Version,
+    string? Timestamp,
+    CycloneDxComponentSummary? Component,
+    int ComponentCount,
+    int ServiceCount,
+    int VulnerabilityCount);
+
+internal sealed record CycloneDxComponentSummary(
+    string? Type,
+    string? Name,
+    string? Version);
+
+internal sealed record InTotoSummary(
+    string? StatementType,
+    string? PredicateType,
+    int SubjectCount,
+    IReadOnlyList<string> SubjectNames,
+    string? BuilderId,
+    string? BuildType);
+
+internal sealed record DsseSummary(
+    string? PayloadType,
+    int SignatureCount,
+    InTotoSummary? Statement);
+
+internal sealed record NotarySignatureSummary(string EnvelopeFormat);
+
+internal static class ArtifactInspectionFactory
+{
+    private const string InTotoMediaType = "application/vnd.in-toto";
+    private const string NotarySignatureMediaType = "application/vnd.cncf.notary.signature";
+    private const string SpdxFormat = "SPDX";
+    private const string CycloneDxFormat = "CycloneDX";
+    private const string InTotoFormat = "in-toto";
+    private const string DsseFormat = "DSSE";
+    private const string NotarySignatureFormat = "Notary signature";
+    private const string InTotoStatementTypeV01 = "https://in-toto.io/Statement/v0.1";
+    private const string InTotoStatementTypeV1 = "https://in-toto.io/Statement/v1";
+
+    public static async Task<ArtifactInspection> CreateAsync(
+        IDockerRegistryClient client,
+        ResolvedArtifact artifact,
+        CancellationToken cancellationToken)
+    {
+        List<ArtifactPayloadInspection> payloads = [];
+        string effectiveArtifactType =
+            artifact.Manifest.ArtifactType ?? artifact.Manifest.Config.MediaType;
+
+        for (int index = 0; index < artifact.Manifest.Layers.Length; index++)
+        {
+            OciDescriptor descriptor = artifact.Manifest.Layers[index];
+            object? summary = null;
+            string classificationMediaType = descriptor.MediaType;
+            string? format = GetFormatByMediaType(classificationMediaType);
+            if (artifact.Manifest.Layers.Length == 1 &&
+                effectiveArtifactType.Equals(
+                    NotarySignatureMediaType,
+                    StringComparison.OrdinalIgnoreCase) &&
+                GetNotaryEnvelopeFormat(descriptor.MediaType) is string envelopeFormat)
+            {
+                format = NotarySignatureFormat;
+                summary = new NotarySignatureSummary(envelopeFormat);
+            }
+            else if (format is null &&
+                artifact.Manifest.Layers.Length == 1 &&
+                IsGenericJsonMediaType(descriptor.MediaType))
+            {
+                classificationMediaType = effectiveArtifactType;
+                format = GetFormatByMediaType(classificationMediaType);
+            }
+
+            bool requireInTotoStatement =
+                IsPredicateSpecificInTotoMediaType(classificationMediaType, "+dsse");
+
+            if (summary is null &&
+                (format is not null ||
+                 IsJsonMediaType(descriptor.MediaType)))
+            {
+                await using Stream stream = await ArtifactHelper.OpenPayloadAsync(
+                    client,
+                    artifact.Image.Repo,
+                    descriptor,
+                    cancellationToken);
+                (format, summary) = await ParseSummaryAsync(
+                    format,
+                    requireInTotoStatement,
+                    stream,
+                    cancellationToken);
+            }
+
+            payloads.Add(new ArtifactPayloadInspection(
+                index,
+                descriptor.Digest,
+                descriptor.MediaType,
+                descriptor.Size,
+                format,
+                summary));
+        }
+
+        return new ArtifactInspection(
+            artifact.Image.ToString(),
+            artifact.ManifestInfo.DockerContentDigest,
+            effectiveArtifactType,
+            artifact.Manifest,
+            payloads);
+    }
+
+    private static string? GetFormatByMediaType(string mediaType)
+    {
+        if (mediaType.Equals("application/spdx+json", StringComparison.OrdinalIgnoreCase) ||
+            mediaType.Equals("application/vnd.spdx+json", StringComparison.OrdinalIgnoreCase))
+        {
+            return SpdxFormat;
+        }
+
+        if (mediaType.Equals(
+            "application/vnd.cyclonedx+json",
+            StringComparison.OrdinalIgnoreCase))
+        {
+            return CycloneDxFormat;
+        }
+
+        if (IsInTotoStatementMediaType(mediaType))
+        {
+            return InTotoFormat;
+        }
+
+        if (mediaType.Equals(
+            "application/vnd.dsse.envelope.v1+json",
+            StringComparison.OrdinalIgnoreCase) ||
+            IsPredicateSpecificInTotoMediaType(mediaType, "+dsse"))
+        {
+            return DsseFormat;
+        }
+
+        return null;
+    }
+
+    private static bool IsInTotoStatementMediaType(string mediaType) =>
+        mediaType.Equals(
+            $"{InTotoMediaType}+json",
+            StringComparison.OrdinalIgnoreCase) ||
+        IsPredicateSpecificInTotoMediaType(mediaType, "+json");
+
+    private static bool IsPredicateSpecificInTotoMediaType(string mediaType, string suffix)
+    {
+        string prefix = $"{InTotoMediaType}.";
+        return mediaType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+            mediaType.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) &&
+            mediaType.Length > prefix.Length + suffix.Length;
+    }
+
+    private static bool IsGenericJsonMediaType(string mediaType) =>
+        mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetNotaryEnvelopeFormat(string mediaType)
+    {
+        if (mediaType.Equals("application/jose+json", StringComparison.OrdinalIgnoreCase))
+        {
+            return "JWS";
+        }
+
+        return mediaType.Equals("application/cose", StringComparison.OrdinalIgnoreCase)
+            ? "COSE"
+            : null;
+    }
+
+    private static bool IsJsonMediaType(string? mediaType) =>
+        mediaType is not null &&
+        (IsGenericJsonMediaType(mediaType) ||
+         mediaType.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
+
+    private static async Task<(string? Format, object? Summary)> ParseSummaryAsync(
+        string? advertisedFormat,
+        bool requireInTotoStatement,
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using JsonDocument document = await JsonDocument.ParseAsync(
+                stream,
+                cancellationToken: cancellationToken);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                if (advertisedFormat is not null)
+                {
+                    throw new InvalidDataException(
+                        $"Payload advertised as {advertisedFormat} does not contain a JSON object.");
+                }
+
+                return (null, null);
+            }
+
+            string? format = advertisedFormat ?? DetectFormat(document.RootElement);
+            object? summary = format switch
+            {
+                SpdxFormat => ParseSpdx(document.RootElement),
+                CycloneDxFormat => ParseCycloneDx(document.RootElement),
+                InTotoFormat => ParseInToto(document.RootElement),
+                DsseFormat => ParseDsse(document.RootElement, requireInTotoStatement),
+                _ => null
+            };
+
+            return (format, summary);
+        }
+        catch (JsonException ex) when (advertisedFormat is not null)
+        {
+            throw new InvalidDataException(
+                $"Payload advertised as {advertisedFormat} does not contain valid JSON.",
+                ex);
+        }
+        catch (JsonException)
+        {
+            return (null, null);
+        }
+        catch (InvalidDataException) when (advertisedFormat is null)
+        {
+            return (null, null);
+        }
+    }
+
+    private static string? DetectFormat(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (root.TryGetProperty("spdxVersion", out _))
+        {
+            return SpdxFormat;
+        }
+
+        if (string.Equals(
+            GetString(root, "bomFormat"),
+            "CycloneDX",
+            StringComparison.OrdinalIgnoreCase))
+        {
+            return CycloneDxFormat;
+        }
+
+        if (IsInTotoStatement(root))
+        {
+            return InTotoFormat;
+        }
+
+        if (IsDsseEnvelope(root))
+        {
+            return DsseFormat;
+        }
+
+        return null;
+    }
+
+    private static SpdxSummary ParseSpdx(JsonElement root) =>
+        new(
+            GetString(root, "spdxVersion"),
+            GetString(root, "name"),
+            GetString(root, "documentNamespace"),
+            GetString(root, "dataLicense"),
+            GetNestedString(root, "creationInfo", "created"),
+            GetNestedStringArray(root, "creationInfo", "creators"),
+            GetArrayLength(root, "packages"),
+            GetArrayLength(root, "files"),
+            GetArrayLength(root, "relationships"));
+
+    private static CycloneDxSummary ParseCycloneDx(JsonElement root)
+    {
+        CycloneDxComponentSummary? component = null;
+        if (TryGetObject(root, "metadata", out JsonElement metadata) &&
+            TryGetObject(metadata, "component", out JsonElement componentElement))
+        {
+            component = new CycloneDxComponentSummary(
+                GetString(componentElement, "type"),
+                GetString(componentElement, "name"),
+                GetString(componentElement, "version"));
+        }
+
+        return new CycloneDxSummary(
+            GetString(root, "specVersion"),
+            GetString(root, "serialNumber"),
+            GetInt32(root, "version"),
+            GetNestedString(root, "metadata", "timestamp"),
+            component,
+            GetArrayLength(root, "components"),
+            GetArrayLength(root, "services"),
+            GetArrayLength(root, "vulnerabilities"));
+    }
+
+    private static InTotoSummary ParseInToto(JsonElement root)
+    {
+        if (!IsInTotoStatement(root))
+        {
+            throw new InvalidDataException(
+                "The in-toto payload is not a valid v0.1 or v1 Statement.");
+        }
+
+        return new InTotoSummary(
+            GetString(root, "_type"),
+            GetString(root, "predicateType"),
+            GetArrayLength(root, "subject"),
+            GetObjectArrayStrings(root, "subject", "name"),
+            GetNestedString(root, "predicate", "builder", "id") ??
+                GetNestedString(root, "predicate", "runDetails", "builder", "id"),
+            GetNestedString(root, "predicate", "buildType") ??
+                GetNestedString(root, "predicate", "buildDefinition", "buildType"));
+    }
+
+    private static DsseSummary ParseDsse(JsonElement root, bool requireInTotoStatement)
+    {
+        byte[] payload = ValidateDsseEnvelope(root);
+        string payloadType = GetString(root, "payloadType")!;
+        InTotoSummary? statement = null;
+
+        if (IsInTotoStatementMediaType(payloadType))
+        {
+            try
+            {
+                using JsonDocument statementDocument = JsonDocument.Parse(payload);
+                statement = ParseInToto(statementDocument.RootElement);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException(
+                    "The DSSE envelope payload does not contain a valid JSON statement.",
+                    ex);
+            }
+        }
+        else if (requireInTotoStatement)
+        {
+            throw new InvalidDataException(
+                $"A predicate-specific in-toto DSSE envelope must use an in-toto JSON payload type, not '{payloadType}'.");
+        }
+
+        return new DsseSummary(
+            payloadType,
+            GetArrayLength(root, "signatures"),
+            statement);
+    }
+
+    private static byte[] ValidateDsseEnvelope(JsonElement root)
+    {
+        if (!HasStringProperty(root, "payloadType") ||
+            !HasStringProperty(root, "payload") ||
+            !root.TryGetProperty("signatures", out JsonElement signatures) ||
+            signatures.ValueKind != JsonValueKind.Array ||
+            signatures.GetArrayLength() == 0)
+        {
+            throw new InvalidDataException(
+                "The DSSE envelope must define string payloadType and payload fields " +
+                "and at least one signature.");
+        }
+
+        byte[] payload = DecodeBase64(GetString(root, "payload")!, "payload");
+        foreach (JsonElement signature in signatures.EnumerateArray())
+        {
+            if (signature.ValueKind != JsonValueKind.Object ||
+                !HasStringProperty(signature, "sig"))
+            {
+                throw new InvalidDataException(
+                    "Each DSSE signature must define a string 'sig' field.");
+            }
+
+            DecodeBase64(GetString(signature, "sig")!, "signature");
+            if (signature.TryGetProperty("keyid", out JsonElement keyId) &&
+                keyId.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidDataException(
+                    "A DSSE signature's optional 'keyid' field must be a string.");
+            }
+        }
+
+        return payload;
+    }
+
+    private static bool IsInTotoStatement(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        string? statementType = GetString(root, "_type");
+        if ((!string.Equals(statementType, InTotoStatementTypeV01, StringComparison.Ordinal) &&
+                !string.Equals(statementType, InTotoStatementTypeV1, StringComparison.Ordinal)) ||
+            string.IsNullOrEmpty(GetString(root, "predicateType")) ||
+            !root.TryGetProperty("subject", out JsonElement subjects) ||
+            subjects.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        return subjects.EnumerateArray().All(subject =>
+        {
+            if (subject.ValueKind != JsonValueKind.Object ||
+                !subject.TryGetProperty("digest", out JsonElement digest) ||
+                digest.ValueKind != JsonValueKind.Object ||
+                !digest.EnumerateObject().Any())
+            {
+                return false;
+            }
+
+            return digest.EnumerateObject().All(
+                property => property.Value.ValueKind == JsonValueKind.String);
+        });
+    }
+
+    private static bool IsDsseEnvelope(JsonElement root) =>
+        HasStringProperty(root, "payloadType") &&
+        HasStringProperty(root, "payload") &&
+        root.TryGetProperty("signatures", out JsonElement signatures) &&
+        signatures.ValueKind == JsonValueKind.Array &&
+        signatures.GetArrayLength() > 0;
+
+    private static bool HasStringProperty(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out JsonElement property) &&
+        property.ValueKind == JsonValueKind.String;
+
+    private static byte[] DecodeBase64(string value, string field)
+    {
+        string normalized = value.Replace('-', '+').Replace('_', '/');
+        normalized = (normalized.Length % 4) switch
+        {
+            0 => normalized,
+            2 => normalized + "==",
+            3 => normalized + "=",
+            _ => throw new InvalidDataException(
+                $"The DSSE envelope {field} is not valid base64.")
+        };
+
+        try
+        {
+            return Convert.FromBase64String(normalized);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidDataException(
+                $"The DSSE envelope {field} is not valid base64.",
+                ex);
+        }
+    }
+
+    private static string? GetString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out JsonElement property) &&
+        property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static int? GetInt32(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out JsonElement property) &&
+        property.TryGetInt32(out int value)
+            ? value
+            : null;
+
+    private static string? GetNestedString(
+        JsonElement element,
+        string objectName,
+        string propertyName) =>
+        TryGetObject(element, objectName, out JsonElement nested)
+            ? GetString(nested, propertyName)
+            : null;
+
+    private static string? GetNestedString(
+        JsonElement element,
+        string firstObjectName,
+        string secondObjectName,
+        string propertyName) =>
+        TryGetObject(element, firstObjectName, out JsonElement first) &&
+        TryGetObject(first, secondObjectName, out JsonElement second)
+            ? GetString(second, propertyName)
+            : null;
+
+    private static string? GetNestedString(
+        JsonElement element,
+        string firstObjectName,
+        string secondObjectName,
+        string thirdObjectName,
+        string propertyName) =>
+        TryGetObject(element, firstObjectName, out JsonElement first) &&
+        TryGetObject(first, secondObjectName, out JsonElement second) &&
+        TryGetObject(second, thirdObjectName, out JsonElement third)
+            ? GetString(third, propertyName)
+            : null;
+
+    private static IReadOnlyList<string> GetNestedStringArray(
+        JsonElement element,
+        string objectName,
+        string propertyName) =>
+        TryGetObject(element, objectName, out JsonElement nested)
+            ? GetStringArray(nested, propertyName)
+            : [];
+
+    private static IReadOnlyList<string> GetStringArray(
+        JsonElement element,
+        string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property) ||
+            property.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return property.EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.String)
+            .Select(item => item.GetString()!)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> GetObjectArrayStrings(
+        JsonElement element,
+        string arrayName,
+        string propertyName)
+    {
+        if (!element.TryGetProperty(arrayName, out JsonElement array) ||
+            array.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return array.EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.Object)
+            .Select(item => GetString(item, propertyName))
+            .Where(value => value is not null)
+            .Select(value => value!)
+            .ToArray();
+    }
+
+    private static int GetArrayLength(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out JsonElement property) &&
+        property.ValueKind == JsonValueKind.Array
+            ? property.GetArrayLength()
+            : 0;
+
+    private static bool TryGetObject(
+        JsonElement element,
+        string propertyName,
+        out JsonElement value)
+    {
+        if (element.TryGetProperty(propertyName, out value) &&
+            value.ValueKind == JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}
+
+internal static class ArtifactInspectionJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ArtifactSummaryWriter.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ArtifactSummaryWriter.cs
@@ -1,0 +1,128 @@
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+internal static class ArtifactSummaryWriter
+{
+    public static void Write(TextWriter writer, ArtifactInspection inspection)
+    {
+        writer.WriteLine($"Image: {inspection.Image}");
+        writer.WriteLine($"Artifact digest: {inspection.ArtifactDigest}");
+        writer.WriteLine($"Artifact type: {inspection.ArtifactType ?? "(not specified)"}");
+        writer.WriteLine($"Manifest media type: {inspection.Manifest.MediaType}");
+        writer.WriteLine($"Subject digest: {inspection.Manifest.Subject?.Digest}");
+        writer.WriteLine(
+            $"Config: {inspection.Manifest.Config.Digest} " +
+            $"({inspection.Manifest.Config.MediaType}, {inspection.Manifest.Config.Size} bytes)");
+
+        if (inspection.Manifest.Annotations.Count > 0)
+        {
+            writer.WriteLine("Annotations:");
+            foreach ((string key, string value) in inspection.Manifest.Annotations.OrderBy(item => item.Key))
+            {
+                writer.WriteLine($"  {key}: {value}");
+            }
+        }
+
+        writer.WriteLine("Payloads:");
+        if (inspection.Payloads.Count == 0)
+        {
+            writer.WriteLine("  (none)");
+            return;
+        }
+
+        foreach (ArtifactPayloadInspection payload in inspection.Payloads)
+        {
+            writer.WriteLine($"  [{payload.Index}] {payload.Digest}");
+            writer.WriteLine($"      Media type: {payload.MediaType}");
+            writer.WriteLine($"      Size: {payload.Size} bytes");
+            if (payload.Format is not null)
+            {
+                writer.WriteLine($"      Format: {payload.Format}");
+                WriteFormatSummary(writer, payload.Summary);
+            }
+        }
+    }
+
+    private static void WriteFormatSummary(TextWriter writer, object? summary)
+    {
+        switch (summary)
+        {
+            case SpdxSummary spdx:
+                WriteValue(writer, "SPDX version", spdx.SpdxVersion);
+                WriteValue(writer, "Document name", spdx.Name);
+                WriteValue(writer, "Document namespace", spdx.DocumentNamespace);
+                WriteValue(writer, "Data license", spdx.DataLicense);
+                WriteValue(writer, "Created", spdx.Created);
+                foreach (string creator in spdx.Creators)
+                {
+                    writer.WriteLine($"      Creator: {creator}");
+                }
+                writer.WriteLine($"      Packages: {spdx.PackageCount}");
+                writer.WriteLine($"      Files: {spdx.FileCount}");
+                writer.WriteLine($"      Relationships: {spdx.RelationshipCount}");
+                break;
+
+            case CycloneDxSummary cycloneDx:
+                WriteValue(writer, "Spec version", cycloneDx.SpecVersion);
+                WriteValue(writer, "Serial number", cycloneDx.SerialNumber);
+                if (cycloneDx.Version is not null)
+                {
+                    writer.WriteLine($"      Document version: {cycloneDx.Version}");
+                }
+                WriteValue(writer, "Timestamp", cycloneDx.Timestamp);
+                if (cycloneDx.Component is not null)
+                {
+                    string component = string.Join(
+                        " ",
+                        new[]
+                        {
+                            cycloneDx.Component.Type,
+                            cycloneDx.Component.Name,
+                            cycloneDx.Component.Version
+                        }.Where(value => !string.IsNullOrEmpty(value)));
+                    WriteValue(writer, "Metadata component", component);
+                }
+                writer.WriteLine($"      Components: {cycloneDx.ComponentCount}");
+                writer.WriteLine($"      Services: {cycloneDx.ServiceCount}");
+                writer.WriteLine($"      Vulnerabilities: {cycloneDx.VulnerabilityCount}");
+                break;
+
+            case InTotoSummary inToto:
+                WriteInTotoSummary(writer, inToto);
+                break;
+
+            case DsseSummary dsse:
+                WriteValue(writer, "Payload type", dsse.PayloadType);
+                writer.WriteLine($"      Signatures: {dsse.SignatureCount}");
+                if (dsse.Statement is not null)
+                {
+                    WriteInTotoSummary(writer, dsse.Statement);
+                }
+                break;
+
+            case NotarySignatureSummary notary:
+                WriteValue(writer, "Envelope format", notary.EnvelopeFormat);
+                break;
+        }
+    }
+
+    private static void WriteInTotoSummary(TextWriter writer, InTotoSummary inToto)
+    {
+        WriteValue(writer, "Statement type", inToto.StatementType);
+        WriteValue(writer, "Predicate type", inToto.PredicateType);
+        WriteValue(writer, "Builder ID", inToto.BuilderId);
+        WriteValue(writer, "Build type", inToto.BuildType);
+        writer.WriteLine($"      Subjects: {inToto.SubjectCount}");
+        foreach (string subjectName in inToto.SubjectNames)
+        {
+            writer.WriteLine($"        {subjectName}");
+        }
+    }
+
+    private static void WriteValue(TextWriter writer, string label, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            writer.WriteLine($"      {label}: {value}");
+        }
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/GetCommand.cs
@@ -1,0 +1,58 @@
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class GetCommand : RegistryCommandBase<GetOptions>
+{
+    private readonly Stream standardOutput;
+
+    public GetCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        Stream? standardOutput = null)
+        : base(
+            "get",
+            "Retrieves a payload from an OCI artifact referenced by an image",
+            dockerRegistryClientFactory)
+    {
+        this.standardOutput = standardOutput ?? Console.OpenStandardOutput();
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            ResolvedArtifact artifact = await ArtifactHelper.ResolveAsync(
+                client,
+                imageName,
+                Options.ArtifactDigest,
+                ct);
+            OciDescriptor payload =
+                ArtifactHelper.SelectPayload(artifact.Manifest.Layers, Options.Payload);
+            await using Stream payloadStream = await ArtifactHelper.OpenPayloadAsync(
+                client,
+                imageName.Repo,
+                payload,
+                ct);
+
+            if (Options.OutputPath is null)
+            {
+                await payloadStream.CopyToAsync(standardOutput, ct);
+                await standardOutput.FlushAsync(ct);
+            }
+            else
+            {
+                await using FileStream output = new(
+                    Options.OutputPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 81920,
+                    useAsync: true);
+                await payloadStream.CopyToAsync(output, ct);
+            }
+        });
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
@@ -1,0 +1,44 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class GetOptions : OptionsBase
+{
+    private readonly Argument<string> nameArgument;
+    private readonly Argument<string> artifactDigestArgument;
+    private readonly Option<string> payloadOption;
+    private readonly Option<string> outputOption;
+
+    public string Image { get; set; } = string.Empty;
+    public string ArtifactDigest { get; set; } = string.Empty;
+    public string? Payload { get; set; }
+    public string? OutputPath { get; set; }
+
+    public GetOptions()
+    {
+        nameArgument = Add(new Argument<string>("name")
+        {
+            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+        });
+        artifactDigestArgument = Add(new Argument<string>("artifact-digest")
+        {
+            Description = "Digest of the artifact manifest"
+        });
+        payloadOption = Add(new Option<string>("--payload")
+        {
+            Description = "Payload index or digest (required when the artifact has multiple payloads)"
+        });
+        outputOption = Add(new Option<string>("--output")
+        {
+            Description = "File path for the payload; writes exact bytes to standard output when omitted"
+        });
+    }
+
+    protected override void GetValues()
+    {
+        Image = GetValue(nameArgument);
+        ArtifactDigest = GetValue(artifactDigestArgument);
+        Payload = GetValue(payloadOption);
+        OutputPath = GetValue(outputOption);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/InspectCommand.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class InspectCommand : RegistryCommandBase<InspectOptions>
+{
+    public InspectCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        TextWriter? output = null)
+        : base(
+            "inspect",
+            "Inspects an OCI artifact referenced by an image",
+            dockerRegistryClientFactory,
+            output)
+    {
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            ResolvedArtifact artifact = await ArtifactHelper.ResolveAsync(
+                client,
+                imageName,
+                Options.ArtifactDigest,
+                ct);
+            ArtifactInspection inspection =
+                await ArtifactInspectionFactory.CreateAsync(client, artifact, ct);
+
+            if (Options.OutputFormat == ArtifactInspectOutput.Json)
+            {
+                string json = JsonSerializer.Serialize(inspection, ArtifactInspectionJson.Options);
+                Output.WriteLine(json);
+            }
+            else
+            {
+                ArtifactSummaryWriter.Write(Output, inspection);
+            }
+        });
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
@@ -1,0 +1,38 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class InspectOptions : OptionsBase
+{
+    private readonly Argument<string> nameArgument;
+    private readonly Argument<string> artifactDigestArgument;
+    private readonly Option<ArtifactInspectOutput> outputOption;
+
+    public string Image { get; set; } = string.Empty;
+    public string ArtifactDigest { get; set; } = string.Empty;
+    public ArtifactInspectOutput OutputFormat { get; set; }
+
+    public InspectOptions()
+    {
+        nameArgument = Add(new Argument<string>("name")
+        {
+            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+        });
+        artifactDigestArgument = Add(new Argument<string>("artifact-digest")
+        {
+            Description = "Digest of the artifact manifest"
+        });
+        outputOption = Add(new Option<ArtifactInspectOutput>("--output")
+        {
+            Description = "Output format",
+            DefaultValueFactory = _ => ArtifactInspectOutput.Summary
+        });
+    }
+
+    protected override void GetValues()
+    {
+        Image = GetValue(nameArgument);
+        ArtifactDigest = GetValue(artifactDigestArgument);
+        OutputFormat = GetValue(outputOption);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
@@ -8,5 +8,7 @@ public class ReferrerCommand : Command
         : base("referrer", "Commands related to referrers")
     {
         Subcommands.Add(new ListCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new InspectCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new GetCommand(dockerRegistryClientFactory));
     }
 }


### PR DESCRIPTION
## Summary

Add `referrer inspect` and `referrer get` so users can inspect OCI artifact manifests and retrieve payloads without modifying registry content.

- Produce human-readable or JSON inspection output with generic metadata plus summaries for SPDX, CycloneDX, in-toto, DSSE, and Notary Project signatures.
- Resolve current and legacy artifact types, validate artifact subjects, support inline descriptor data, and preserve exact payload bytes for stdout or file output.
- Support selecting payloads by index or digest and report actionable errors for malformed recognized formats.
- Document the commands with a runnable Notary signature example.

## Testing

- Added command structure and end-to-end mocked registry coverage.
- Full Release suite passes with 341 tests.

Fixes: #298