### PR TITLE
Add CI check for required OCI referrer artifact types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Dredge does not modify registry content.
 
 - Query raw JSON data for [manifests](docs/commands/manifests.md),
   [tags](docs/commands/tags.md), [repositories](docs/commands/repositories.md),
-  and [referrers](docs/commands/referrers.md), including OCI artifact inspection
-  and payload retrieval.
+  and [referrers](docs/commands/referrers.md).
+- Inspect and retrieve OCI artifacts or check for required artifact types in CI.
 - Inspect an image's [configuration](docs/commands/images.md#inspect) and
   [operating system information](docs/commands/images.md#os).
 - Compare [layers](docs/commands/images.md#compare-layers) or

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ configure authentication, settings, and platform selection.
 
 - [`image`](commands/images.md) — Inspect, compare, and export container images
 - [`manifest`](commands/manifests.md) — Query and resolve manifests
-- [`referrer`](commands/referrers.md) — List and inspect referrers and retrieve artifact payloads
+- [`referrer`](commands/referrers.md) — List, check, and inspect referrers and retrieve artifact payloads
 - [`repo`](commands/repositories.md) — List repositories in a registry
 - [`tag`](commands/tags.md) — List tags in a repository
 - [`settings`](commands/settings.md) — Manage Dredge configuration

--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -3,6 +3,7 @@
 | Sub-command | Description |
 |-------------|-------------|
 | [`list`](#list) | List the referrers to a manifest |
+| [`check`](#check) | Check for required OCI referrer artifact types |
 | [`inspect`](#inspect) | Inspect an OCI artifact referenced by an image |
 | [`get`](#get) | Retrieve an OCI artifact payload |
 
@@ -41,6 +42,80 @@ dredge referrer list mcr.microsoft.com/dotnet/core/sdk:latest
   "mediaType": "application/vnd.oci.image.index.v1+json"
 }
 ```
+
+## Check
+
+Checks that an image has every required OCI referrer artifact type. Tagged
+references are resolved to their manifest digest, and all pages of referrers
+are checked.
+
+Artifact types use exact, case-sensitive matching. This command checks only
+for matching referrer descriptors; it does not inspect artifact payloads or
+verify signatures.
+
+```console
+dredge referrer check <name> --artifact-type <type> [--artifact-type <type>]... [--output <format>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--artifact-type` | Required artifact media type. Specify once for each required type |
+| `--output` | Output format: `summary` (default) or `json` |
+
+The summary reports every requested artifact type and the digest of each
+matching referrer:
+
+```console
+dredge referrer check mcr.microsoft.com/dotnet/sdk:10.0.300 \
+  --artifact-type application/vnd.cncf.notary.signature \
+  --artifact-type application/spdx+json
+PASS application/vnd.cncf.notary.signature
+  sha256:ed1eda051b8d154c19e0499ae5dadf3022e1c07f38fef2b6652beaeac2ce5069
+FAIL application/spdx+json
+```
+
+JSON output includes the overall result, each artifact type's status, and the
+complete OCI descriptor for every matching referrer:
+
+```console
+dredge referrer check mcr.microsoft.com/dotnet/sdk:10.0.300 \
+  --artifact-type application/vnd.cncf.notary.signature \
+  --artifact-type application/spdx+json \
+  --output json
+{
+  "succeeded": false,
+  "results": [
+    {
+      "artifactType": "application/vnd.cncf.notary.signature",
+      "found": true,
+      "referrers": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:ed1eda051b8d154c19e0499ae5dadf3022e1c07f38fef2b6652beaeac2ce5069",
+          "size": 990,
+          "urls": [],
+          "annotations": {
+            "io.cncf.notary.x509chain.thumbprint#S256": "[\"5461c8da6c44fc19706a093ae02cf04548a6c13242ae983d954be429666e6440\",\"9b1894f223d934cbd6575af3c6e1f6096b9221a7da132185f5a5cdc92235b5dc\",\"23ffe2b8bdb9a1711515d4cffda04bc7f793d513c76c243f1020507d8669b7db\"]",
+            "org.opencontainers.image.created": "2026-05-20T21:19:22.3944247Z"
+          },
+          "artifactType": "application/vnd.cncf.notary.signature"
+        }
+      ]
+    },
+    {
+      "artifactType": "application/spdx+json",
+      "found": false,
+      "referrers": []
+    }
+  ]
+}
+```
+
+| Exit code | Meaning |
+|----------:|---------|
+| `0` | Every required artifact type exists |
+| `1` | A configuration, registry, or execution error occurred |
+| `2` | At least one required artifact type is missing |
 
 ## Inspect
 

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -26,7 +26,7 @@ public class CommandStructureTests
             ["get", "digest", "resolve"],
             new ManifestCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(
-            ["list", "inspect", "get"],
+            ["list", "check", "inspect", "get"],
             new ReferrerCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(["list"], new RepoCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(["list"], new TagCommand(factory.Object).Subcommands.Select(command => command.Name));
@@ -104,6 +104,55 @@ public class CommandStructureTests
         Assert.Equal("registry.example/repo:tag", options.Image);
         Assert.Equal("sha256:artifact", options.ArtifactDigest);
         Assert.Equal(ArtifactInspectOutput.Json, options.OutputFormat);
+    }
+
+    [Fact]
+    public void ReferrerCheckOptions_BindRequiredArtifactTypesAndOutput()
+    {
+        CheckOptions options = Bind(
+            new CheckOptions(),
+            "registry.example/repo:tag",
+            "--artifact-type",
+            "application/spdx+json",
+            "--artifact-type",
+            "application/vnd.in-toto+json",
+            "--output",
+            "Json");
+
+        Assert.Equal("registry.example/repo:tag", options.Image);
+        Assert.Equal(
+            ["application/spdx+json", "application/vnd.in-toto+json"],
+            options.ArtifactTypes);
+        Assert.Equal(CheckOutput.Json, options.OutputFormat);
+    }
+
+    [Fact]
+    public void ReferrerCheckOptions_RequireArtifactType()
+    {
+        Command command = new("check");
+        new CheckOptions().SetCommandOptions(command);
+
+        ParseResult parseResult = command.Parse("registry.example/repo:tag");
+
+        Assert.Single(parseResult.Errors);
+        Assert.Contains("--artifact-type", parseResult.Errors[0].Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void ReferrerCheckOptions_RejectEmptyArtifactType(string artifactType)
+    {
+        Command command = new("check");
+        new CheckOptions().SetCommandOptions(command);
+
+        ParseResult parseResult = command.Parse(
+            ["registry.example/repo:tag", "--artifact-type", artifactType]);
+
+        Assert.Single(parseResult.Errors);
+        Assert.Equal(
+            "Artifact types cannot be empty or whitespace.",
+            parseResult.Errors[0].Message);
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
@@ -1,0 +1,234 @@
+namespace Valleysoft.Dredge.Tests;
+
+using Newtonsoft.Json.Linq;
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+using Valleysoft.Dredge.Commands.Referrer;
+using OciManifestReference = Valleysoft.DockerRegistryClient.Models.Manifests.Oci.ManifestReference;
+
+public class ReferrerCheckCommandTests
+{
+    private const string Registry = "registry.example";
+
+    [Fact]
+    public async Task CheckCommand_ResolvesTagCombinesPagesAndReportsAllMatches()
+    {
+        OciManifestReference sbom = new()
+        {
+            ArtifactType = "application/spdx+json",
+            Digest = "sha256:sbom"
+        };
+        OciManifestReference provenance = new()
+        {
+            ArtifactType = "application/vnd.in-toto+json",
+            Digest = "sha256:provenance"
+        };
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateManifestInfo("sha256:image"));
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex { Manifests = [sbom] },
+                "next"));
+        client
+            .Setup(o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex { Manifests = [provenance] },
+                null));
+        using StringWriter output = new();
+        TestCheckCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new CheckOptions
+            {
+                Image = $"{Registry}/repo:tag",
+                ArtifactTypes =
+                [
+                    "application/spdx+json",
+                    "application/vnd.in-toto+json"
+                ]
+            }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(
+            $"""
+            PASS application/spdx+json
+              sha256:sbom
+            PASS application/vnd.in-toto+json
+              sha256:provenance
+
+            """.ReplaceLineEndings(),
+            output.ToString());
+        client.Verify(
+            o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()),
+            Times.Once);
+        client.Verify(
+            o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckCommand_WhenTypeIsMissing_ReportsEveryResultAndExitsTwo()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex
+                {
+                    Manifests =
+                    [
+                        new OciManifestReference
+                        {
+                            ArtifactType = "application/spdx+json",
+                            Digest = "sha256:sbom"
+                        }
+                    ]
+                },
+                null));
+        using StringWriter output = new();
+        TestCheckCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new CheckOptions
+            {
+                Image = $"{Registry}/repo@sha256:image",
+                ArtifactTypes =
+                [
+                    "application/spdx+json",
+                    "application/vnd.in-toto+json"
+                ]
+            }
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(2, exception.ExitCode);
+        Assert.Equal(
+            $"""
+            PASS application/spdx+json
+              sha256:sbom
+            FAIL application/vnd.in-toto+json
+
+            """.ReplaceLineEndings(),
+            output.ToString());
+        client.Verify(
+            o => o.Manifests.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckCommand_WithJsonOutput_IncludesMatchingDescriptors()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex
+                {
+                    Manifests =
+                    [
+                        new OciManifestReference
+                        {
+                            ArtifactType = "application/spdx+json",
+                            Digest = "sha256:sbom",
+                            MediaType = "application/vnd.oci.image.manifest.v1+json",
+                            Size = 123
+                        }
+                    ]
+                },
+                null));
+        using StringWriter output = new();
+        TestCheckCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new CheckOptions
+            {
+                Image = $"{Registry}/repo@sha256:image",
+                ArtifactTypes = ["application/spdx+json"],
+                OutputFormat = CheckOutput.Json
+            }
+        };
+
+        await command.RunAsync();
+        JObject json = JObject.Parse(output.ToString());
+
+        Assert.True((bool)json["succeeded"]!);
+        Assert.True((bool)json["results"]![0]!["found"]!);
+        Assert.Equal("application/spdx+json", (string?)json["results"]![0]!["artifactType"]);
+        Assert.Equal("sha256:sbom", (string?)json["results"]![0]!["referrers"]![0]!["digest"]);
+        Assert.Equal(123, (int)json["results"]![0]!["referrers"]![0]!["size"]!);
+    }
+
+    [Fact]
+    public async Task CheckCommand_WhenRegistryRequestFails_ExitsOne()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("failure"));
+        using StringWriter output = new();
+        TestCheckCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new CheckOptions
+            {
+                Image = $"{Registry}/repo@sha256:image",
+                ArtifactTypes = ["application/spdx+json"]
+            }
+        };
+
+        CommandExitException exception = await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+        Assert.Equal(1, exception.ExitCode);
+    }
+
+    private static Mock<IDockerRegistryClient> CreateClient() =>
+        new() { DefaultValue = DefaultValue.Mock };
+
+    private static IDockerRegistryClientFactory CreateFactory(IDockerRegistryClient client)
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(It.IsAny<string?>())).ReturnsAsync(client);
+        return factory.Object;
+    }
+
+    private static ManifestInfo CreateManifestInfo(string manifestDigest) =>
+        new(
+            "application/test",
+            manifestDigest,
+            new DockerManifest
+            {
+                Config = new ManifestConfig { Digest = "sha256:config" },
+                Layers = []
+            });
+
+    private sealed class TestCheckCommand : CheckCommand
+    {
+        public TestCheckCommand(IDockerRegistryClientFactory factory, TextWriter output)
+            : base(factory, output)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync(TestContext.Current.CancellationToken);
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class CommandExitException : Exception
+    {
+        public CommandExitException(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
@@ -1,0 +1,66 @@
+using Newtonsoft.Json;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class CheckCommand : RegistryCommandBase<CheckOptions>
+{
+    public CheckCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        TextWriter? output = null)
+        : base(
+            "check",
+            "Checks for required OCI referrer artifact types",
+            dockerRegistryClientFactory,
+            output)
+    {
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        bool succeeded = true;
+
+        await ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            OciImageIndex index =
+                await ReferrerHelper.GetReferrersAsync(client, imageName, artifactType: null, ct);
+            CheckResult result = GetResult(index);
+            WriteResult(result);
+            succeeded = result.Succeeded;
+        });
+
+        if (!succeeded)
+        {
+            Exit(2);
+        }
+    }
+
+    private CheckResult GetResult(OciImageIndex index) =>
+        new(Options.ArtifactTypes.Select(artifactType =>
+            new ArtifactTypeCheckResult(
+                artifactType,
+                index.Manifests.Where(referrer =>
+                    string.Equals(referrer.ArtifactType, artifactType, StringComparison.Ordinal)))));
+
+    private void WriteResult(CheckResult result)
+    {
+        if (Options.OutputFormat == CheckOutput.Json)
+        {
+            Output.WriteLine(JsonConvert.SerializeObject(result, JsonHelper.Settings));
+            return;
+        }
+
+        foreach (ArtifactTypeCheckResult artifactTypeResult in result.Results)
+        {
+            Output.WriteLine(
+                $"{(artifactTypeResult.Found ? "PASS" : "FAIL")} {artifactTypeResult.ArtifactType}");
+            foreach (ManifestReference referrer in artifactTypeResult.Referrers)
+            {
+                Output.WriteLine($"  {referrer.Digest}");
+            }
+        }
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
@@ -25,6 +25,7 @@ public class CheckCommand : RegistryCommandBase<CheckOptions>
         {
             using IDockerRegistryClient client =
                 await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            // Fetch all types once instead of traversing the registry for each requirement.
             OciImageIndex index =
                 await ReferrerHelper.GetReferrersAsync(client, imageName, artifactType: null, ct);
             CheckResult result = GetResult(index);

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
@@ -1,0 +1,47 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class CheckOptions : OptionsBase
+{
+    private readonly Argument<string> nameArgument;
+    private readonly Option<string[]> artifactTypeOption;
+    private readonly Option<CheckOutput> outputOption;
+
+    public string Image { get; set; } = string.Empty;
+    public string[] ArtifactTypes { get; set; } = [];
+    public CheckOutput OutputFormat { get; set; }
+
+    public CheckOptions()
+    {
+        nameArgument = Add(new Argument<string>("name")
+        {
+            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+        });
+        artifactTypeOption = Add(new Option<string[]>("--artifact-type")
+        {
+            Description = "Required artifact media type; may be specified multiple times",
+            Required = true,
+            AllowMultipleArgumentsPerToken = false
+        });
+        artifactTypeOption.Validators.Add(result =>
+        {
+            if (result.GetValueOrDefault<string[]>().Any(string.IsNullOrWhiteSpace))
+            {
+                result.AddError("Artifact types cannot be empty or whitespace.");
+            }
+        });
+        outputOption = Add(new Option<CheckOutput>("--output")
+        {
+            Description = "Output format",
+            DefaultValueFactory = _ => CheckOutput.Summary
+        });
+    }
+
+    protected override void GetValues()
+    {
+        Image = GetValue(nameArgument);
+        ArtifactTypes = GetValue(artifactTypeOption) ?? [];
+        OutputFormat = GetValue(outputOption);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckOutput.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckOutput.cs
@@ -1,0 +1,7 @@
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public enum CheckOutput
+{
+    Summary,
+    Json
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckResult.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckResult.cs
@@ -1,0 +1,27 @@
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+public class CheckResult
+{
+    public CheckResult(IEnumerable<ArtifactTypeCheckResult> results)
+    {
+        Results = results.ToArray();
+    }
+
+    public bool Succeeded => Results.All(result => result.Found);
+    public IReadOnlyList<ArtifactTypeCheckResult> Results { get; }
+}
+
+public class ArtifactTypeCheckResult
+{
+    public ArtifactTypeCheckResult(string artifactType, IEnumerable<ManifestReference> referrers)
+    {
+        ArtifactType = artifactType;
+        Referrers = referrers.ToArray();
+    }
+
+    public string ArtifactType { get; }
+    public bool Found => Referrers.Count > 0;
+    public IReadOnlyList<ManifestReference> Referrers { get; }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Valleysoft.DockerRegistryClient;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Newtonsoft.Json;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 namespace Valleysoft.Dredge.Commands.Referrer;
@@ -18,36 +16,9 @@ public class ListCommand : RegistryCommandBase<ListOptions>
         return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
-
-            OciImageIndex initialIndex;
-
-            string digest;
-            if (!string.IsNullOrEmpty(imageName.Digest))
-            {
-                digest = imageName.Digest;
-            }
-            else
-            {
-                ManifestInfo manifestInfo = await client.Manifests.GetAsync(imageName.Repo, imageName.Tag!, ct);
-                digest = manifestInfo.DockerContentDigest;
-            }
-
-            Page<OciImageIndex> indexPage =
-                await client.Referrers.GetAsync(imageName.Repo, digest, Options.ArtifactType, ct);
-            initialIndex = indexPage.Value;
-            while (indexPage.NextPageLink is not null)
-            {
-                Page<OciImageIndex> nextPage =
-                    await client.Referrers.GetNextAsync(indexPage.NextPageLink, ct);
-                initialIndex.Manifests =
-                [
-                    .. initialIndex.Manifests,
-                    .. nextPage.Value.Manifests
-                ];
-                indexPage = nextPage;
-            }
-
-            string output = JsonConvert.SerializeObject(initialIndex, JsonHelper.Settings);
+            OciImageIndex index =
+                await ReferrerHelper.GetReferrersAsync(client, imageName, Options.ArtifactType, ct);
+            string output = JsonConvert.SerializeObject(index, JsonHelper.Settings);
 
             Output.WriteLine(output);
         });

--- a/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ReferrerCommand.cs
@@ -8,6 +8,7 @@ public class ReferrerCommand : Command
         : base("referrer", "Commands related to referrers")
     {
         Subcommands.Add(new ListCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new CheckCommand(dockerRegistryClientFactory));
         Subcommands.Add(new InspectCommand(dockerRegistryClientFactory));
         Subcommands.Add(new GetCommand(dockerRegistryClientFactory));
     }

--- a/src/Valleysoft.Dredge/Commands/Referrer/ReferrerHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ReferrerHelper.cs
@@ -1,0 +1,42 @@
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
+
+namespace Valleysoft.Dredge.Commands.Referrer;
+
+internal static class ReferrerHelper
+{
+    public static async Task<OciImageIndex> GetReferrersAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        string? artifactType,
+        CancellationToken cancellationToken)
+    {
+        string digest;
+        if (!string.IsNullOrEmpty(imageName.Digest))
+        {
+            digest = imageName.Digest;
+        }
+        else
+        {
+            ManifestInfo manifestInfo =
+                await client.Manifests.GetAsync(imageName.Repo, imageName.Tag!, cancellationToken);
+            digest = manifestInfo.DockerContentDigest;
+        }
+
+        Page<OciImageIndex> indexPage =
+            await client.Referrers.GetAsync(imageName.Repo, digest, artifactType, cancellationToken);
+        OciImageIndex index = indexPage.Value;
+        while (indexPage.NextPageLink is not null)
+        {
+            indexPage = await client.Referrers.GetNextAsync(indexPage.NextPageLink, cancellationToken);
+            index.Manifests =
+            [
+                .. index.Manifests,
+                .. indexPage.Value.Manifests
+            ];
+        }
+
+        return index;
+    }
+}


### PR DESCRIPTION
Adds `dredge referrer check` so CI workflows can require specific OCI referrer artifact types and fail predictably when any are missing.

- Resolves tagged references and traverses every referrer page once
- Matches required artifact types exactly and reports matching descriptors in summary or JSON output
- Returns exit code 2 when a required type is missing while preserving exit code 1 for execution errors
- Adds coverage for pagination, tag and digest inputs, validation, output formats, and exit codes
- Documents command behavior, limitations, examples, and CI usage

Fixes: #319