### PR TITLE
Add image filesystem browsing commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ dotnet test --no-restore --filter "FullyQualifiedName~Valleysoft.Dredge.Tests.Co
 dotnet test --no-restore --filter "ClassName=Valleysoft.Dredge.Tests.CompareLayersCommandTests"
 ```
 
-The solution requires the .NET 10 SDK (see `global.json`). The main project multi-targets `net9.0` and `net10.0`; the test project targets `net10.0` only.
+The solution requires the .NET 10 SDK (see `global.json`). The main and test projects multi-target `net9.0` and `net10.0`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Dredge does not modify registry content.
 - Inspect and retrieve OCI artifacts or check for required artifact types in CI.
 - Inspect an image's [configuration](docs/commands/images.md#inspect) and
   [operating system information](docs/commands/images.md#os).
+- Browse, read, and selectively [extract files from Linux
+  images](docs/commands/images.md#ls) with layer provenance.
 - Compare [layers](docs/commands/images.md#compare-layers) or
   [files](docs/commands/images.md#compare-files) between images.
 - [Generate a Dockerfile](docs/commands/images.md#dockerfile) from an image.

--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -6,6 +6,9 @@ All image commands support [platform resolution](../platform-resolution.md) via 
 |-------------|-------------|
 | [`inspect`](#inspect) | Inspect an image configuration |
 | [`os`](#os) | Show OS information |
+| [`ls`](#ls) | List image filesystem entries and layer provenance |
+| [`cat`](#cat) | Write an image file to standard output |
+| [`extract`](#extract) | Extract an image file or directory |
 | [`compare metadata`](#compare-metadata) | Compare image configuration and platform metadata |
 | [`compare layers`](#compare-layers) | Compare the layers of two images |
 | [`compare files`](#compare-files) | Compare the file contents of two images |
@@ -81,6 +84,131 @@ dredge image os mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
   "Version": "10.0.20348.1249"
 }
 ```
+
+## LS
+
+Lists the effective filesystem entries in a Linux image without extracting the
+complete image.
+
+```console
+dredge image ls <image> [path] [-l|--long] [--provenance] [--recursive] [--show-deleted] [--output <text|json>] [--os <os>] [--arch <arch>] [--os-version <version>]
+```
+
+The command lists direct children of the image root or selected directory by
+default. Use `--recursive` to list all descendants. If `path` identifies a
+file or link, the command lists only that entry. Paths may start with `/`.
+
+Text output uses terminal-width name columns relative to the listed directory
+by default, similar to `ls`. Redirected output uses one name per line without
+terminal padding. Use `-l` or `--long` to show file type and mode, UID, GID,
+size, UTC modification time (marked with `Z`), and symbolic-link target. Use
+`--provenance` independently or with `--long` to show the layer index and an
+abbreviated digest for the layer that introduced, modified, or deleted each
+path. Text output labels these values `i`, `m`, and `d`, respectively.
+
+For example, list the periodic task directories in Alpine. Piping the output
+shows the redirected, one-name-per-line format:
+
+```console
+$ dredge image ls alpine:3.22.1 /etc/periodic | cat
+15min
+daily
+hourly
+monthly
+weekly
+```
+
+This multi-layer .NET image shows that `/etc/apk/world` was introduced by
+layer 0 and modified by layer 1:
+
+```console
+$ dredge image ls mcr.microsoft.com/dotnet/runtime-deps:10.0.8-alpine3.23-amd64 /etc/apk/world -l --provenance
+-rw-r--r-- 0 0 127 2026-05-12 05:31Z etc/apk/world  i=0:6a0ac1617861 m=1:243c8d038cfe
+```
+
+Ordinary and opaque OCI whiteouts remove entries from the effective
+filesystem. Removed entries are hidden by default. Use `--show-deleted` to
+include them; combine it with `--provenance` to show the layer that removed
+them.
+
+Layer numbers are zero-based. Use `--output json` for camel-cased
+machine-readable output; text detail options do not alter JSON:
+
+```console
+$ dredge image ls alpine:3.22.1 /etc/alpine-release --output json
+[
+  {
+    "path": "etc/alpine-release",
+    "type": "File",
+    "mode": 420,
+    "userId": 0,
+    "groupId": 0,
+    "size": 7,
+    "modifiedTime": "2025-07-15T10:41:41Z",
+    "introducedLayer": {
+      "index": 0,
+      "digest": "sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8"
+    }
+  }
+]
+```
+
+## Cat
+
+Writes the effective contents of one Linux image file to standard output.
+Standard output contains only file bytes, so the command is safe to use in a
+pipeline or redirect to a binary file.
+
+```console
+dredge image cat <image> <path> [--os <os>] [--arch <arch>] [--os-version <version>]
+```
+
+The command follows symbolic links with Linux path semantics and follows hard
+links to their image-layer content. Link resolution cannot escape the image
+root and fails for dangling links or link loops. The command rejects
+directories, deleted paths, and unsupported file types.
+
+For example:
+
+```console
+$ dredge image cat alpine:3.22.1 /etc/alpine-release
+3.22.1
+```
+
+## Extract
+
+Extracts one effective file or a directory subtree from a Linux image. For a
+directory, Dredge reads the effective entries from all layers but writes only
+the selected subtree.
+
+```console
+dredge image extract <image> <path> <output-path> [--os <os>] [--arch <arch>] [--os-version <version>]
+```
+
+`output-path` must not exist. Dredge validates all archive paths and
+destinations before writing, and it does not overwrite files. Use `/` as
+`path` to extract the complete effective image filesystem.
+
+For example:
+
+```console
+$ dredge image extract alpine:3.22.1 /etc/alpine-release alpine-release
+$ cat alpine-release
+3.22.1
+```
+
+Dredge preserves modification times and, on Unix hosts, available file modes.
+It reports UID and GID through `image ls` but does not apply image
+ownership to the host. Extraction preserves safe hard and symbolic links when
+possible. Symbolic links retain their original targets, including dangling
+targets and targets outside the selected subtree. Hard links whose targets are
+also selected remain hard links; otherwise, Dredge materializes their effective
+content. Archive entries and extraction destinations cannot escape their
+respective roots.
+
+The `ls`, `cat`, and `extract` commands support gzip-compressed Linux tar
+layers. They reject Windows image layers with an explicit unsupported-platform
+error.
 
 ## Compare metadata
 

--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -85,7 +85,7 @@ dredge image os mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
 }
 ```
 
-## LS
+## Ls
 
 Lists the effective filesystem entries in a Linux image without extracting the
 complete image.

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -20,7 +20,7 @@ public class CommandStructureTests
         Mock<IDockerRegistryClientFactory> factory = new();
 
         Assert.Equal(
-            ["compare", "inspect", "os", "save-layers", "dockerfile"],
+            ["compare", "ls", "cat", "extract", "inspect", "os", "save-layers", "dockerfile"],
             new ImageCommand(factory.Object).Subcommands.Select(command => command.Name));
         Assert.Equal(
             ["get", "digest", "resolve"],
@@ -33,6 +33,74 @@ public class CommandStructureTests
         Assert.Equal(
             ["open", "get", "set", "clear-cache"],
             new SettingsCommand().Subcommands.Select(command => command.Name));
+    }
+
+    [Fact]
+    public void ImageFilesystemOptions_BindArgumentsOptionsAndPlatform()
+    {
+        LsOptions ls = Bind(
+            new LsOptions(),
+            "image:tag",
+            "/etc",
+            "--recursive",
+            "--show-deleted",
+            "-l",
+            "--provenance",
+            "--output",
+            "json",
+            "--os",
+            "linux",
+            "--arch",
+            "arm64");
+        CatOptions cat = Bind(new CatOptions(), "image:tag", "/etc/hosts", "--os-version", "1");
+        ExtractOptions extract = Bind(
+            new ExtractOptions(),
+            "image:tag",
+            "/etc",
+            "output",
+            "--arch",
+            "amd64");
+
+        Assert.Equal("/etc", ls.Path);
+        Assert.True(ls.Recursive);
+        Assert.True(ls.ShowDeleted);
+        Assert.True(ls.Long);
+        Assert.True(ls.ShowProvenance);
+        Assert.Equal(LsOutput.Json, ls.OutputFormat);
+        Assert.Equal("linux", ls.Os);
+        Assert.Equal("arm64", ls.Architecture);
+        Assert.Equal("/etc/hosts", cat.Path);
+        Assert.Equal("1", cat.OsVersion);
+        Assert.Equal("/etc", extract.Path);
+        Assert.Equal("output", extract.OutputPath);
+        Assert.Equal("amd64", extract.Architecture);
+    }
+
+    [Fact]
+    public void LsOptions_UseExpectedDefaults()
+    {
+        LsOptions options = Bind(new LsOptions(), "image");
+
+        Assert.Null(options.Path);
+        Assert.False(options.Recursive);
+        Assert.False(options.ShowDeleted);
+        Assert.False(options.Long);
+        Assert.False(options.ShowProvenance);
+        Assert.Equal(LsOutput.Text, options.OutputFormat);
+    }
+
+    [Fact]
+    public void LsOptions_AdvertiseLowercaseOutputValues()
+    {
+        LsOptions options = new();
+        Command command = new("test");
+        options.SetCommandOptions(command);
+        Option outputOption = Assert.Single(
+            command.Options,
+            option => option.Name == "--output");
+
+        Assert.Equal("text|json", outputOption.HelpName);
+        Assert.Empty(command.Parse(["image", "--output", "Json"]).Errors);
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -269,6 +269,17 @@ public class ImageFileSystemTests
                 TestContext.Current.CancellationToken));
     }
 
+    [Theory]
+    [InlineData("control\npath")]
+    [InlineData("control\u001bpath")]
+    public void ImagePath_RejectsControlCharacters(string path)
+    {
+        Assert.Throws<InvalidDataException>(() => ImagePath.NormalizeArchive(path));
+        Assert.Throws<InvalidDataException>(() => ImagePath.NormalizeRequested(path));
+        Assert.Throws<InvalidDataException>(
+            () => ImagePath.ResolveLinkTarget(string.Empty, path, string.Empty, "link"));
+    }
+
     [Fact]
     public async Task Index_WhenLayerArchiveIsInvalid_ProvidesLayerContext()
     {

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -117,6 +117,43 @@ public class ImageFileSystemTests
         }
     }
 
+    [Fact]
+    public async Task ListAndExtract_ResolveIntermediateSymbolicLinks()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        using IDockerRegistryClient client = CreateClient(
+        [
+            CreateLayer(
+                Entry.File("usr/bin/tool", "tool"),
+                Entry.SymbolicLink("bin", "/usr/bin"))
+        ]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            ImageFileSystemEntry listed = Assert.Single(
+                fileSystem.List("bin/tool", recursive: false, showDeleted: false));
+            Assert.Equal("bin/tool", listed.Path);
+
+            await fileSystem.ExtractAsync(
+                "bin/tool",
+                output,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("tool", File.ReadAllText(output));
+        }
+        finally
+        {
+            File.Delete(output);
+        }
+    }
+
     [Theory]
     [InlineData(TarEntryFormat.Pax)]
     [InlineData(TarEntryFormat.Gnu)]
@@ -311,6 +348,44 @@ public class ImageFileSystemTests
             {
                 Directory.Delete(rootOutput, recursive: true);
             }
+        }
+    }
+
+    [Fact]
+    public async Task Extract_HardLinkSurvivesWhiteoutedTargetParent()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        using IDockerRegistryClient client = CreateClient(
+        [
+            CreateLayer(
+                Entry.File("original/file", "content"),
+                Entry.HardLink("survivor", "original/file")),
+            CreateLayer(Entry.File(".wh.original", ""))
+        ]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            ImageFileSystemEntry listed = Assert.Single(
+                fileSystem.List("survivor", recursive: false, showDeleted: false));
+            Assert.Equal(7, listed.Size);
+
+            await fileSystem.ExtractAsync(
+                "survivor",
+                output,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("content", File.ReadAllText(output));
+        }
+        finally
+        {
+            File.Delete(output);
         }
     }
 

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -652,6 +652,28 @@ public class ImageFileSystemTests
     }
 
     [Fact]
+    public async Task Extract_WhenDirectoryCreationIsCanceled_RemovesOutput()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        using IDockerRegistryClient client = CreateClient(
+            [CreateLayer(Entry.Directory("tree/nested"))]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => fileSystem.ExtractAsync("tree", output, cancellation.Token));
+
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
     public async Task Operations_RejectTraversalAndHonorCancellation()
     {
         using IDockerRegistryClient client =

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -83,7 +83,10 @@ public class ImageFileSystemTests
                 Entry.SymbolicLink("absolute", "/data/value"),
                 Entry.SymbolicLink("unicode", unicodePath),
                 Entry.HardLink("hard", "data/value"),
-                Entry.HardLink("hard-symbolic", "relative")),
+                Entry.HardLink("hard-symbolic", "relative"),
+                Entry.File("usr/bin/tool", "tool"),
+                Entry.SymbolicLink("bin", "/usr/bin"),
+                Entry.HardLink("hard-symlinked-parent", "bin/tool")),
             CreateLayer(Entry.File("data/value", binary))
         ];
         using IDockerRegistryClient client = CreateClient(layers).Object;
@@ -101,7 +104,8 @@ public class ImageFileSystemTests
             ("unicode", Encoding.UTF8.GetBytes("certificate")),
             ("duplicate", Encoding.UTF8.GetBytes("second")),
             ("hard", Encoding.UTF8.GetBytes("old")),
-            ("hard-symbolic", binary)
+            ("hard-symbolic", binary),
+            ("hard-symlinked-parent", Encoding.UTF8.GetBytes("tool"))
         })
         {
             using MemoryStream output = new();
@@ -338,11 +342,50 @@ public class ImageFileSystemTests
                 "1199",
                 File.ReadAllText(Path.Combine(output, "file-1199")));
         }
+
         finally
         {
             if (Directory.Exists(output))
             {
                 Directory.Delete(output, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Extract_AllowsUserSelectedSymlinkedParent()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        string actualParent = Path.Combine(root, "actual");
+        string linkedParent = Path.Combine(root, "linked");
+        string output = Path.Combine(linkedParent, "file");
+        using IDockerRegistryClient client =
+            CreateClient([CreateLayer(Entry.File("file", "value"))]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            Directory.CreateDirectory(actualParent);
+            Directory.CreateSymbolicLink(linkedParent, actualParent);
+
+            await fileSystem.ExtractAsync(
+                "file",
+                output,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("value", File.ReadAllText(Path.Combine(actualParent, "file")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
             }
         }
     }

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -154,6 +154,29 @@ public class ImageFileSystemTests
         }
     }
 
+    [Fact]
+    public async Task List_ShowDeletedResolvesIntermediateSymbolicLinks()
+    {
+        using IDockerRegistryClient client = CreateClient(
+        [
+            CreateLayer(
+                Entry.File("usr/bin/deleted", "content"),
+                Entry.SymbolicLink("bin", "/usr/bin")),
+            CreateLayer(Entry.File("usr/bin/.wh.deleted", ""))
+        ]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        ImageFileSystemEntry listed = Assert.Single(
+            fileSystem.List("bin/deleted", recursive: false, showDeleted: true));
+
+        Assert.Equal("bin/deleted", listed.Path);
+        Assert.Equal(1, listed.DeletedLayer?.Index);
+    }
+
     [Theory]
     [InlineData(TarEntryFormat.Pax)]
     [InlineData(TarEntryFormat.Gnu)]
@@ -387,6 +410,35 @@ public class ImageFileSystemTests
         {
             File.Delete(output);
         }
+    }
+
+    [Fact]
+    public async Task Extract_DirectoryRejectsUnsupportedDescendant()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        using IDockerRegistryClient client = CreateClient(
+        [
+            CreateLayer(
+                Entry.File("tree/file", "content"),
+                Entry.Other("tree/device"))
+        ]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("/tree/device", exception.Message);
+        Assert.False(File.Exists(output));
+        Assert.False(Directory.Exists(output));
     }
 
     [Fact]
@@ -919,5 +971,8 @@ public class ImageFileSystemTests
 
         public static Entry HardLink(string path, string target) =>
             new(TarEntryType.HardLink, path, null, target);
+
+        public static Entry Other(string path) =>
+            new(TarEntryType.Fifo, path, null, null);
     }
 }

--- a/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageFileSystemTests.cs
@@ -1,0 +1,805 @@
+namespace Valleysoft.Dredge.Tests;
+
+using Spectre.Console;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.Dredge.Commands;
+using Valleysoft.Dredge.Commands.Image;
+
+public class ImageFileSystemTests
+{
+    private const string ConfigDigest = "sha256:config";
+    private static readonly ImageName ImageName = ImageName.Parse("registry.test/repo:tag");
+
+    [Fact]
+    public async Task Index_AppliesLayersWhiteoutsAndProvenance()
+    {
+        byte[][] layers =
+        [
+            CreateLayer(
+                Entry.File("etc/config", "old"),
+                Entry.File("etc/deleted", "gone"),
+                Entry.File("opaque/old", "gone"),
+                Entry.File("recreated", "first")),
+            CreateLayer(
+                Entry.File("etc/config", "new"),
+                Entry.File("etc/.wh.deleted", ""),
+                Entry.File("opaque/.wh..wh..opq", ""),
+                Entry.File("opaque/new", "new"),
+                Entry.File(".wh.recreated", "")),
+            CreateLayer(Entry.File("recreated", "again"))
+        ];
+        using IDockerRegistryClient client = CreateClient(layers).Object;
+
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["etc", "opaque", "recreated"],
+            fileSystem.List(null, recursive: false, showDeleted: false)
+                .Select(entry => entry.Path));
+        IReadOnlyList<ImageFileSystemEntry> all =
+            fileSystem.List(null, recursive: true, showDeleted: true);
+        ImageFileSystemEntry config = Assert.Single(all, entry => entry.Path == "etc/config");
+        Assert.Equal(0, config.IntroducedLayer.Index);
+        Assert.Equal(1, config.ModifiedLayer?.Index);
+        ImageFileSystemEntry deleted = Assert.Single(all, entry => entry.Path == "etc/deleted");
+        Assert.Equal(1, deleted.DeletedLayer?.Index);
+        Assert.Same(
+            deleted,
+            Assert.Single(fileSystem.List("etc/deleted", recursive: false, showDeleted: true)));
+        Assert.Contains(all, entry => entry.Path == "opaque/old" && entry.DeletedLayer?.Index == 1);
+        ImageFileSystemEntry recreated = Assert.Single(all, entry => entry.Path == "recreated");
+        Assert.Equal(2, recreated.IntroducedLayer.Index);
+        Assert.Null(recreated.ModifiedLayer);
+        Assert.Null(recreated.DeletedLayer);
+        Assert.Equal(
+            all.OrderBy(entry => entry.Path, StringComparer.Ordinal).Select(entry => entry.Path),
+            all.Select(entry => entry.Path));
+    }
+
+    [Fact]
+    public async Task CopyFile_FollowsLinksAndReturnsExactEffectiveBytes()
+    {
+        byte[] binary = [0, 1, 2, 10, 13, 255];
+        const string unicodePath = "data/Főtanúsítvány.pem";
+        byte[][] layers =
+        [
+            CreateLayer(
+                Entry.File("data/value", "old"),
+                Entry.File(unicodePath, "certificate"),
+                Entry.File("duplicate", "first"),
+                Entry.File("duplicate", "second"),
+                Entry.SymbolicLink("relative", "data/value"),
+                Entry.SymbolicLink("absolute", "/data/value"),
+                Entry.SymbolicLink("unicode", unicodePath),
+                Entry.HardLink("hard", "data/value"),
+                Entry.HardLink("hard-symbolic", "relative")),
+            CreateLayer(Entry.File("data/value", binary))
+        ];
+        using IDockerRegistryClient client = CreateClient(layers).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        foreach ((string path, byte[] expected) in new[]
+        {
+            ("data/value", binary),
+            ("relative", binary),
+            ("absolute", binary),
+            ("unicode", Encoding.UTF8.GetBytes("certificate")),
+            ("duplicate", Encoding.UTF8.GetBytes("second")),
+            ("hard", Encoding.UTF8.GetBytes("old")),
+            ("hard-symbolic", binary)
+        })
+        {
+            using MemoryStream output = new();
+            await fileSystem.CopyFileToAsync(
+                path,
+                output,
+                TestContext.Current.CancellationToken);
+            Assert.Equal(expected, output.ToArray());
+        }
+    }
+
+    [Theory]
+    [InlineData(TarEntryFormat.Pax)]
+    [InlineData(TarEntryFormat.Gnu)]
+    public async Task Index_ReadsSupportedTarFormats(TarEntryFormat format)
+    {
+        const string Target = "Főtanúsítvány.pem";
+        using IDockerRegistryClient client = CreateClient(
+            [CreateLayer(
+                format,
+                Entry.File(Target, "x"),
+                Entry.SymbolicLink("link", Target))]).Object;
+
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+        using MemoryStream output = new();
+        await fileSystem.CopyFileToAsync(
+            "link",
+            output,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("x", Encoding.UTF8.GetString(output.ToArray()));
+        Assert.Equal(
+            Target,
+            Assert.Single(fileSystem.List("link", recursive: false, showDeleted: false))
+                .LinkTarget);
+    }
+
+    [Fact]
+    public async Task CopyFile_RejectsDanglingAndLoopingLinksAndClampsAtRoot()
+    {
+        byte[][] layers =
+        [
+            CreateLayer(
+                Entry.SymbolicLink("dangling", "missing"),
+                Entry.SymbolicLink("a", "b"),
+                Entry.SymbolicLink("b", "a"))
+        ];
+        using IDockerRegistryClient client = CreateClient(layers).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => fileSystem.CopyFileToAsync(
+                "dangling",
+                new MemoryStream(),
+                TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => fileSystem.CopyFileToAsync(
+                "a",
+                new MemoryStream(),
+                TestContext.Current.CancellationToken));
+
+        using IDockerRegistryClient rootClient = CreateClient(
+            [CreateLayer(
+                Entry.File("outside", "root"),
+                Entry.SymbolicLink("escape", "../../outside"))]).Object;
+        ImageFileSystem rootFileSystem = await ImageFileSystem.CreateAsync(
+            rootClient,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+        using MemoryStream rootOutput = new();
+        await rootFileSystem.CopyFileToAsync(
+            "escape",
+            rootOutput,
+            TestContext.Current.CancellationToken);
+        Assert.Equal("root", Encoding.UTF8.GetString(rootOutput.ToArray()));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("/absolute")]
+    [InlineData(@"windows\path")]
+    public async Task Index_RejectsUnsafeArchivePaths(string path)
+    {
+        using IDockerRegistryClient client =
+            CreateClient([CreateLayer(Entry.File(path, "unsafe"))]).Object;
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => ImageFileSystem.CreateAsync(
+                client,
+                ImageName,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Index_WhenLayerArchiveIsInvalid_ProvidesLayerContext()
+    {
+        using IDockerRegistryClient client =
+            CreateClient([Encoding.UTF8.GetBytes("not a gzip archive")]).Object;
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => ImageFileSystem.CreateAsync(
+                client,
+                ImageName,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("Layer 0 ('sha256:layer-0')", exception.Message);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task Extract_AssemblesDirectoryAcrossLayersAndDoesNotOverwrite()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        string rootOutput = $"{output}-root";
+        byte[][] layers =
+        [
+            CreateLayer(
+                Entry.Directory("tree/empty"),
+                Entry.File("tree/one", "one"),
+                Entry.HardLink("tree/hard", "tree/one"),
+                Entry.File("tree/repeated", "old"),
+                Entry.HardLink("tree/repeated-hard", "tree/repeated"),
+                Entry.File("tree/repeated", "new"),
+                Entry.File("tree/change", "old"),
+                Entry.SymbolicLink("tree/dangling", "missing"),
+                Entry.HardLink("tree/symlink-hard", "tree/dangling"),
+                Entry.SymbolicLink("tree/outside", "../outside-target"),
+                Entry.File("outside-target", "outside"),
+                Entry.HardLink("tree/outside-hard", "outside-target")),
+            CreateLayer(
+                Entry.File("tree/change", "new"),
+                Entry.File("tree/two", "two"))
+        ];
+        using IDockerRegistryClient client = CreateClient(layers).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            await fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("one", File.ReadAllText(Path.Combine(output, "one")));
+            Assert.Equal("one", File.ReadAllText(Path.Combine(output, "hard")));
+            File.WriteAllText(Path.Combine(output, "one"), "linked");
+            Assert.Equal("linked", File.ReadAllText(Path.Combine(output, "hard")));
+            Assert.Equal("new", File.ReadAllText(Path.Combine(output, "repeated")));
+            Assert.Equal("old", File.ReadAllText(Path.Combine(output, "repeated-hard")));
+            File.WriteAllText(Path.Combine(output, "repeated"), "changed");
+            Assert.Equal("old", File.ReadAllText(Path.Combine(output, "repeated-hard")));
+            Assert.Equal("new", File.ReadAllText(Path.Combine(output, "change")));
+            Assert.Equal("two", File.ReadAllText(Path.Combine(output, "two")));
+            Assert.True(Directory.Exists(Path.Combine(output, "empty")));
+            Assert.Equal("missing", new FileInfo(Path.Combine(output, "dangling")).LinkTarget);
+            Assert.Equal(
+                "missing",
+                new FileInfo(Path.Combine(output, "symlink-hard")).LinkTarget);
+            Assert.Equal(
+                "../outside-target",
+                new FileInfo(Path.Combine(output, "outside")).LinkTarget);
+            Assert.Equal(
+                "outside",
+                File.ReadAllText(Path.Combine(output, "outside-hard")));
+            await Assert.ThrowsAsync<IOException>(
+                () => fileSystem.ExtractAsync(
+                    "tree",
+                    output,
+                    TestContext.Current.CancellationToken));
+            await fileSystem.ExtractAsync(
+                "/",
+                rootOutput,
+                TestContext.Current.CancellationToken);
+            Assert.Equal(
+                "two",
+                File.ReadAllText(Path.Combine(rootOutput, "tree", "two")));
+        }
+
+        finally
+        {
+            if (Directory.Exists(output))
+            {
+                Directory.Delete(output, recursive: true);
+            }
+            if (Directory.Exists(rootOutput))
+            {
+                Directory.Delete(rootOutput, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Extract_HandlesLargeFileSet()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        Entry[] files = Enumerable.Range(0, 1200)
+            .Select(index => Entry.File($"tree/file-{index}", index.ToString()))
+            .ToArray();
+        using IDockerRegistryClient client =
+            CreateClient([CreateLayer(files)]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            await fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(
+                "1199",
+                File.ReadAllText(Path.Combine(output, "file-1199")));
+        }
+        finally
+        {
+            if (Directory.Exists(output))
+            {
+                Directory.Delete(output, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Extract_WhenLaterLayerFails_RemovesPartialOutput()
+    {
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        byte[][] layers =
+        [
+            CreateLayer(Entry.File("tree/first", "first")),
+            CreateLayer(Entry.File("tree/second", "second"))
+        ];
+        Mock<IDockerRegistryClient> client = CreateClient(layers);
+        int secondLayerRequests = 0;
+        client
+            .Setup(item => item.Blobs.GetAsync(
+                ImageName.Repo,
+                "sha256:layer-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                secondLayerRequests++;
+                if (secondLayerRequests > 1)
+                {
+                    throw new IOException("Layer download failed.");
+                }
+                return new MemoryStream(layers[1]);
+            });
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client.Object,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(
+            () => fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("Layer download failed.", exception.Message);
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
+    public async Task Extract_WhenSingleFileFails_RemovesCreatedParentDirectories()
+    {
+        string outputRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        string output = Path.Combine(outputRoot, "nested", "file");
+        byte[] layer = CreateLayer(Entry.File("file", "value"));
+        Mock<IDockerRegistryClient> client = CreateClient([layer]);
+        int layerRequests = 0;
+        client
+            .Setup(item => item.Blobs.GetAsync(
+                ImageName.Repo,
+                "sha256:layer-0",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                layerRequests++;
+                if (layerRequests > 1)
+                {
+                    throw new IOException("Layer download failed.");
+                }
+                return new MemoryStream(layer);
+            });
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client.Object,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(
+            () => fileSystem.ExtractAsync(
+                "file",
+                output,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("Layer download failed.", exception.Message);
+        Assert.False(Directory.Exists(outputRoot));
+    }
+
+    [Fact]
+    public async Task Extract_WhenDirectoryFails_RemovesCreatedParentDirectories()
+    {
+        string outputRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        string output = Path.Combine(outputRoot, "nested", "tree");
+        byte[] layer = CreateLayer(Entry.File("tree/file", "value"));
+        Mock<IDockerRegistryClient> client = CreateClient([layer]);
+        int layerRequests = 0;
+        client
+            .Setup(item => item.Blobs.GetAsync(
+                ImageName.Repo,
+                "sha256:layer-0",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                layerRequests++;
+                if (layerRequests > 1)
+                {
+                    throw new IOException("Layer download failed.");
+                }
+                return new MemoryStream(layer);
+            });
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client.Object,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(
+            () => fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("Layer download failed.", exception.Message);
+        Assert.False(Directory.Exists(outputRoot));
+    }
+
+    [Fact]
+    public async Task Operations_RejectTraversalAndHonorCancellation()
+    {
+        using IDockerRegistryClient client =
+            CreateClient([CreateLayer(Entry.File("file", "value"))]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        Assert.Throws<InvalidDataException>(
+            () => fileSystem.List("../outside", recursive: false, showDeleted: false));
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => fileSystem.CopyFileToAsync(
+                "file",
+                new MemoryStream(),
+                cancellation.Token));
+    }
+
+    [Theory]
+    [InlineData("tree/name:stream")]
+    [InlineData("tree/name.")]
+    [InlineData("tree/name ")]
+    [InlineData("tree/NUL.txt")]
+    [InlineData("tree/COM1")]
+    [InlineData("tree/CONIN$")]
+    [InlineData("tree/CONOUT$.txt")]
+    public async Task Extract_OnWindowsRejectsInvalidDestinationNames(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string output = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-filesystem-{Guid.NewGuid():N}");
+        using IDockerRegistryClient client =
+            CreateClient([CreateLayer(Entry.File(path, "value"))]).Object;
+        ImageFileSystem fileSystem = await ImageFileSystem.CreateAsync(
+            client,
+            ImageName,
+            new PlatformOptionsBase(),
+            TestContext.Current.CancellationToken);
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => fileSystem.ExtractAsync(
+                "tree",
+                output,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("valid Windows path", exception.Message);
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
+    public async Task LsCommand_ProducesCamelCaseJsonAndForwardsPlatformOptions()
+    {
+        byte[][] layers = [CreateLayer(Entry.File("file", "value"))];
+        Mock<IDockerRegistryClient> client = CreateClient(layers);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync("registry.test")).ReturnsAsync(client.Object);
+        StringWriter writer = new();
+        IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer)
+        });
+        LsCommand command = new TestLsCommand(factory.Object, console);
+
+        int exitCode = await command
+            .Parse([ImageName.ToString(), "--output", "json", "--os", "linux", "--arch", "amd64"])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+        using JsonDocument json = JsonDocument.Parse(writer.ToString());
+        JsonElement item = Assert.Single(json.RootElement.EnumerateArray());
+        Assert.Equal("file", item.GetProperty("path").GetString());
+        Assert.Equal("File", item.GetProperty("type").GetString());
+        Assert.EndsWith("Z", item.GetProperty("modifiedTime").GetString());
+        Assert.Equal(0, item.GetProperty("introducedLayer").GetProperty("index").GetInt32());
+        Assert.False(item.TryGetProperty("Path", out _));
+        Assert.Equal("linux", command.Options.Os);
+        Assert.Equal("amd64", command.Options.Architecture);
+    }
+
+    [Fact]
+    public async Task LsCommand_HumanOutputUsesLsStyleDetailLevels()
+    {
+        Mock<IDockerRegistryClient> client =
+            CreateClient([CreateLayer(
+                Entry.File("dir/file", "value"),
+                Entry.SymbolicLink("dir/link", "file"),
+                Entry.File("dir/second", "value"))]);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync("registry.test")).ReturnsAsync(client.Object);
+
+        string defaultOutput = await InvokeLsCommandAsync(factory.Object, "/dir");
+        string longOutput = await InvokeLsCommandAsync(factory.Object, "/dir", "-l");
+        string provenanceOutput = await InvokeLsCommandAsync(
+            factory.Object,
+            "/dir",
+            "--provenance");
+        string combinedOutput = await InvokeLsCommandAsync(
+            factory.Object,
+            "/dir",
+            "--long",
+            "--provenance");
+
+        Assert.Equal(
+            ["file", "link", "second"],
+            defaultOutput.Split(
+                Environment.NewLine,
+                StringSplitOptions.RemoveEmptyEntries));
+        Assert.DoesNotContain("dir/", defaultOutput);
+        Assert.DoesNotContain("rwx", defaultOutput);
+        Assert.DoesNotContain("i=", defaultOutput);
+        Assert.Contains("-rwxr-xr-x", longOutput);
+        Assert.Contains("1970-01-01 00:00Z", longOutput);
+        Assert.Contains("link -> file", longOutput);
+        Assert.DoesNotContain("i=", longOutput);
+        Assert.Contains("i=", provenanceOutput);
+        Assert.Contains("0:layer-0", provenanceOutput);
+        Assert.DoesNotContain("rwx", provenanceOutput);
+        Assert.DoesNotContain("->", provenanceOutput);
+        Assert.Contains("-rwxr-xr-x", combinedOutput);
+        Assert.Contains("i=", combinedOutput);
+        Assert.All(
+            longOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries),
+            line => Assert.Equal(line.TrimEnd(), line));
+        Assert.All(
+            combinedOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries),
+            line => Assert.Equal(line.TrimEnd(), line));
+    }
+
+    [Fact]
+    public async Task CatCommand_WritesOnlyBinaryContentToOutputStream()
+    {
+        byte[] content = [0, 10, 255, 42];
+        Mock<IDockerRegistryClient> client =
+            CreateClient([CreateLayer(Entry.File("file", content))]);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync("registry.test")).ReturnsAsync(client.Object);
+        using MemoryStream output = new();
+        CatCommand command = new TestCatCommand(factory.Object, output);
+
+        int exitCode = await command
+            .Parse([ImageName.ToString(), "file"])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(content, output.ToArray());
+    }
+
+    [Fact]
+    public async Task Create_RejectsWindowsImagesBeforeReadingLayers()
+    {
+        Mock<IDockerRegistryClient> client =
+            CreateClient([CreateLayer(Entry.File("file", "value"))], os: "windows");
+
+        NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ImageFileSystem.CreateAsync(
+                client.Object,
+                ImageName,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("Linux", exception.Message);
+        Assert.Contains("Windows", exception.Message);
+        client.Verify(
+            item => item.Blobs.GetAsync(
+                ImageName.Repo,
+                "sha256:layer-0",
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static async Task<string> InvokeLsCommandAsync(
+        IDockerRegistryClientFactory factory,
+        params string[] options)
+    {
+        StringWriter writer = new();
+        IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer)
+        });
+        TestLsCommand command = new(factory, console);
+
+        int exitCode = await command
+            .Parse([ImageName.ToString(), .. options])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private sealed class TestLsCommand : LsCommand
+    {
+        public TestLsCommand(
+            IDockerRegistryClientFactory dockerRegistryClientFactory,
+            IAnsiConsole console)
+            : base(dockerRegistryClientFactory, console)
+        {
+        }
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) =>
+            throw new InvalidOperationException($"Command exited with code {exitCode}.");
+    }
+
+    private sealed class TestCatCommand : CatCommand
+    {
+        public TestCatCommand(
+            IDockerRegistryClientFactory dockerRegistryClientFactory,
+            Stream output)
+            : base(dockerRegistryClientFactory, output)
+        {
+        }
+
+        protected override TextWriter Error => TextWriter.Null;
+
+        protected override void Exit(int exitCode) =>
+            throw new InvalidOperationException($"Command exited with code {exitCode}.");
+    }
+
+    private static Mock<IDockerRegistryClient> CreateClient(
+        byte[][] layers,
+        string os = "linux")
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        DockerManifest manifest = new()
+        {
+            Config = new ManifestConfig { Digest = ConfigDigest },
+            Layers = layers
+                .Select((_, index) => new ManifestLayer { Digest = $"sha256:layer-{index}" })
+                .ToArray()
+        };
+        client
+            .Setup(item => item.Manifests.GetAsync(
+                ImageName.Repo,
+                ImageName.Tag!,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/vnd.oci.image.manifest.v1+json",
+                "sha256:manifest",
+                manifest));
+        client
+            .Setup(item => item.Blobs.GetAsync(
+                ImageName.Repo,
+                ConfigDigest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(
+                Encoding.UTF8.GetBytes($"{{\"os\":\"{os}\"}}")));
+        for (int index = 0; index < layers.Length; index++)
+        {
+            int captured = index;
+            client
+                .Setup(item => item.Blobs.GetAsync(
+                    ImageName.Repo,
+                    $"sha256:layer-{captured}",
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new MemoryStream(layers[captured]));
+        }
+        return client;
+    }
+
+    private static byte[] CreateLayer(params Entry[] entries)
+    {
+        return CreateLayer(TarEntryFormat.Pax, entries);
+    }
+
+    private static byte[] CreateLayer(TarEntryFormat format, params Entry[] entries)
+    {
+        using MemoryStream result = new();
+        using (GZipStream gzip = new(result, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, format, leaveOpen: true))
+        {
+            foreach (Entry definition in entries)
+            {
+                TarEntry entry = format == TarEntryFormat.Gnu
+                    ? new GnuTarEntry(definition.Type, definition.Path)
+                    : new PaxTarEntry(definition.Type, definition.Path);
+                entry.Mode = (UnixFileMode)Convert.ToInt32("755", 8);
+                entry.ModificationTime = DateTimeOffset.FromUnixTimeSeconds(1);
+                if (definition.LinkTarget is not null)
+                {
+                    entry.LinkName = definition.LinkTarget;
+                }
+                if (definition.Content is not null)
+                {
+                    entry.DataStream = new MemoryStream(definition.Content);
+                }
+                writer.WriteEntry(entry);
+            }
+        }
+        return result.ToArray();
+    }
+
+    private sealed record Entry(
+        TarEntryType Type,
+        string Path,
+        byte[]? Content,
+        string? LinkTarget)
+    {
+        public static Entry File(string path, string content) =>
+            File(path, Encoding.UTF8.GetBytes(content));
+
+        public static Entry File(string path, byte[] content) =>
+            new(TarEntryType.RegularFile, path, content, null);
+
+        public static Entry Directory(string path) =>
+            new(TarEntryType.Directory, path, null, null);
+
+        public static Entry SymbolicLink(string path, string target) =>
+            new(TarEntryType.SymbolicLink, path, null, target);
+
+        public static Entry HardLink(string path, string target) =>
+            new(TarEntryType.HardLink, path, null, target);
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
+++ b/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Valleysoft.Dredge/Commands/Image/CatCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CatCommand.cs
@@ -1,0 +1,31 @@
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class CatCommand : RegistryCommandBase<CatOptions>
+{
+    private readonly Stream standardOutput;
+
+    public CatCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        Stream? standardOutput = null)
+        : base(
+            "cat",
+            "Writes a file from an image filesystem to standard output",
+            dockerRegistryClientFactory)
+    {
+        this.standardOutput = standardOutput ?? Console.OpenStandardOutput();
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            ImageFileSystem fileSystem =
+                await ImageFileSystem.CreateAsync(client, imageName, Options, ct);
+            await fileSystem.CopyFileToAsync(Options.Path, standardOutput, ct);
+            await standardOutput.FlushAsync(ct);
+        });
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
@@ -1,0 +1,31 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class CatOptions : PlatformOptionsBase
+{
+    private readonly Argument<string> imageArgument;
+    private readonly Argument<string> pathArgument;
+
+    public string Image { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+
+    public CatOptions()
+    {
+        imageArgument = Add(new Argument<string>("image")
+        {
+            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+        });
+        pathArgument = Add(new Argument<string>("path")
+        {
+            Description = "Image file path to write to standard output"
+        });
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        Image = GetValue(imageArgument);
+        Path = GetValue(pathArgument);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/ExtractCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/ExtractCommand.cs
@@ -1,0 +1,25 @@
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class ExtractCommand : RegistryCommandBase<ExtractOptions>
+{
+    public ExtractCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : base(
+            "extract",
+            "Extracts a file or directory from an image filesystem",
+            dockerRegistryClientFactory)
+    {
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            ImageFileSystem fileSystem =
+                await ImageFileSystem.CreateAsync(client, imageName, Options, ct);
+            await fileSystem.ExtractAsync(Options.Path, Options.OutputPath, ct);
+        });
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
@@ -1,0 +1,38 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class ExtractOptions : PlatformOptionsBase
+{
+    private readonly Argument<string> imageArgument;
+    private readonly Argument<string> pathArgument;
+    private readonly Argument<string> outputPathArgument;
+
+    public string Image { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string OutputPath { get; set; } = string.Empty;
+
+    public ExtractOptions()
+    {
+        imageArgument = Add(new Argument<string>("image")
+        {
+            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+        });
+        pathArgument = Add(new Argument<string>("path")
+        {
+            Description = "Image file or directory path to extract"
+        });
+        outputPathArgument = Add(new Argument<string>("output-path")
+        {
+            Description = "New destination path"
+        });
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        Image = GetValue(imageArgument);
+        Path = GetValue(pathArgument);
+        OutputPath = GetValue(outputPathArgument);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/ImageCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/ImageCommand.cs
@@ -8,6 +8,9 @@ public class ImageCommand : Command
         : base("image", "Commands related to container images")
     {
         Subcommands.Add(new CompareCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new LsCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new CatCommand(dockerRegistryClientFactory));
+        Subcommands.Add(new ExtractCommand(dockerRegistryClientFactory));
         Subcommands.Add(new InspectCommand(dockerRegistryClientFactory));
         Subcommands.Add(new OsCommand(dockerRegistryClientFactory));
         Subcommands.Add(new SaveLayersCommand(dockerRegistryClientFactory));

--- a/src/Valleysoft.Dredge/Commands/Image/LsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsCommand.cs
@@ -1,0 +1,205 @@
+using Newtonsoft.Json;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using System.Globalization;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class LsCommand : RegistryCommandBase<LsOptions>
+{
+    private const int DisplayDigestLength = 12;
+    private readonly IAnsiConsole ansiConsole;
+
+    public LsCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IAnsiConsole? ansiConsole = null)
+        : base(
+            "ls",
+            "Lists files in an image filesystem with layer provenance",
+            dockerRegistryClientFactory)
+    {
+        this.ansiConsole = ansiConsole ?? AnsiConsole.Console;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ImageName imageName = ImageName.Parse(Options.Image);
+        return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
+        {
+            using IDockerRegistryClient client =
+                await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
+            ImageFileSystem fileSystem =
+                await ImageFileSystem.CreateAsync(client, imageName, Options, ct);
+            IReadOnlyList<ImageFileSystemEntry> entries =
+                fileSystem.List(Options.Path, Options.Recursive, Options.ShowDeleted);
+
+            if (Options.OutputFormat == LsOutput.Json)
+            {
+                ansiConsole.Profile.Out.Writer.WriteLine(
+                    JsonConvert.SerializeObject(entries, JsonHelper.Settings));
+            }
+            else
+            {
+                WriteTextOutput(entries, Options);
+            }
+        });
+    }
+
+    private void WriteTextOutput(
+        IEnumerable<ImageFileSystemEntry> entries,
+        LsOptions options)
+    {
+        ImageFileSystemEntry[] entryArray = entries.ToArray();
+        string listedPath = ImagePath.NormalizeRequested(options.Path);
+        if (!options.Long && !options.ShowProvenance)
+        {
+            IEnumerable<string> namePaths = entryArray.Select(
+                entry => FormatPath(entry, listedPath));
+            if (ansiConsole.Profile.Out.IsTerminal)
+            {
+                ansiConsole.Write(new Columns(namePaths.Select(path => new Text(path))));
+            }
+            else
+            {
+                foreach (string path in namePaths)
+                {
+                    ansiConsole.Profile.Out.Writer.WriteLine(path);
+                }
+            }
+            return;
+        }
+
+        string[] paths = entryArray
+            .Select(entry => options.Long
+                ? FormatLongPath(entry, listedPath)
+                : FormatPath(entry, listedPath))
+            .ToArray();
+        int userIdWidth = entryArray
+            .Select(entry => entry.UserId.ToString(CultureInfo.InvariantCulture).Length)
+            .DefaultIfEmpty()
+            .Max();
+        int groupIdWidth = entryArray
+            .Select(entry => entry.GroupId.ToString(CultureInfo.InvariantCulture).Length)
+            .DefaultIfEmpty()
+            .Max();
+        int sizeWidth = entryArray
+            .Select(entry => entry.Size.ToString(CultureInfo.InvariantCulture).Length)
+            .DefaultIfEmpty()
+            .Max();
+        for (int index = 0; index < entryArray.Length; index++)
+        {
+            ImageFileSystemEntry entry = entryArray[index];
+            TextWriter writer = ansiConsole.Profile.Out.Writer;
+            if (options.Long)
+            {
+                writer.Write(FormatMode(entry));
+                writer.Write(' ');
+                writer.Write(entry.UserId.ToString(CultureInfo.InvariantCulture).PadLeft(userIdWidth));
+                writer.Write(' ');
+                writer.Write(entry.GroupId.ToString(CultureInfo.InvariantCulture).PadLeft(groupIdWidth));
+                writer.Write(' ');
+                writer.Write(entry.Size.ToString(CultureInfo.InvariantCulture).PadLeft(sizeWidth));
+                writer.Write(' ');
+                writer.Write(entry.ModifiedTime?.ToString(
+                    "yyyy-MM-dd HH:mm'Z'",
+                    CultureInfo.InvariantCulture) ?? new string(' ', 17));
+                writer.Write(' ');
+            }
+            writer.Write(paths[index]);
+            if (options.ShowProvenance)
+            {
+                writer.Write("  ");
+                writer.Write(FormatLayers(entry));
+            }
+            writer.WriteLine();
+        }
+    }
+
+    private static string FormatPath(
+        ImageFileSystemEntry entry,
+        string listedPath)
+    {
+        string path = listedPath.Length > 0 &&
+            entry.Path.StartsWith($"{listedPath}/", StringComparison.Ordinal)
+                ? entry.Path[(listedPath.Length + 1)..]
+                : entry.Path;
+        return $"{path}{(entry.IsDeleted ? " (deleted)" : string.Empty)}";
+    }
+
+    private static string FormatLongPath(
+        ImageFileSystemEntry entry,
+        string listedPath)
+    {
+        string path = FormatPath(entry, listedPath);
+        return entry.LinkTarget is null ? path : $"{path} -> {entry.LinkTarget}";
+    }
+
+    private static string FormatMode(ImageFileSystemEntry entry)
+    {
+        char type = entry.Type switch
+        {
+            ImageFileType.Directory => 'd',
+            ImageFileType.SymbolicLink => 'l',
+            ImageFileType.File or ImageFileType.HardLink => '-',
+            _ => '?'
+        };
+        Span<char> permissions = stackalloc char[10];
+        permissions[0] = type;
+        int[] masks = [0x100, 0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1];
+        char[] symbols = ['r', 'w', 'x', 'r', 'w', 'x', 'r', 'w', 'x'];
+        for (int index = 0; index < masks.Length; index++)
+        {
+            permissions[index + 1] = (entry.Mode & masks[index]) == 0
+                ? '-'
+                : symbols[index];
+        }
+        permissions[3] = FormatSpecialPermission(
+            permissions[3], entry.Mode, 0x800, 's', 'S');
+        permissions[6] = FormatSpecialPermission(
+            permissions[6], entry.Mode, 0x400, 's', 'S');
+        permissions[9] = FormatSpecialPermission(
+            permissions[9], entry.Mode, 0x200, 't', 'T');
+        return new string(permissions);
+    }
+
+    private static char FormatSpecialPermission(
+        char executePermission,
+        int mode,
+        int mask,
+        char withExecute,
+        char withoutExecute) =>
+        (mode & mask) == 0
+            ? executePermission
+            : executePermission == 'x' ? withExecute : withoutExecute;
+
+    private static string FormatLayer(ImageLayerReference? layer)
+    {
+        if (layer is null)
+        {
+            return string.Empty;
+        }
+
+        int separatorIndex = layer.Digest.IndexOf(':');
+        string value = separatorIndex < 0
+            ? layer.Digest
+            : layer.Digest[(separatorIndex + 1)..];
+        string abbreviatedDigest = value.Length <= DisplayDigestLength
+            ? value
+            : value[..DisplayDigestLength];
+        return $"{layer.Index}:{abbreviatedDigest}";
+    }
+
+    private static string FormatLayers(ImageFileSystemEntry entry)
+    {
+        List<string> layers = [$"i={FormatLayer(entry.IntroducedLayer)}"];
+        if (entry.ModifiedLayer is not null)
+        {
+            layers.Add($"m={FormatLayer(entry.ModifiedLayer)}");
+        }
+        if (entry.DeletedLayer is not null)
+        {
+            layers.Add($"d={FormatLayer(entry.DeletedLayer)}");
+        }
+        return string.Join(' ', layers);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
@@ -1,0 +1,92 @@
+using System.CommandLine;
+using System.CommandLine.Completions;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+public class LsOptions : PlatformOptionsBase
+{
+    private const string TextOutput = "text";
+    private const string JsonOutput = "json";
+
+    private readonly Argument<string> imageArgument;
+    private readonly Argument<string?> pathArgument;
+    private readonly Option<bool> recursiveOption;
+    private readonly Option<bool> showDeletedOption;
+    private readonly Option<bool> longOption;
+    private readonly Option<bool> provenanceOption;
+    private readonly Option<string> outputOption;
+
+    public string Image { get; set; } = string.Empty;
+    public string? Path { get; set; }
+    public bool Recursive { get; set; }
+    public bool ShowDeleted { get; set; }
+    public bool Long { get; set; }
+    public bool ShowProvenance { get; set; }
+    public LsOutput OutputFormat { get; set; }
+
+    public LsOptions()
+    {
+        imageArgument = Add(new Argument<string>("image")
+        {
+            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+        });
+        pathArgument = Add(new Argument<string?>("path")
+        {
+            Description = "Image path to list",
+            DefaultValueFactory = _ => null
+        });
+        recursiveOption = Add(new Option<bool>("--recursive")
+        {
+            Description = "List all descendants recursively"
+        });
+        showDeletedOption = Add(new Option<bool>("--show-deleted")
+        {
+            Description = "Include paths removed by image whiteouts"
+        });
+        longOption = Add(new Option<bool>("--long")
+        {
+            Description = "Use a long listing format"
+        });
+        longOption.Aliases.Add("-l");
+        provenanceOption = Add(new Option<bool>("--provenance")
+        {
+            Description = "Show layer provenance"
+        });
+        outputOption = Add(new Option<string>("--output")
+        {
+            Description = "Output format",
+            HelpName = $"{TextOutput}|{JsonOutput}",
+            DefaultValueFactory = _ => TextOutput
+        });
+        outputOption.CompletionSources.Add(
+            _ => [new CompletionItem(TextOutput), new CompletionItem(JsonOutput)]);
+        outputOption.Validators.Add(result =>
+        {
+            string? value = result.GetValueOrDefault<string>();
+            if (!string.Equals(value, TextOutput, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(value, JsonOutput, StringComparison.OrdinalIgnoreCase))
+            {
+                result.AddError(
+                    $"Invalid output format '{value}'. Expected '{TextOutput}' or '{JsonOutput}'.");
+            }
+        });
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        Image = GetValue(imageArgument);
+        Path = GetValue(pathArgument);
+        Recursive = GetValue(recursiveOption);
+        ShowDeleted = GetValue(showDeletedOption);
+        Long = GetValue(longOption);
+        ShowProvenance = GetValue(provenanceOption);
+        OutputFormat = GetValue(outputOption)?.ToLowerInvariant() switch
+        {
+            TextOutput => LsOutput.Text,
+            JsonOutput => LsOutput.Json,
+            var value => throw new NotSupportedException(
+                $"Unsupported output format '{value}'.")
+        };
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/LsOutput.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsOutput.cs
@@ -1,0 +1,7 @@
+namespace Valleysoft.Dredge.Commands.Image;
+
+public enum LsOutput
+{
+    Text,
+    Json
+}

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -1,7 +1,6 @@
-﻿using ICSharpCode.SharpZipLib.Tar;
+﻿using System.Formats.Tar;
 using Newtonsoft.Json;
 using System.IO.Compression;
-using System.Text;
 using System.Text.RegularExpressions;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
@@ -76,27 +75,31 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
             await client.Blobs.GetAsync(imageName.Repo, baseLayerDigest, cancellationToken);
         using GZipStream gZipStream = new(blobStream, CompressionMode.Decompress);
 
-        // Can't use System.Formats.Tar.TarReader because it fails to read certain types of tarballs:
-        // https://github.com/dotnet/runtime/issues/74316#issuecomment-1312227247
-
-        using TarInputStream tarStream = new(gZipStream, Encoding.UTF8);
+        using TarReader tarReader = new(gZipStream, leaveOpen: true);
         TarEntry? entry = null;
         do
         {
             cancellationToken.ThrowIfCancellationRequested();
-            entry = tarStream.GetNextEntry();
+            entry = await tarReader.GetNextEntryAsync(
+                copyData: false,
+                cancellationToken);
 
             // Look for the os-release file (skip symlinks)
             if (entry is not null &&
-                entry.Size > 0 &&
+                entry.EntryType is not TarEntryType.SymbolicLink and not TarEntryType.HardLink &&
+                entry.Length > 0 &&
                 (osReleaseRegex.IsMatch(entry.Name)))
             {
                 using MemoryStream memStream = new();
-                await tarStream.CopyEntryContentsAsync(memStream, cancellationToken);
+                await entry.DataStream!.CopyToAsync(memStream, cancellationToken);
                 memStream.Position = 0;
                 using StreamReader reader = new(memStream);
                 string content = await reader.ReadToEndAsync(cancellationToken);
                 return LinuxOsInfo.Parse(content);
+            }
+            if (entry?.DataStream is not null)
+            {
+                await entry.DataStream.CopyToAsync(Stream.Null, cancellationToken);
             }
         } while (entry is not null);
 

--- a/src/Valleysoft.Dredge/FileHelper.cs
+++ b/src/Valleysoft.Dredge/FileHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace Valleysoft.Dredge;
 
@@ -78,15 +79,50 @@ internal static class FileHelper
         }
     }
 
-    public static void CreateSymbolicLink(string targetFilePath, string linkTarget)
+    public static void CreateSymbolicLink(
+        string targetFilePath,
+        string linkTarget,
+        bool targetIsDirectory = false)
     {
         try
         {
-            File.CreateSymbolicLink(targetFilePath, linkTarget);
+            if (targetIsDirectory)
+            {
+                Directory.CreateSymbolicLink(targetFilePath, linkTarget);
+            }
+            else
+            {
+                File.CreateSymbolicLink(targetFilePath, linkTarget);
+            }
         }
         catch (IOException ex) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             throw new Exception($"Unable to create symbolic link from '{targetFilePath}' to '{linkTarget}'. Ensure that Windows Developer mode is enabled.\n\nError:\n{ex.Message}", ex);
         }
     }
+
+    public static void CreateHardLink(string linkPath, string targetPath)
+    {
+        bool success = OperatingSystem.IsWindows()
+            ? CreateHardLinkWindows(linkPath, targetPath, IntPtr.Zero)
+            : CreateHardLinkUnix(targetPath, linkPath) == 0;
+        if (!success)
+        {
+            throw new IOException(
+                $"Unable to create hard link from '{linkPath}' to '{targetPath}'.",
+                new Win32Exception(Marshal.GetLastPInvokeError()));
+        }
+    }
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateHardLinkW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateHardLinkWindows(
+        string fileName,
+        string existingFileName,
+        IntPtr securityAttributes);
+
+    [DllImport("libc", EntryPoint = "link", SetLastError = true)]
+    private static extern int CreateHardLinkUnix(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string existingPath,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string newPath);
 }

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -1,0 +1,1242 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Formats.Tar;
+using System.IO.Compression;
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models.Images;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.Dredge.Commands;
+
+namespace Valleysoft.Dredge;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ImageFileType
+{
+    File,
+    Directory,
+    SymbolicLink,
+    HardLink,
+    Other
+}
+
+public sealed record ImageLayerReference(int Index, string Digest);
+
+public sealed record ImageFileSystemEntry
+{
+    public required string Path { get; init; }
+    public required ImageFileType Type { get; init; }
+    public int Mode { get; init; }
+    public int UserId { get; init; }
+    public int GroupId { get; init; }
+    public long Size { get; init; }
+    public DateTime? ModifiedTime { get; init; }
+    public string? LinkTarget { get; init; }
+    public required ImageLayerReference IntroducedLayer { get; init; }
+    public ImageLayerReference? ModifiedLayer { get; init; }
+    public ImageLayerReference? DeletedLayer { get; init; }
+
+    [JsonIgnore]
+    internal int ContentLayerIndex { get; init; }
+
+    [JsonIgnore]
+    internal string? ContentPath { get; init; }
+
+    [JsonIgnore]
+    // The ordinal disambiguates duplicate paths in non-conforming layers so content reads
+    // reopen the exact entry that produced the index metadata.
+    internal int ContentEntryIndex { get; init; }
+
+    [JsonIgnore]
+    internal string? ContentLinkTarget { get; init; }
+
+    [JsonIgnore]
+    internal bool IsDeleted => DeletedLayer is not null;
+}
+
+internal sealed class ImageFileSystem
+{
+    private const string WhiteoutPrefix = ".wh.";
+    private const string OpaqueWhiteout = ".wh..wh..opq";
+    private const int MaximumLinkHops = 40;
+
+    private readonly IDockerRegistryClient client;
+    private readonly ImageName imageName;
+    private readonly IImageManifest manifest;
+    private readonly Dictionary<string, ImageFileSystemEntry> entries =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ImageFileSystemEntry> deletedEntries =
+        new(StringComparer.Ordinal);
+
+    private ImageFileSystem(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        IImageManifest manifest)
+    {
+        this.client = client;
+        this.imageName = imageName;
+        this.manifest = manifest;
+    }
+
+    public static async Task<ImageFileSystem> CreateAsync(
+        IDockerRegistryClient client,
+        ImageName imageName,
+        PlatformOptionsBase options,
+        CancellationToken cancellationToken)
+    {
+        ResolvedManifest resolved =
+            await ManifestHelper.GetResolvedManifestAsync(client, imageName, options, cancellationToken);
+        IImageManifest manifest = resolved.Manifest;
+        string configDigest = manifest.Config?.Digest ??
+            throw new NotSupportedException(
+                $"Could not resolve the image config digest of '{imageName}'.");
+        Image config = await client.Blobs.GetImageAsync(
+            imageName.Repo,
+            configDigest,
+            cancellationToken);
+        if (string.Equals(config.Os, "windows", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException(
+                "Image filesystem commands support Linux image layers only; Windows image layers are not supported.");
+        }
+
+        ImageFileSystem fileSystem = new(client, imageName, manifest);
+        await fileSystem.BuildIndexAsync(cancellationToken);
+        return fileSystem;
+    }
+
+    public IReadOnlyList<ImageFileSystemEntry> List(
+        string? requestedPath,
+        bool recursive,
+        bool showDeleted)
+    {
+        string path = ImagePath.NormalizeRequested(requestedPath);
+        ImageFileSystemEntry? selected = null;
+        if (path.Length > 0)
+        {
+            entries.TryGetValue(path, out selected);
+            if (selected is null && showDeleted)
+            {
+                deletedEntries.TryGetValue(path, out selected);
+            }
+            if (selected is null)
+            {
+                throw new FileNotFoundException($"Path '/{path}' does not exist in the image.");
+            }
+        }
+
+        if (selected is not null && selected.Type != ImageFileType.Directory)
+        {
+            return [selected];
+        }
+
+        IEnumerable<ImageFileSystemEntry> results = entries.Values;
+        if (showDeleted)
+        {
+            results = results.Concat(deletedEntries.Values);
+        }
+
+        string prefix = path.Length == 0 ? string.Empty : $"{path}/";
+        return results
+            .Where(entry =>
+            {
+                if (!entry.Path.StartsWith(prefix, StringComparison.Ordinal) ||
+                    entry.Path.Length == prefix.Length)
+                {
+                    return false;
+                }
+
+                string relative = entry.Path[prefix.Length..];
+                return recursive || !relative.Contains('/');
+            })
+            .OrderBy(entry => entry.Path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public async Task CopyFileToAsync(
+        string requestedPath,
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        ImageFileSystemEntry entry = ResolveContentEntry(requestedPath);
+        await CopyContentEntriesAsync(
+            [(entry, destination)],
+            cancellationToken);
+    }
+
+    public async Task ExtractAsync(
+        string requestedPath,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        string sourcePath = ImagePath.NormalizeRequested(requestedPath);
+        bool extractingRoot = sourcePath.Length == 0;
+        ImageFileSystemEntry? source = null;
+        if (!extractingRoot &&
+            !entries.TryGetValue(sourcePath, out source))
+        {
+            throw new FileNotFoundException($"Path '/{sourcePath}' does not exist in the image.");
+        }
+        if (source?.Type == ImageFileType.Other)
+        {
+            throw new NotSupportedException(
+                $"Path '/{sourcePath}' has unsupported file type '{source.Type}'.");
+        }
+
+        string fullOutputPath = Path.GetFullPath(outputPath);
+        ValidateNewDestination(fullOutputPath);
+        string? missingParentRoot = GetMissingParentRoot(fullOutputPath);
+
+        List<ImageFileSystemEntry> selected = extractingRoot
+            ? entries.Values
+                .OrderBy(entry => entry.Path.Count(c => c == '/'))
+                .ThenBy(entry => entry.Path, StringComparer.Ordinal)
+                .ToList()
+            : source!.Type == ImageFileType.Directory
+            ? entries.Values
+                .Where(entry =>
+                    entry.Path == sourcePath ||
+                    entry.Path.StartsWith($"{sourcePath}/", StringComparison.Ordinal))
+                .OrderBy(entry => entry.Path.Count(c => c == '/'))
+                .ThenBy(entry => entry.Path, StringComparer.Ordinal)
+                .ToList()
+            : [source];
+
+        Dictionary<string, string> destinations = selected.ToDictionary(
+            entry => entry.Path,
+            entry => !extractingRoot && entry.Path == sourcePath
+                ? fullOutputPath
+                : GetContainedDestination(
+                    fullOutputPath,
+                    extractingRoot
+                        ? entry.Path
+                        : entry.Path[(sourcePath.Length + 1)..]),
+            StringComparer.Ordinal);
+
+        Dictionary<string, string> hardLinkTargets = selected
+            .Where(entry => entry.Type == ImageFileType.HardLink)
+            .ToDictionary(
+                entry => entry.Path,
+                entry => GetHardLinkTargetPath(entry),
+                StringComparer.Ordinal);
+        HashSet<string> preservableHardLinks = selected
+            .Where(entry =>
+                entry.Type == ImageFileType.HardLink &&
+                entry.ContentLinkTarget is null)
+            .Where(entry =>
+            {
+                string targetPath = hardLinkTargets[entry.Path];
+                return destinations.ContainsKey(targetPath) &&
+                    entries.TryGetValue(targetPath, out ImageFileSystemEntry? target) &&
+                    target.ContentLayerIndex == entry.ContentLayerIndex &&
+                    target.ContentPath == entry.ContentPath &&
+                    target.ContentEntryIndex == entry.ContentEntryIndex;
+            })
+            .Select(entry => entry.Path)
+            .ToHashSet(StringComparer.Ordinal);
+
+        bool outputCreated = false;
+        try
+        {
+            if (extractingRoot || source!.Type == ImageFileType.Directory)
+            {
+                Directory.CreateDirectory(fullOutputPath);
+                outputCreated = true;
+            }
+
+            foreach (ImageFileSystemEntry directory in selected
+                .Where(entry => entry.Type == ImageFileType.Directory))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Directory.CreateDirectory(destinations[directory.Path]);
+            }
+
+            List<(ImageFileSystemEntry Entry, string Destination)> content = selected
+                .Where(entry =>
+                    entry.Type == ImageFileType.File ||
+                    (entry.Type == ImageFileType.HardLink &&
+                        !preservableHardLinks.Contains(entry.Path) &&
+                        entry.ContentLinkTarget is null))
+                .Select(entry => (entry, destinations[entry.Path]))
+                .ToList();
+            outputCreated |= content.Count > 0;
+            await ExtractContentEntriesAsync(content, cancellationToken);
+
+            List<ImageFileSystemEntry> pendingHardLinks = selected
+                .Where(entry =>
+                    entry.Type == ImageFileType.HardLink &&
+                    preservableHardLinks.Contains(entry.Path))
+                .ToList();
+            // Multiple passes allow hard-link chains whose immediate target has not been
+            // materialized yet, without replacing them with independent file copies.
+            while (pendingHardLinks.Count > 0)
+            {
+                int createdCount = 0;
+                for (int index = pendingHardLinks.Count - 1; index >= 0; index--)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ImageFileSystemEntry hardLink = pendingHardLinks[index];
+                    string target = hardLinkTargets[hardLink.Path];
+                    if (!File.Exists(destinations[target]))
+                    {
+                        continue;
+                    }
+                    FileHelper.CreateHardLink(destinations[hardLink.Path], destinations[target]);
+                    pendingHardLinks.RemoveAt(index);
+                    createdCount++;
+                    outputCreated = true;
+                }
+                if (createdCount == 0)
+                {
+                    throw new InvalidDataException(
+                        $"Unable to create hard link '/{pendingHardLinks[0].Path}'.");
+                }
+            }
+
+            foreach (ImageFileSystemEntry symbolicLink in selected
+                .Where(entry => entry.Type == ImageFileType.SymbolicLink))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                string destination = destinations[symbolicLink.Path];
+                string target = symbolicLink.LinkTarget ??
+                    throw new InvalidDataException(
+                        $"Symbolic link '/{symbolicLink.Path}' has no target.");
+                bool targetsDirectory = TryResolvePath(symbolicLink.Path)?.Type ==
+                    ImageFileType.Directory;
+                FileHelper.CreateSymbolicLink(destination, target, targetsDirectory);
+                outputCreated = true;
+            }
+
+            foreach (ImageFileSystemEntry hardLink in selected
+                .Where(entry =>
+                    entry.Type == ImageFileType.HardLink &&
+                    entry.ContentLinkTarget is not null))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                string targetPath = GetHardLinkTargetPath(hardLink);
+                bool targetsDirectory = TryResolvePath(targetPath)?.Type ==
+                    ImageFileType.Directory;
+                FileHelper.CreateSymbolicLink(
+                    destinations[hardLink.Path],
+                    hardLink.ContentLinkTarget!,
+                    targetsDirectory);
+                outputCreated = true;
+            }
+
+            foreach (ImageFileSystemEntry entry in selected
+                .Where(entry =>
+                    entry.Type is ImageFileType.File or ImageFileType.Directory ||
+                    (entry.Type == ImageFileType.HardLink &&
+                        !preservableHardLinks.Contains(entry.Path) &&
+                        entry.ContentLinkTarget is null))
+                .OrderByDescending(entry => entry.Path.Count(c => c == '/')))
+            {
+                ApplyMetadata(destinations[entry.Path], entry);
+            }
+        }
+        catch (Exception exception)
+        {
+            // Preserve the extraction failure as the primary exception; cleanup failures
+            // remain available as diagnostics without masking the original cause.
+            if (outputCreated)
+            {
+                try
+                {
+                    DeleteOutput(fullOutputPath);
+                }
+                catch (Exception cleanupException)
+                {
+                    exception.Data["ExtractionCleanupException"] = cleanupException;
+                }
+            }
+            if (missingParentRoot is not null && Directory.Exists(missingParentRoot))
+            {
+                try
+                {
+                    Directory.Delete(missingParentRoot, recursive: true);
+                }
+                catch (Exception cleanupException)
+                {
+                    exception.Data["ExtractionParentCleanupException"] = cleanupException;
+                }
+            }
+            throw;
+        }
+    }
+
+    private async Task BuildIndexAsync(CancellationToken cancellationToken)
+    {
+        for (int layerIndex = 0; layerIndex < manifest.Layers.Length; layerIndex++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IDescriptor layer = manifest.Layers[layerIndex];
+            string digest = layer.Digest ??
+                throw new InvalidDataException(
+                    $"Layer digest not set for image '{imageName}'.");
+            ImageLayerReference layerReference = new(layerIndex, digest);
+            using Stream blob = await client.Blobs.GetAsync(
+                imageName.Repo,
+                digest,
+                cancellationToken);
+            LayerChanges changes = await ScanLayerAsync(
+                blob,
+                layerReference,
+                cancellationToken);
+            ApplyLayer(changes, layerReference, cancellationToken);
+        }
+    }
+
+    private static async Task<LayerChanges> ScanLayerAsync(
+        Stream blob,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        List<ScannedEntry> entries = [];
+        List<string> whiteouts = [];
+        List<string> opaqueDirectories = [];
+
+        using GZipStream gzip = new(blob, CompressionMode.Decompress, leaveOpen: true);
+        using TarReader tar = new(gzip, leaveOpen: true);
+        int entryIndex = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TarEntry? tarEntry = await GetNextTarEntryAsync(
+                tar,
+                layer,
+                cancellationToken);
+            if (tarEntry is null)
+            {
+                break;
+            }
+            int currentEntryIndex = entryIndex++;
+            await DrainTarEntryAsync(tarEntry, layer, cancellationToken);
+
+            string path = ImagePath.NormalizeArchive(tarEntry.Name);
+            if (path.Length == 0)
+            {
+                continue;
+            }
+
+            string fileName = ImagePath.GetFileName(path);
+            string parent = ImagePath.GetDirectoryName(path);
+            if (string.Equals(fileName, OpaqueWhiteout, StringComparison.Ordinal))
+            {
+                if (parent.Length == 0)
+                {
+                    throw new InvalidDataException(
+                        "The opaque whiteout marker cannot exist at the image root.");
+                }
+                opaqueDirectories.Add(parent);
+                continue;
+            }
+
+            if (fileName.StartsWith(WhiteoutPrefix, StringComparison.Ordinal))
+            {
+                string targetName = fileName[WhiteoutPrefix.Length..];
+                ImagePath.ValidateSegment(targetName, "whiteout target");
+                whiteouts.Add(
+                    parent.Length == 0 ? targetName : $"{parent}/{targetName}");
+                continue;
+            }
+
+            ImageFileType type = GetFileType(tarEntry);
+            string? linkTarget = type is ImageFileType.SymbolicLink or ImageFileType.HardLink
+                ? tarEntry.LinkName
+                : null;
+            if (linkTarget is not null && linkTarget.IndexOf('\0') >= 0)
+            {
+                throw new InvalidDataException(
+                    $"Link '/{path}' has an invalid target.");
+            }
+            if (type == ImageFileType.SymbolicLink)
+            {
+                string basePath = ImagePath.IsAbsolute(linkTarget!)
+                    ? string.Empty
+                    : parent;
+                _ = ImagePath.ResolveLinkTarget(
+                    basePath,
+                    linkTarget!,
+                    string.Empty,
+                    path);
+            }
+
+            entries.Add(new ScannedEntry(
+                path,
+                type,
+                (int)tarEntry.Mode,
+                tarEntry.Uid,
+                tarEntry.Gid,
+                type == ImageFileType.File ? tarEntry.Length : 0,
+                tarEntry.ModificationTime.UtcDateTime,
+                linkTarget,
+                currentEntryIndex,
+                layer));
+        }
+        return new LayerChanges(entries, whiteouts, opaqueDirectories);
+    }
+
+    private void ApplyLayer(
+        LayerChanges changes,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        // OCI whiteouts affect only lower layers, and opaque markers take effect before
+        // same-layer additions regardless of their position in the tar stream.
+        foreach (string directory in changes.OpaqueDirectories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RemovePath(directory, includePath: false, layer);
+        }
+
+        foreach (string path in changes.Whiteouts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RemovePath(path, includePath: true, layer);
+        }
+
+        foreach (ScannedEntry scanned in changes.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureParentDirectories(scanned.Path, layer);
+
+            if (entries.TryGetValue(scanned.Path, out ImageFileSystemEntry? previous) &&
+                previous.Type == ImageFileType.Directory &&
+                scanned.Type != ImageFileType.Directory)
+            {
+                RemovePath(scanned.Path, includePath: false, layer);
+            }
+
+            ImageLayerReference introduced =
+                entries.TryGetValue(scanned.Path, out previous)
+                    ? previous.IntroducedLayer
+                    : layer;
+            ImageLayerReference? modified =
+                previous is not null && previous.IntroducedLayer.Index != layer.Index
+                    ? layer
+                    : previous?.ModifiedLayer;
+            ImageFileSystemEntry current = scanned.ToEntry(introduced, modified);
+            if (current.Type == ImageFileType.HardLink)
+            {
+                string targetPath = GetHardLinkTargetPath(current);
+                if (!entries.TryGetValue(targetPath, out ImageFileSystemEntry? target) ||
+                    target.Type == ImageFileType.Directory)
+                {
+                    throw new InvalidDataException(
+                        $"Hard link '/{current.Path}' targets missing or invalid path '/{targetPath}'.");
+                }
+                current = current with
+                {
+                    ContentLayerIndex = target.ContentLayerIndex,
+                    ContentPath = target.ContentPath,
+                    ContentEntryIndex = target.ContentEntryIndex,
+                    ContentLinkTarget = target.Type == ImageFileType.SymbolicLink
+                        ? target.LinkTarget
+                        : target.ContentLinkTarget
+                };
+            }
+            entries[scanned.Path] = current;
+            deletedEntries.Remove(scanned.Path);
+        }
+    }
+
+    private void EnsureParentDirectories(string path, ImageLayerReference layer)
+    {
+        string parent = ImagePath.GetDirectoryName(path);
+        if (parent.Length == 0)
+        {
+            return;
+        }
+
+        EnsureParentDirectories(parent, layer);
+        if (!entries.TryGetValue(parent, out ImageFileSystemEntry? entry) ||
+            entry.Type != ImageFileType.Directory)
+        {
+            entries[parent] = new ImageFileSystemEntry
+            {
+                Path = parent,
+                Type = ImageFileType.Directory,
+                Mode = 0x1ED,
+                IntroducedLayer = layer,
+                ContentLayerIndex = layer.Index
+            };
+            deletedEntries.Remove(parent);
+        }
+    }
+
+    private void RemovePath(
+        string path,
+        bool includePath,
+        ImageLayerReference layer)
+    {
+        string prefix = $"{path}/";
+        string[] affected = entries.Keys
+            .Where(candidate =>
+                (includePath && candidate == path) ||
+                candidate.StartsWith(prefix, StringComparison.Ordinal))
+            .ToArray();
+        foreach (string candidate in affected)
+        {
+            ImageFileSystemEntry removed = entries[candidate] with
+            {
+                DeletedLayer = layer
+            };
+            entries.Remove(candidate);
+            deletedEntries[candidate] = removed;
+        }
+
+        if (includePath && affected.Length == 0)
+        {
+            if (deletedEntries.TryGetValue(path, out ImageFileSystemEntry? alreadyDeleted))
+            {
+                deletedEntries[path] = alreadyDeleted with { DeletedLayer = layer };
+            }
+            else
+            {
+                deletedEntries[path] = new ImageFileSystemEntry
+                {
+                    Path = path,
+                    Type = ImageFileType.Other,
+                    IntroducedLayer = layer,
+                    DeletedLayer = layer,
+                    ContentLayerIndex = layer.Index
+                };
+            }
+        }
+    }
+
+    private ImageFileSystemEntry ResolveContentEntry(string requestedPath)
+    {
+        string path = ImagePath.NormalizeRequested(requestedPath);
+        if (path.Length == 0)
+        {
+            throw new InvalidDataException("The image root is a directory.");
+        }
+
+        ImageFileSystemEntry entry = ResolvePath(path);
+        if (entry.Type == ImageFileType.Directory)
+        {
+            throw new InvalidDataException($"Path '/{path}' is a directory.");
+        }
+        if (entry.Type == ImageFileType.HardLink &&
+            entry.ContentLinkTarget is string linkTarget)
+        {
+            string basePath = ImagePath.IsAbsolute(linkTarget)
+                ? string.Empty
+                : ImagePath.GetDirectoryName(entry.Path);
+            string targetPath = ImagePath.ResolveLinkTarget(
+                basePath,
+                linkTarget,
+                string.Empty,
+                entry.Path);
+            entry = ResolvePath(targetPath);
+        }
+        if (entry.Type == ImageFileType.HardLink)
+        {
+            return entry with { Type = ImageFileType.File };
+        }
+        if (entry.Type != ImageFileType.File)
+        {
+            throw new NotSupportedException(
+                $"Path '/{path}' has unsupported file type '{entry.Type}'.");
+        }
+        return entry;
+    }
+
+    private ImageFileSystemEntry ResolvePath(string requestedPath)
+    {
+        string current = ImagePath.NormalizeRequested(requestedPath);
+        for (int hop = 0; hop < MaximumLinkHops; hop++)
+        {
+            string[] segments = current.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            bool followedLink = false;
+            for (int i = 0; i < segments.Length; i++)
+            {
+                string candidate = string.Join('/', segments.Take(i + 1));
+                if (!entries.TryGetValue(candidate, out ImageFileSystemEntry? entry))
+                {
+                    throw new FileNotFoundException(
+                        $"Path '/{requestedPath}' resolves to missing path '/{candidate}'.");
+                }
+
+                if (entry.Type != ImageFileType.SymbolicLink)
+                {
+                    continue;
+                }
+
+                string target = entry.LinkTarget ??
+                    throw new InvalidDataException(
+                        $"Link '/{candidate}' has no target.");
+                string basePath = entry.Type == ImageFileType.SymbolicLink &&
+                    !ImagePath.IsAbsolute(target)
+                        ? ImagePath.GetDirectoryName(candidate)
+                        : string.Empty;
+                string remainder = string.Join('/', segments.Skip(i + 1));
+                current = ImagePath.ResolveLinkTarget(basePath, target, remainder, candidate);
+                followedLink = true;
+                break;
+            }
+
+            if (!followedLink)
+            {
+                if (!entries.TryGetValue(current, out ImageFileSystemEntry? result))
+                {
+                    throw new FileNotFoundException(
+                        $"Path '/{requestedPath}' does not exist in the image.");
+                }
+                return result;
+            }
+        }
+
+        throw new InvalidDataException(
+            $"Link resolution for '/{requestedPath}' exceeded {MaximumLinkHops} hops.");
+    }
+
+    private ImageFileSystemEntry? TryResolvePath(string requestedPath)
+    {
+        // Extraction must preserve dangling links; resolution here is only a best-effort
+        // probe for choosing the host symlink type.
+        try
+        {
+            return ResolvePath(requestedPath);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (InvalidDataException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetHardLinkTargetPath(ImageFileSystemEntry entry)
+    {
+        string target = entry.LinkTarget ??
+            throw new InvalidDataException($"Hard link '/{entry.Path}' has no target.");
+        return ImagePath.ResolveLinkTarget(
+            string.Empty,
+            target,
+            string.Empty,
+            entry.Path);
+    }
+
+    private async Task CopyContentEntriesAsync(
+        IEnumerable<(ImageFileSystemEntry Entry, Stream Destination)> requests,
+        CancellationToken cancellationToken)
+    {
+        List<(ImageFileSystemEntry Entry, Stream Destination)> requestList = requests.ToList();
+        foreach (IGrouping<int, (ImageFileSystemEntry Entry, Stream Destination)> group in
+            requestList.GroupBy(request => request.Entry.ContentLayerIndex))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IDescriptor layer = manifest.Layers[group.Key];
+            string digest = layer.Digest ??
+                throw new InvalidDataException($"Layer {group.Key} has no digest.");
+            Dictionary<(string Path, int EntryIndex), Queue<Stream>> destinations = group
+                .GroupBy(request => (
+                    Path: request.Entry.ContentPath ?? request.Entry.Path,
+                    EntryIndex: request.Entry.ContentEntryIndex))
+                .ToDictionary(
+                    item => item.Key,
+                    item => new Queue<Stream>(item.Select(request => request.Destination)));
+
+            using Stream blob = await client.Blobs.GetAsync(
+                imageName.Repo,
+                digest,
+                cancellationToken);
+            using GZipStream gzip = new(blob, CompressionMode.Decompress, leaveOpen: true);
+            using TarReader tar = new(gzip, leaveOpen: true);
+            int entryIndex = 0;
+            while (destinations.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TarEntry? tarEntry = await GetNextTarEntryAsync(
+                    tar,
+                    new(group.Key, digest),
+                    cancellationToken);
+                if (tarEntry is null)
+                {
+                    break;
+                }
+
+                int currentEntryIndex = entryIndex++;
+                string path = ImagePath.NormalizeArchive(tarEntry.Name);
+                if (!destinations.Remove(
+                    (path, currentEntryIndex),
+                    out Queue<Stream>? outputs))
+                {
+                    await DrainTarEntryAsync(
+                        tarEntry,
+                        new(group.Key, digest),
+                        cancellationToken);
+                    continue;
+                }
+
+                using MemoryStream? buffer = outputs.Count > 1 ? new MemoryStream() : null;
+                Stream first = buffer ?? outputs.Dequeue();
+                await CopyTarEntryAsync(
+                    tarEntry,
+                    first,
+                    new(group.Key, digest),
+                    path,
+                    cancellationToken);
+                if (buffer is not null)
+                {
+                    foreach (Stream output in outputs)
+                    {
+                        buffer.Position = 0;
+                        await buffer.CopyToAsync(output, cancellationToken);
+                    }
+                }
+            }
+
+            if (destinations.Count > 0)
+            {
+                throw new InvalidDataException(
+                    $"Could not locate effective content for '/{destinations.Keys.First().Path}' in layer {group.Key}.");
+            }
+        }
+    }
+
+    private async Task ExtractContentEntriesAsync(
+        IEnumerable<(ImageFileSystemEntry Entry, string Destination)> requests,
+        CancellationToken cancellationToken)
+    {
+        foreach (IGrouping<int, (ImageFileSystemEntry Entry, string Destination)> group in
+            requests.GroupBy(request => request.Entry.ContentLayerIndex))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IDescriptor layer = manifest.Layers[group.Key];
+            string digest = layer.Digest ??
+                throw new InvalidDataException($"Layer {group.Key} has no digest.");
+            Dictionary<(string Path, int EntryIndex), Queue<string>> destinations = group
+                .GroupBy(request => (
+                    Path: request.Entry.ContentPath ?? request.Entry.Path,
+                    EntryIndex: request.Entry.ContentEntryIndex))
+                .ToDictionary(
+                    item => item.Key,
+                    item => new Queue<string>(item.Select(request => request.Destination)));
+
+            using Stream blob = await client.Blobs.GetAsync(
+                imageName.Repo,
+                digest,
+                cancellationToken);
+            using GZipStream gzip = new(blob, CompressionMode.Decompress, leaveOpen: true);
+            using TarReader tar = new(gzip, leaveOpen: true);
+            int entryIndex = 0;
+            while (destinations.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TarEntry? tarEntry = await GetNextTarEntryAsync(
+                    tar,
+                    new(group.Key, digest),
+                    cancellationToken);
+                if (tarEntry is null)
+                {
+                    break;
+                }
+
+                int currentEntryIndex = entryIndex++;
+                string path = ImagePath.NormalizeArchive(tarEntry.Name);
+                if (!destinations.Remove(
+                    (path, currentEntryIndex),
+                    out Queue<string>? outputs))
+                {
+                    await DrainTarEntryAsync(
+                        tarEntry,
+                        new(group.Key, digest),
+                        cancellationToken);
+                    continue;
+                }
+
+                string first = outputs.Dequeue();
+                Directory.CreateDirectory(Path.GetDirectoryName(first)!);
+                await using (FileStream destination = new(
+                    first,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 81920,
+                    FileOptions.Asynchronous))
+                {
+                    await CopyTarEntryAsync(
+                        tarEntry,
+                        destination,
+                        new(group.Key, digest),
+                        path,
+                        cancellationToken);
+                }
+
+                foreach (string output in outputs)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Directory.CreateDirectory(Path.GetDirectoryName(output)!);
+                    File.Copy(first, output);
+                }
+            }
+
+            if (destinations.Count > 0)
+            {
+                throw new InvalidDataException(
+                    $"Could not locate effective content for '/{destinations.Keys.First().Path}' in layer {group.Key}.");
+            }
+        }
+    }
+
+    private static ImageFileType GetFileType(TarEntry entry) =>
+        entry.EntryType switch
+        {
+            TarEntryType.RegularFile or
+                TarEntryType.V7RegularFile or
+                TarEntryType.ContiguousFile => ImageFileType.File,
+            TarEntryType.SymbolicLink => ImageFileType.SymbolicLink,
+            TarEntryType.HardLink => ImageFileType.HardLink,
+            TarEntryType.Directory => ImageFileType.Directory,
+            _ => ImageFileType.Other
+        };
+
+    private static async ValueTask<TarEntry?> GetNextTarEntryAsync(
+        TarReader reader,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await reader.GetNextEntryAsync(
+                copyData: false,
+                cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    private static async Task DrainTarEntryAsync(
+        TarEntry entry,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        if (entry.DataStream is null)
+        {
+            return;
+        }
+
+        // On .NET 9, GetNextEntryAsync(copyData: false) does not reliably advance past
+        // skipped data, so every unconsumed entry must be drained before reading the next.
+        try
+        {
+            await entry.DataStream.CopyToAsync(Stream.Null, cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    private static async Task CopyTarEntryAsync(
+        TarEntry entry,
+        Stream destination,
+        ImageLayerReference layer,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        Stream data = entry.DataStream ??
+            throw new InvalidDataException($"File '/{path}' has no content stream.");
+        try
+        {
+            await data.CopyToAsync(destination, cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    private static InvalidDataException CreateInvalidLayerException(
+        ImageLayerReference layer,
+        Exception innerException) =>
+        new(
+            $"Layer {layer.Index} ('{layer.Digest}') is not a supported gzip-compressed Linux tar layer.",
+            innerException);
+
+    private static void ValidateNewDestination(string outputPath)
+    {
+        if (PathExists(outputPath))
+        {
+            throw new IOException($"Destination '{outputPath}' already exists.");
+        }
+
+        string? parent = Path.GetDirectoryName(outputPath);
+        while (parent is not null)
+        {
+            if (PathExists(parent) &&
+                File.GetAttributes(parent).HasFlag(FileAttributes.ReparsePoint))
+            {
+                throw new InvalidDataException(
+                    $"Destination '{outputPath}' traverses a symbolic link.");
+            }
+            parent = Path.GetDirectoryName(parent);
+        }
+    }
+
+    private static bool PathExists(string path)
+    {
+        try
+        {
+            _ = File.GetAttributes(path);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    private static string? GetMissingParentRoot(string outputPath)
+    {
+        string? missingRoot = null;
+        string? parent = Path.GetDirectoryName(outputPath);
+        while (parent is not null && !PathExists(parent))
+        {
+            missingRoot = parent;
+            parent = Path.GetDirectoryName(parent);
+        }
+        return missingRoot;
+    }
+
+    private static string GetContainedDestination(string root, string relativePath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            ValidateWindowsDestinationPath(relativePath);
+        }
+
+        string result = Path.GetFullPath(
+            Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        string relative = Path.GetRelativePath(root, result);
+        if (Path.IsPathRooted(relative) ||
+            relative == ".." ||
+            relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Extraction path '{relativePath}' is outside the destination.");
+        }
+        return result;
+    }
+
+    private static void ValidateWindowsDestinationPath(string relativePath)
+    {
+        foreach (string segment in relativePath.Split('/'))
+        {
+            string stem = segment.Split('.')[0];
+            if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+                segment.EndsWith('.') ||
+                segment.EndsWith(' ') ||
+                stem.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals("CONIN$", StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals("CONOUT$", StringComparison.OrdinalIgnoreCase) ||
+                IsWindowsNumberedDevice(stem, "COM") ||
+                IsWindowsNumberedDevice(stem, "LPT"))
+            {
+                throw new InvalidDataException(
+                    $"Extraction path '{relativePath}' is not a valid Windows path.");
+            }
+        }
+    }
+
+    private static bool IsWindowsNumberedDevice(string value, string prefix) =>
+        value.Length == prefix.Length + 1 &&
+        value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+        value[^1] is >= '1' and <= '9';
+
+    private static void ApplyMetadata(string path, ImageFileSystemEntry entry)
+    {
+        if (entry.ModifiedTime is DateTime modifiedTime)
+        {
+            DateTime utcModifiedTime = DateTime.SpecifyKind(modifiedTime, DateTimeKind.Utc);
+            if (entry.Type == ImageFileType.Directory)
+            {
+                Directory.SetLastWriteTimeUtc(path, utcModifiedTime);
+            }
+            else
+            {
+                File.SetLastWriteTimeUtc(path, utcModifiedTime);
+            }
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, (UnixFileMode)(entry.Mode & 0xFFF));
+        }
+    }
+
+    private static void DeleteOutput(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        else if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private sealed record LayerChanges(
+        IReadOnlyList<ScannedEntry> Entries,
+        IReadOnlyList<string> Whiteouts,
+        IReadOnlyList<string> OpaqueDirectories);
+
+    private sealed record ScannedEntry(
+        string Path,
+        ImageFileType Type,
+        int Mode,
+        int UserId,
+        int GroupId,
+        long Size,
+        DateTime ModifiedTime,
+        string? LinkTarget,
+        int EntryIndex,
+        ImageLayerReference Layer)
+    {
+        public ImageFileSystemEntry ToEntry(
+            ImageLayerReference introduced,
+            ImageLayerReference? modified) =>
+            new()
+            {
+                Path = Path,
+                Type = Type,
+                Mode = Mode,
+                UserId = UserId,
+                GroupId = GroupId,
+                Size = Size,
+                ModifiedTime = ModifiedTime,
+                LinkTarget = LinkTarget,
+                IntroducedLayer = introduced,
+                ModifiedLayer = modified,
+                ContentLayerIndex = Layer.Index,
+                ContentPath = Type == ImageFileType.File ? Path : null,
+                ContentEntryIndex = EntryIndex
+            };
+    }
+}
+
+internal static class ImagePath
+{
+    public static string NormalizeArchive(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException($"Invalid archive entry path '{value}'.");
+        }
+        if (IsAbsolute(value) || value.Contains('\\'))
+        {
+            throw new InvalidDataException(
+                $"Archive entry path '{value}' must be a relative Linux path.");
+        }
+        return Normalize(value, allowParentSegments: false, "archive entry");
+    }
+
+    public static string NormalizeRequested(string? value)
+    {
+        value = string.IsNullOrEmpty(value) ? string.Empty : value;
+        if (value.Contains('\\') || value.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException($"Invalid image path '{value}'.");
+        }
+        return Normalize(value.TrimStart('/'), allowParentSegments: false, "image");
+    }
+
+    public static string ResolveLinkTarget(
+        string basePath,
+        string target,
+        string remainder,
+        string linkPath)
+    {
+        if (target.Contains('\\') || target.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException(
+                $"Link '/{linkPath}' has invalid target '{target}'.");
+        }
+
+        string combined = IsAbsolute(target)
+            ? target.TrimStart('/')
+            : Join(basePath, target);
+        combined = Join(combined, remainder);
+        return Normalize(combined, allowParentSegments: true, $"link target for '/{linkPath}'");
+    }
+
+    public static bool IsAbsolute(string path) => path.StartsWith('/');
+
+    public static string GetDirectoryName(string path)
+    {
+        int separator = path.LastIndexOf('/');
+        return separator < 0 ? string.Empty : path[..separator];
+    }
+
+    public static string GetFileName(string path)
+    {
+        int separator = path.LastIndexOf('/');
+        return separator < 0 ? path : path[(separator + 1)..];
+    }
+
+    public static void ValidateSegment(string value, string description)
+    {
+        if (string.IsNullOrEmpty(value) ||
+            value is "." or ".." ||
+            value.Contains('/') ||
+            value.Contains('\\') ||
+            value.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException($"Invalid {description} '{value}'.");
+        }
+    }
+
+    private static string Normalize(
+        string value,
+        bool allowParentSegments,
+        string description)
+    {
+        List<string> segments = [];
+        foreach (string segment in value.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+            if (segment == "..")
+            {
+                if (!allowParentSegments)
+                {
+                    throw new InvalidDataException(
+                        $"The {description} path '{value}' escapes the image root.");
+                }
+                if (segments.Count > 0)
+                {
+                    segments.RemoveAt(segments.Count - 1);
+                }
+                // Linux clamps excess ".." segments at the filesystem root.
+                continue;
+            }
+            ValidateSegment(segment, $"{description} path segment");
+            segments.Add(segment);
+        }
+        return string.Join('/', segments);
+    }
+
+    private static string Join(string first, string second) =>
+        first.Length == 0 ? second :
+        second.Length == 0 ? first :
+        $"{first}/{second}";
+}

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -709,15 +709,28 @@ internal sealed class ImageFileSystem
         }
     }
 
-    private static string GetHardLinkTargetPath(ImageFileSystemEntry entry)
+    private string GetHardLinkTargetPath(ImageFileSystemEntry entry)
     {
         string target = entry.LinkTarget ??
             throw new InvalidDataException($"Hard link '/{entry.Path}' has no target.");
-        return ImagePath.ResolveLinkTarget(
+        string targetPath = ImagePath.ResolveLinkTarget(
             string.Empty,
             target,
             string.Empty,
             entry.Path);
+        string parentPath = ImagePath.GetDirectoryName(targetPath);
+        if (parentPath.Length == 0)
+        {
+            return targetPath;
+        }
+
+        ImageFileSystemEntry parent = ResolvePath(parentPath);
+        if (parent.Type != ImageFileType.Directory)
+        {
+            throw new InvalidDataException(
+                $"Hard link '/{entry.Path}' targets path '/{targetPath}' with a non-directory parent.");
+        }
+        return $"{parent.Path}/{ImagePath.GetFileName(targetPath)}";
     }
 
     private async Task CopyContentEntriesAsync(
@@ -968,18 +981,6 @@ internal sealed class ImageFileSystem
         if (PathExists(outputPath))
         {
             throw new IOException($"Destination '{outputPath}' already exists.");
-        }
-
-        string? parent = Path.GetDirectoryName(outputPath);
-        while (parent is not null)
-        {
-            if (PathExists(parent) &&
-                File.GetAttributes(parent).HasFlag(FileAttributes.ReparsePoint))
-            {
-                throw new InvalidDataException(
-                    $"Destination '{outputPath}' traverses a symbolic link.");
-            }
-            parent = Path.GetDirectoryName(parent);
         }
     }
 

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.Formats.Tar;
 using System.IO.Compression;
 using Valleysoft.DockerRegistryClient;
@@ -9,54 +7,8 @@ using Valleysoft.Dredge.Commands;
 
 namespace Valleysoft.Dredge;
 
-[JsonConverter(typeof(StringEnumConverter))]
-public enum ImageFileType
-{
-    File,
-    Directory,
-    SymbolicLink,
-    HardLink,
-    Other
-}
-
-public sealed record ImageLayerReference(int Index, string Digest);
-
-public sealed record ImageFileSystemEntry
-{
-    public required string Path { get; init; }
-    public required ImageFileType Type { get; init; }
-    public int Mode { get; init; }
-    public int UserId { get; init; }
-    public int GroupId { get; init; }
-    public long Size { get; init; }
-    public DateTime? ModifiedTime { get; init; }
-    public string? LinkTarget { get; init; }
-    public required ImageLayerReference IntroducedLayer { get; init; }
-    public ImageLayerReference? ModifiedLayer { get; init; }
-    public ImageLayerReference? DeletedLayer { get; init; }
-
-    [JsonIgnore]
-    internal int ContentLayerIndex { get; init; }
-
-    [JsonIgnore]
-    internal string? ContentPath { get; init; }
-
-    [JsonIgnore]
-    // The ordinal disambiguates duplicate paths in non-conforming layers so content reads
-    // reopen the exact entry that produced the index metadata.
-    internal int ContentEntryIndex { get; init; }
-
-    [JsonIgnore]
-    internal string? ContentLinkTarget { get; init; }
-
-    [JsonIgnore]
-    internal bool IsDeleted => DeletedLayer is not null;
-}
-
 internal sealed class ImageFileSystem
 {
-    private const string WhiteoutPrefix = ".wh.";
-    private const string OpaqueWhiteout = ".wh..wh..opq";
     private const int MaximumLinkHops = 40;
 
     private readonly IDockerRegistryClient client;
@@ -173,43 +125,108 @@ internal sealed class ImageFileSystem
         string outputPath,
         CancellationToken cancellationToken)
     {
+        ExtractionPlan plan = CreateExtractionPlan(requestedPath, outputPath);
+        ExtractionState state = new();
+        try
+        {
+            if (plan.ExtractingRoot || plan.Source!.Type == ImageFileType.Directory)
+            {
+                Directory.CreateDirectory(plan.OutputPath);
+                state.OutputCreated = true;
+            }
+            CreateExtractionSubdirectories(plan, cancellationToken);
+            List<(ImageFileSystemEntry Entry, string Destination)> content =
+                GetContentExtractionRequests(plan);
+            state.OutputCreated |= content.Count > 0;
+            await ExtractContentEntriesAsync(content, cancellationToken);
+            CreatePreservedHardLinks(plan, state, cancellationToken);
+            CreateSymbolicLinks(plan, state, cancellationToken);
+            CreateSymbolicHardLinks(plan, state, cancellationToken);
+            ApplyExtractionMetadata(plan);
+        }
+        catch (Exception exception)
+        {
+            CleanupFailedExtraction(plan, state.OutputCreated, exception);
+            throw;
+        }
+    }
+
+    private ExtractionPlan CreateExtractionPlan(string requestedPath, string outputPath)
+    {
         string sourcePath = ImagePath.NormalizeRequested(requestedPath);
         bool extractingRoot = sourcePath.Length == 0;
-        ImageFileSystemEntry? source = null;
-        if (!extractingRoot)
+        ImageFileSystemEntry? source = extractingRoot
+            ? null
+            : GetExtractionSource(sourcePath);
+        if (source is not null)
         {
-            string lookupPath = ResolveParentComponents(sourcePath);
-            if (!entries.TryGetValue(lookupPath, out source))
-            {
-                throw new FileNotFoundException(
-                    $"Path '/{sourcePath}' does not exist in the image.");
-            }
             sourcePath = source.Path;
-        }
-        if (source?.Type == ImageFileType.Other)
-        {
-            throw new NotSupportedException(
-                $"Path '/{sourcePath}' has unsupported file type '{source.Type}'.");
         }
 
         string fullOutputPath = Path.GetFullPath(outputPath);
         ValidateNewDestination(fullOutputPath);
         string? missingParentRoot = GetMissingParentRoot(fullOutputPath);
+        List<ImageFileSystemEntry> selected =
+            SelectExtractionEntries(sourcePath, source, extractingRoot);
+        ValidateExtractionEntries(selected);
+        Dictionary<string, string> destinations = CreateExtractionDestinations(
+            selected,
+            sourcePath,
+            fullOutputPath,
+            extractingRoot);
+        Dictionary<string, string> hardLinkTargets = GetExtractionHardLinkTargets(selected);
+        HashSet<string> preservableHardLinks = GetPreservableHardLinks(
+            selected,
+            destinations,
+            hardLinkTargets);
+        return new(
+            source,
+            extractingRoot,
+            fullOutputPath,
+            missingParentRoot,
+            selected,
+            destinations,
+            hardLinkTargets,
+            preservableHardLinks);
+    }
 
-        List<ImageFileSystemEntry> selected = extractingRoot
-            ? entries.Values
-                .OrderBy(entry => entry.Path.Count(c => c == '/'))
-                .ThenBy(entry => entry.Path, StringComparer.Ordinal)
-                .ToList()
+    private ImageFileSystemEntry GetExtractionSource(string sourcePath)
+    {
+        string lookupPath = ResolveParentComponents(sourcePath);
+        if (!entries.TryGetValue(lookupPath, out ImageFileSystemEntry? source))
+        {
+            throw new FileNotFoundException(
+                $"Path '/{sourcePath}' does not exist in the image.");
+        }
+        if (source.Type == ImageFileType.Other)
+        {
+            throw new NotSupportedException(
+                $"Path '/{source.Path}' has unsupported file type '{source.Type}'.");
+        }
+        return source;
+    }
+
+    private List<ImageFileSystemEntry> SelectExtractionEntries(
+        string sourcePath,
+        ImageFileSystemEntry? source,
+        bool extractingRoot) =>
+        extractingRoot
+            ? OrderExtractionEntries(entries.Values)
             : source!.Type == ImageFileType.Directory
-            ? entries.Values
-                .Where(entry =>
+                ? OrderExtractionEntries(entries.Values.Where(entry =>
                     entry.Path == sourcePath ||
-                    entry.Path.StartsWith($"{sourcePath}/", StringComparison.Ordinal))
-                .OrderBy(entry => entry.Path.Count(c => c == '/'))
-                .ThenBy(entry => entry.Path, StringComparer.Ordinal)
-                .ToList()
-            : [source];
+                    entry.Path.StartsWith($"{sourcePath}/", StringComparison.Ordinal)))
+                : [source];
+
+    private static List<ImageFileSystemEntry> OrderExtractionEntries(
+        IEnumerable<ImageFileSystemEntry> selected) =>
+        selected
+            .OrderBy(entry => entry.Path.Count(c => c == '/'))
+            .ThenBy(entry => entry.Path, StringComparer.Ordinal)
+            .ToList();
+
+    private static void ValidateExtractionEntries(IEnumerable<ImageFileSystemEntry> selected)
+    {
         ImageFileSystemEntry? unsupported = selected.FirstOrDefault(
             entry => entry.Type == ImageFileType.Other);
         if (unsupported is not null)
@@ -217,19 +234,27 @@ internal sealed class ImageFileSystem
             throw new NotSupportedException(
                 $"Path '/{unsupported.Path}' has unsupported file type '{unsupported.Type}'.");
         }
+    }
 
-        Dictionary<string, string> destinations = selected.ToDictionary(
+    private static Dictionary<string, string> CreateExtractionDestinations(
+        IEnumerable<ImageFileSystemEntry> selected,
+        string sourcePath,
+        string outputPath,
+        bool extractingRoot) =>
+        selected.ToDictionary(
             entry => entry.Path,
             entry => !extractingRoot && entry.Path == sourcePath
-                ? fullOutputPath
+                ? outputPath
                 : GetContainedDestination(
-                    fullOutputPath,
+                    outputPath,
                     extractingRoot
                         ? entry.Path
                         : entry.Path[(sourcePath.Length + 1)..]),
             StringComparer.Ordinal);
 
-        Dictionary<string, string> hardLinkTargets = selected
+    private Dictionary<string, string> GetExtractionHardLinkTargets(
+        IEnumerable<ImageFileSystemEntry> selected) =>
+        selected
             .Where(entry => entry.Type == ImageFileType.HardLink)
             .Select(entry => (Entry: entry, Target: TryGetHardLinkTargetPath(entry)))
             .Where(item => item.Target is not null)
@@ -237,149 +262,174 @@ internal sealed class ImageFileSystem
                 item => item.Entry.Path,
                 item => item.Target!,
                 StringComparer.Ordinal);
-        HashSet<string> preservableHardLinks = selected
+
+    private HashSet<string> GetPreservableHardLinks(
+        IEnumerable<ImageFileSystemEntry> selected,
+        IReadOnlyDictionary<string, string> destinations,
+        IReadOnlyDictionary<string, string> hardLinkTargets) =>
+        selected
             .Where(entry =>
                 entry.Type == ImageFileType.HardLink &&
                 entry.ContentLinkTarget is null)
             .Where(entry =>
-            {
-                return hardLinkTargets.TryGetValue(entry.Path, out string? targetPath) &&
-                    destinations.ContainsKey(targetPath) &&
-                    entries.TryGetValue(targetPath, out ImageFileSystemEntry? target) &&
-                    target.ContentLayerIndex == entry.ContentLayerIndex &&
-                    target.ContentPath == entry.ContentPath &&
-                    target.ContentEntryIndex == entry.ContentEntryIndex;
-            })
+                hardLinkTargets.TryGetValue(entry.Path, out string? targetPath) &&
+                destinations.ContainsKey(targetPath) &&
+                entries.TryGetValue(targetPath, out ImageFileSystemEntry? target) &&
+                target.ContentLayerIndex == entry.ContentLayerIndex &&
+                target.ContentPath == entry.ContentPath &&
+                target.ContentEntryIndex == entry.ContentEntryIndex)
             .Select(entry => entry.Path)
             .ToHashSet(StringComparer.Ordinal);
 
-        bool outputCreated = false;
-        try
+    private static void CreateExtractionSubdirectories(
+        ExtractionPlan plan,
+        CancellationToken cancellationToken)
+    {
+        foreach (ImageFileSystemEntry directory in plan.Entries
+            .Where(entry => entry.Type == ImageFileType.Directory))
         {
-            if (extractingRoot || source!.Type == ImageFileType.Directory)
-            {
-                Directory.CreateDirectory(fullOutputPath);
-                outputCreated = true;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            Directory.CreateDirectory(plan.Destinations[directory.Path]);
+        }
+    }
 
-            foreach (ImageFileSystemEntry directory in selected
-                .Where(entry => entry.Type == ImageFileType.Directory))
+    private static List<(ImageFileSystemEntry Entry, string Destination)>
+        GetContentExtractionRequests(ExtractionPlan plan) =>
+        plan.Entries
+            .Where(entry =>
+                entry.Type == ImageFileType.File ||
+                (entry.Type == ImageFileType.HardLink &&
+                    !plan.PreservableHardLinks.Contains(entry.Path) &&
+                    entry.ContentLinkTarget is null))
+            .Select(entry => (entry, plan.Destinations[entry.Path]))
+            .ToList();
+
+    private static void CreatePreservedHardLinks(
+        ExtractionPlan plan,
+        ExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        List<ImageFileSystemEntry> pending = plan.Entries
+            .Where(entry =>
+                entry.Type == ImageFileType.HardLink &&
+                plan.PreservableHardLinks.Contains(entry.Path))
+            .ToList();
+        // Multiple passes allow hard-link chains whose immediate target has not been
+        // materialized yet, without replacing them with independent file copies.
+        while (pending.Count > 0)
+        {
+            int createdCount = 0;
+            for (int index = pending.Count - 1; index >= 0; index--)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                Directory.CreateDirectory(destinations[directory.Path]);
-            }
-
-            List<(ImageFileSystemEntry Entry, string Destination)> content = selected
-                .Where(entry =>
-                    entry.Type == ImageFileType.File ||
-                    (entry.Type == ImageFileType.HardLink &&
-                        !preservableHardLinks.Contains(entry.Path) &&
-                        entry.ContentLinkTarget is null))
-                .Select(entry => (entry, destinations[entry.Path]))
-                .ToList();
-            outputCreated |= content.Count > 0;
-            await ExtractContentEntriesAsync(content, cancellationToken);
-
-            List<ImageFileSystemEntry> pendingHardLinks = selected
-                .Where(entry =>
-                    entry.Type == ImageFileType.HardLink &&
-                    preservableHardLinks.Contains(entry.Path))
-                .ToList();
-            // Multiple passes allow hard-link chains whose immediate target has not been
-            // materialized yet, without replacing them with independent file copies.
-            while (pendingHardLinks.Count > 0)
-            {
-                int createdCount = 0;
-                for (int index = pendingHardLinks.Count - 1; index >= 0; index--)
+                ImageFileSystemEntry hardLink = pending[index];
+                string target = plan.HardLinkTargets[hardLink.Path];
+                if (!File.Exists(plan.Destinations[target]))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    ImageFileSystemEntry hardLink = pendingHardLinks[index];
-                    string target = hardLinkTargets[hardLink.Path];
-                    if (!File.Exists(destinations[target]))
-                    {
-                        continue;
-                    }
-                    FileHelper.CreateHardLink(destinations[hardLink.Path], destinations[target]);
-                    pendingHardLinks.RemoveAt(index);
-                    createdCount++;
-                    outputCreated = true;
+                    continue;
                 }
-                if (createdCount == 0)
-                {
-                    throw new InvalidDataException(
-                        $"Unable to create hard link '/{pendingHardLinks[0].Path}'.");
-                }
+                FileHelper.CreateHardLink(
+                    plan.Destinations[hardLink.Path],
+                    plan.Destinations[target]);
+                state.OutputCreated = true;
+                pending.RemoveAt(index);
+                createdCount++;
             }
-
-            foreach (ImageFileSystemEntry symbolicLink in selected
-                .Where(entry => entry.Type == ImageFileType.SymbolicLink))
+            if (createdCount == 0)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                string destination = destinations[symbolicLink.Path];
-                string target = symbolicLink.LinkTarget ??
-                    throw new InvalidDataException(
-                        $"Symbolic link '/{symbolicLink.Path}' has no target.");
-                bool targetsDirectory = TryResolvePath(symbolicLink.Path)?.Type ==
-                    ImageFileType.Directory;
-                FileHelper.CreateSymbolicLink(destination, target, targetsDirectory);
-                outputCreated = true;
-            }
-
-            foreach (ImageFileSystemEntry hardLink in selected
-                .Where(entry =>
-                    entry.Type == ImageFileType.HardLink &&
-                    entry.ContentLinkTarget is not null))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                string? targetPath = TryGetHardLinkTargetPath(hardLink);
-                bool targetsDirectory = targetPath is not null &&
-                    TryResolvePath(targetPath)?.Type ==
-                    ImageFileType.Directory;
-                FileHelper.CreateSymbolicLink(
-                    destinations[hardLink.Path],
-                    hardLink.ContentLinkTarget!,
-                    targetsDirectory);
-                outputCreated = true;
-            }
-
-            foreach (ImageFileSystemEntry entry in selected
-                .Where(entry =>
-                    entry.Type is ImageFileType.File or ImageFileType.Directory ||
-                    (entry.Type == ImageFileType.HardLink &&
-                        !preservableHardLinks.Contains(entry.Path) &&
-                        entry.ContentLinkTarget is null))
-                .OrderByDescending(entry => entry.Path.Count(c => c == '/')))
-            {
-                ApplyMetadata(destinations[entry.Path], entry);
+                throw new InvalidDataException(
+                    $"Unable to create hard link '/{pending[0].Path}'.");
             }
         }
-        catch (Exception exception)
+    }
+
+    private void CreateSymbolicLinks(
+        ExtractionPlan plan,
+        ExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        foreach (ImageFileSystemEntry symbolicLink in plan.Entries
+            .Where(entry => entry.Type == ImageFileType.SymbolicLink))
         {
-            // Preserve the extraction failure as the primary exception; cleanup failures
-            // remain available as diagnostics without masking the original cause.
-            if (outputCreated)
+            cancellationToken.ThrowIfCancellationRequested();
+            string target = symbolicLink.LinkTarget ??
+                throw new InvalidDataException(
+                    $"Symbolic link '/{symbolicLink.Path}' has no target.");
+            bool targetsDirectory = TryResolvePath(symbolicLink.Path)?.Type ==
+                ImageFileType.Directory;
+            FileHelper.CreateSymbolicLink(
+                plan.Destinations[symbolicLink.Path],
+                target,
+                targetsDirectory);
+            state.OutputCreated = true;
+        }
+    }
+
+    private void CreateSymbolicHardLinks(
+        ExtractionPlan plan,
+        ExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        foreach (ImageFileSystemEntry hardLink in plan.Entries
+            .Where(entry =>
+                entry.Type == ImageFileType.HardLink &&
+                entry.ContentLinkTarget is not null))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string? targetPath = TryGetHardLinkTargetPath(hardLink);
+            bool targetsDirectory = targetPath is not null &&
+                TryResolvePath(targetPath)?.Type == ImageFileType.Directory;
+            FileHelper.CreateSymbolicLink(
+                plan.Destinations[hardLink.Path],
+                hardLink.ContentLinkTarget!,
+                targetsDirectory);
+            state.OutputCreated = true;
+        }
+    }
+
+    private static void ApplyExtractionMetadata(ExtractionPlan plan)
+    {
+        foreach (ImageFileSystemEntry entry in plan.Entries
+            .Where(entry =>
+                entry.Type is ImageFileType.File or ImageFileType.Directory ||
+                (entry.Type == ImageFileType.HardLink &&
+                    !plan.PreservableHardLinks.Contains(entry.Path) &&
+                    entry.ContentLinkTarget is null))
+            .OrderByDescending(entry => entry.Path.Count(c => c == '/')))
+        {
+            ApplyMetadata(plan.Destinations[entry.Path], entry);
+        }
+    }
+
+    private static void CleanupFailedExtraction(
+        ExtractionPlan plan,
+        bool outputCreated,
+        Exception exception)
+    {
+        // Preserve the extraction failure as the primary exception; cleanup failures
+        // remain available as diagnostics without masking the original cause.
+        if (outputCreated)
+        {
+            try
             {
-                try
-                {
-                    DeleteOutput(fullOutputPath);
-                }
-                catch (Exception cleanupException)
-                {
-                    exception.Data["ExtractionCleanupException"] = cleanupException;
-                }
+                DeleteOutput(plan.OutputPath);
             }
-            if (missingParentRoot is not null && Directory.Exists(missingParentRoot))
+            catch (Exception cleanupException)
             {
-                try
-                {
-                    Directory.Delete(missingParentRoot, recursive: true);
-                }
-                catch (Exception cleanupException)
-                {
-                    exception.Data["ExtractionParentCleanupException"] = cleanupException;
-                }
+                exception.Data["ExtractionCleanupException"] = cleanupException;
             }
-            throw;
+        }
+        if (plan.MissingParentRoot is not null &&
+            Directory.Exists(plan.MissingParentRoot))
+        {
+            try
+            {
+                Directory.Delete(plan.MissingParentRoot, recursive: true);
+            }
+            catch (Exception cleanupException)
+            {
+                exception.Data["ExtractionParentCleanupException"] = cleanupException;
+            }
         }
     }
 
@@ -397,102 +447,12 @@ internal sealed class ImageFileSystem
                 imageName.Repo,
                 digest,
                 cancellationToken);
-            LayerChanges changes = await ScanLayerAsync(
+            LayerChanges changes = await ImageLayerScanner.ScanAsync(
                 blob,
                 layerReference,
                 cancellationToken);
             ApplyLayer(changes, layerReference, cancellationToken);
         }
-    }
-
-    private static async Task<LayerChanges> ScanLayerAsync(
-        Stream blob,
-        ImageLayerReference layer,
-        CancellationToken cancellationToken)
-    {
-        List<ScannedEntry> entries = [];
-        List<string> whiteouts = [];
-        List<string> opaqueDirectories = [];
-
-        using GZipStream gzip = new(blob, CompressionMode.Decompress, leaveOpen: true);
-        using TarReader tar = new(gzip, leaveOpen: true);
-        int entryIndex = 0;
-        while (true)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            TarEntry? tarEntry = await GetNextTarEntryAsync(
-                tar,
-                layer,
-                cancellationToken);
-            if (tarEntry is null)
-            {
-                break;
-            }
-            int currentEntryIndex = entryIndex++;
-            await DrainTarEntryAsync(tarEntry, layer, cancellationToken);
-
-            string path = ImagePath.NormalizeArchive(tarEntry.Name);
-            if (path.Length == 0)
-            {
-                continue;
-            }
-
-            string fileName = ImagePath.GetFileName(path);
-            string parent = ImagePath.GetDirectoryName(path);
-            if (string.Equals(fileName, OpaqueWhiteout, StringComparison.Ordinal))
-            {
-                if (parent.Length == 0)
-                {
-                    throw new InvalidDataException(
-                        "The opaque whiteout marker cannot exist at the image root.");
-                }
-                opaqueDirectories.Add(parent);
-                continue;
-            }
-
-            if (fileName.StartsWith(WhiteoutPrefix, StringComparison.Ordinal))
-            {
-                string targetName = fileName[WhiteoutPrefix.Length..];
-                ImagePath.ValidateSegment(targetName, "whiteout target");
-                whiteouts.Add(
-                    parent.Length == 0 ? targetName : $"{parent}/{targetName}");
-                continue;
-            }
-
-            ImageFileType type = GetFileType(tarEntry);
-            string? linkTarget = type is ImageFileType.SymbolicLink or ImageFileType.HardLink
-                ? tarEntry.LinkName
-                : null;
-            if (linkTarget is not null && ImagePath.ContainsControlCharacter(linkTarget))
-            {
-                throw new InvalidDataException(
-                    $"Link '/{path}' has an invalid target.");
-            }
-            if (type == ImageFileType.SymbolicLink)
-            {
-                string basePath = ImagePath.IsAbsolute(linkTarget!)
-                    ? string.Empty
-                    : parent;
-                _ = ImagePath.ResolveLinkTarget(
-                    basePath,
-                    linkTarget!,
-                    string.Empty,
-                    path);
-            }
-
-            entries.Add(new ScannedEntry(
-                path,
-                type,
-                (int)tarEntry.Mode,
-                tarEntry.Uid,
-                tarEntry.Gid,
-                type == ImageFileType.File ? tarEntry.Length : 0,
-                tarEntry.ModificationTime.UtcDateTime,
-                linkTarget,
-                currentEntryIndex,
-                layer));
-        }
-        return new LayerChanges(entries, whiteouts, opaqueDirectories);
     }
 
     private void ApplyLayer(
@@ -817,7 +777,7 @@ internal sealed class ImageFileSystem
             while (destinations.Count > 0)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                TarEntry? tarEntry = await GetNextTarEntryAsync(
+                TarEntry? tarEntry = await ImageTarReader.GetNextEntryAsync(
                     tar,
                     new(group.Key, digest),
                     cancellationToken);
@@ -832,7 +792,7 @@ internal sealed class ImageFileSystem
                     (path, currentEntryIndex),
                     out Queue<Stream>? outputs))
                 {
-                    await DrainTarEntryAsync(
+                    await ImageTarReader.DrainEntryAsync(
                         tarEntry,
                         new(group.Key, digest),
                         cancellationToken);
@@ -841,7 +801,7 @@ internal sealed class ImageFileSystem
 
                 using MemoryStream? buffer = outputs.Count > 1 ? new MemoryStream() : null;
                 Stream first = buffer ?? outputs.Dequeue();
-                await CopyTarEntryAsync(
+                await ImageTarReader.CopyEntryAsync(
                     tarEntry,
                     first,
                     new(group.Key, digest),
@@ -894,7 +854,7 @@ internal sealed class ImageFileSystem
             while (destinations.Count > 0)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                TarEntry? tarEntry = await GetNextTarEntryAsync(
+                TarEntry? tarEntry = await ImageTarReader.GetNextEntryAsync(
                     tar,
                     new(group.Key, digest),
                     cancellationToken);
@@ -909,7 +869,7 @@ internal sealed class ImageFileSystem
                     (path, currentEntryIndex),
                     out Queue<string>? outputs))
                 {
-                    await DrainTarEntryAsync(
+                    await ImageTarReader.DrainEntryAsync(
                         tarEntry,
                         new(group.Key, digest),
                         cancellationToken);
@@ -926,7 +886,7 @@ internal sealed class ImageFileSystem
                     bufferSize: 81920,
                     FileOptions.Asynchronous))
                 {
-                    await CopyTarEntryAsync(
+                    await ImageTarReader.CopyEntryAsync(
                         tarEntry,
                         destination,
                         new(group.Key, digest),
@@ -949,86 +909,6 @@ internal sealed class ImageFileSystem
             }
         }
     }
-
-    private static ImageFileType GetFileType(TarEntry entry) =>
-        entry.EntryType switch
-        {
-            TarEntryType.RegularFile or
-                TarEntryType.V7RegularFile or
-                TarEntryType.ContiguousFile => ImageFileType.File,
-            TarEntryType.SymbolicLink => ImageFileType.SymbolicLink,
-            TarEntryType.HardLink => ImageFileType.HardLink,
-            TarEntryType.Directory => ImageFileType.Directory,
-            _ => ImageFileType.Other
-        };
-
-    private static async ValueTask<TarEntry?> GetNextTarEntryAsync(
-        TarReader reader,
-        ImageLayerReference layer,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await reader.GetNextEntryAsync(
-                copyData: false,
-                cancellationToken);
-        }
-        catch (Exception exception) when (
-            exception is InvalidDataException or NotSupportedException)
-        {
-            throw CreateInvalidLayerException(layer, exception);
-        }
-    }
-
-    private static async Task DrainTarEntryAsync(
-        TarEntry entry,
-        ImageLayerReference layer,
-        CancellationToken cancellationToken)
-    {
-        if (entry.DataStream is null)
-        {
-            return;
-        }
-
-        // On .NET 9, GetNextEntryAsync(copyData: false) does not reliably advance past
-        // skipped data, so every unconsumed entry must be drained before reading the next.
-        try
-        {
-            await entry.DataStream.CopyToAsync(Stream.Null, cancellationToken);
-        }
-        catch (Exception exception) when (
-            exception is InvalidDataException or NotSupportedException)
-        {
-            throw CreateInvalidLayerException(layer, exception);
-        }
-    }
-
-    private static async Task CopyTarEntryAsync(
-        TarEntry entry,
-        Stream destination,
-        ImageLayerReference layer,
-        string path,
-        CancellationToken cancellationToken)
-    {
-        Stream data = entry.DataStream ??
-            throw new InvalidDataException($"File '/{path}' has no content stream.");
-        try
-        {
-            await data.CopyToAsync(destination, cancellationToken);
-        }
-        catch (Exception exception) when (
-            exception is InvalidDataException or NotSupportedException)
-        {
-            throw CreateInvalidLayerException(layer, exception);
-        }
-    }
-
-    private static InvalidDataException CreateInvalidLayerException(
-        ImageLayerReference layer,
-        Exception innerException) =>
-        new(
-            $"Layer {layer.Index} ('{layer.Digest}') is not a supported gzip-compressed Linux tar layer.",
-            innerException);
 
     private static void ValidateNewDestination(string outputPath)
     {
@@ -1148,153 +1028,19 @@ internal sealed class ImageFileSystem
         }
     }
 
-    private sealed record LayerChanges(
-        IReadOnlyList<ScannedEntry> Entries,
-        IReadOnlyList<string> Whiteouts,
-        IReadOnlyList<string> OpaqueDirectories);
+    private sealed record ExtractionPlan(
+        ImageFileSystemEntry? Source,
+        bool ExtractingRoot,
+        string OutputPath,
+        string? MissingParentRoot,
+        IReadOnlyList<ImageFileSystemEntry> Entries,
+        IReadOnlyDictionary<string, string> Destinations,
+        IReadOnlyDictionary<string, string> HardLinkTargets,
+        IReadOnlySet<string> PreservableHardLinks);
 
-    private sealed record ScannedEntry(
-        string Path,
-        ImageFileType Type,
-        int Mode,
-        int UserId,
-        int GroupId,
-        long Size,
-        DateTime ModifiedTime,
-        string? LinkTarget,
-        int EntryIndex,
-        ImageLayerReference Layer)
+    private sealed class ExtractionState
     {
-        public ImageFileSystemEntry ToEntry(
-            ImageLayerReference introduced,
-            ImageLayerReference? modified) =>
-            new()
-            {
-                Path = Path,
-                Type = Type,
-                Mode = Mode,
-                UserId = UserId,
-                GroupId = GroupId,
-                Size = Size,
-                ModifiedTime = ModifiedTime,
-                LinkTarget = LinkTarget,
-                IntroducedLayer = introduced,
-                ModifiedLayer = modified,
-                ContentLayerIndex = Layer.Index,
-                ContentPath = Type == ImageFileType.File ? Path : null,
-                ContentEntryIndex = EntryIndex
-            };
-    }
-}
-
-internal static class ImagePath
-{
-    public static string NormalizeArchive(string value)
-    {
-        if (string.IsNullOrEmpty(value) || ContainsControlCharacter(value))
-        {
-            throw new InvalidDataException($"Invalid archive entry path '{value}'.");
-        }
-        if (IsAbsolute(value) || value.Contains('\\'))
-        {
-            throw new InvalidDataException(
-                $"Archive entry path '{value}' must be a relative Linux path.");
-        }
-        return Normalize(value, allowParentSegments: false, "archive entry");
+        public bool OutputCreated { get; set; }
     }
 
-    public static string NormalizeRequested(string? value)
-    {
-        value = string.IsNullOrEmpty(value) ? string.Empty : value;
-        if (value.Contains('\\') || ContainsControlCharacter(value))
-        {
-            throw new InvalidDataException($"Invalid image path '{value}'.");
-        }
-        return Normalize(value.TrimStart('/'), allowParentSegments: false, "image");
-    }
-
-    public static string ResolveLinkTarget(
-        string basePath,
-        string target,
-        string remainder,
-        string linkPath)
-    {
-        if (target.Contains('\\') || ContainsControlCharacter(target))
-        {
-            throw new InvalidDataException(
-                $"Link '/{linkPath}' has invalid target '{target}'.");
-        }
-
-        string combined = IsAbsolute(target)
-            ? target.TrimStart('/')
-            : Join(basePath, target);
-        combined = Join(combined, remainder);
-        return Normalize(combined, allowParentSegments: true, $"link target for '/{linkPath}'");
-    }
-
-    public static bool IsAbsolute(string path) => path.StartsWith('/');
-
-    public static string GetDirectoryName(string path)
-    {
-        int separator = path.LastIndexOf('/');
-        return separator < 0 ? string.Empty : path[..separator];
-    }
-
-    public static string GetFileName(string path)
-    {
-        int separator = path.LastIndexOf('/');
-        return separator < 0 ? path : path[(separator + 1)..];
-    }
-
-    public static void ValidateSegment(string value, string description)
-    {
-        if (string.IsNullOrEmpty(value) ||
-            value is "." or ".." ||
-            value.Contains('/') ||
-            value.Contains('\\') ||
-            ContainsControlCharacter(value))
-        {
-            throw new InvalidDataException($"Invalid {description} '{value}'.");
-        }
-    }
-
-    private static string Normalize(
-        string value,
-        bool allowParentSegments,
-        string description)
-    {
-        List<string> segments = [];
-        foreach (string segment in value.Split('/', StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (segment == ".")
-            {
-                continue;
-            }
-            if (segment == "..")
-            {
-                if (!allowParentSegments)
-                {
-                    throw new InvalidDataException(
-                        $"The {description} path '{value}' escapes the image root.");
-                }
-                if (segments.Count > 0)
-                {
-                    segments.RemoveAt(segments.Count - 1);
-                }
-                // Linux clamps excess ".." segments at the filesystem root.
-                continue;
-            }
-            ValidateSegment(segment, $"{description} path segment");
-            segments.Add(segment);
-        }
-        return string.Join('/', segments);
-    }
-
-    private static string Join(string first, string second) =>
-        first.Length == 0 ? second :
-        second.Length == 0 ? first :
-        $"{first}/{second}";
-
-    internal static bool ContainsControlCharacter(string value) =>
-        value.Any(char.IsControl);
 }

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -113,10 +113,13 @@ internal sealed class ImageFileSystem
         ImageFileSystemEntry? selected = null;
         if (path.Length > 0)
         {
-            entries.TryGetValue(path, out selected);
-            if (selected is null && showDeleted)
+            try
             {
-                deletedEntries.TryGetValue(path, out selected);
+                selected = ResolvePath(path, followFinalSymbolicLink: false);
+            }
+            catch (FileNotFoundException) when (
+                showDeleted && deletedEntries.TryGetValue(path, out selected))
+            {
             }
             if (selected is null)
             {
@@ -126,7 +129,7 @@ internal sealed class ImageFileSystem
 
         if (selected is not null && selected.Type != ImageFileType.Directory)
         {
-            return [selected];
+            return [selected.Path == path ? selected : selected with { Path = path }];
         }
 
         IEnumerable<ImageFileSystemEntry> results = entries.Values;
@@ -135,7 +138,8 @@ internal sealed class ImageFileSystem
             results = results.Concat(deletedEntries.Values);
         }
 
-        string prefix = path.Length == 0 ? string.Empty : $"{path}/";
+        string resolvedPath = selected?.Path ?? path;
+        string prefix = resolvedPath.Length == 0 ? string.Empty : $"{resolvedPath}/";
         return results
             .Where(entry =>
             {
@@ -148,6 +152,9 @@ internal sealed class ImageFileSystem
                 string relative = entry.Path[prefix.Length..];
                 return recursive || !relative.Contains('/');
             })
+            .Select(entry => resolvedPath == path
+                ? entry
+                : entry with { Path = $"{path}/{entry.Path[prefix.Length..]}" })
             .OrderBy(entry => entry.Path, StringComparer.Ordinal)
             .ToArray();
     }
@@ -171,10 +178,10 @@ internal sealed class ImageFileSystem
         string sourcePath = ImagePath.NormalizeRequested(requestedPath);
         bool extractingRoot = sourcePath.Length == 0;
         ImageFileSystemEntry? source = null;
-        if (!extractingRoot &&
-            !entries.TryGetValue(sourcePath, out source))
+        if (!extractingRoot)
         {
-            throw new FileNotFoundException($"Path '/{sourcePath}' does not exist in the image.");
+            source = ResolvePath(sourcePath, followFinalSymbolicLink: false);
+            sourcePath = source.Path;
         }
         if (source?.Type == ImageFileType.Other)
         {
@@ -214,9 +221,11 @@ internal sealed class ImageFileSystem
 
         Dictionary<string, string> hardLinkTargets = selected
             .Where(entry => entry.Type == ImageFileType.HardLink)
+            .Select(entry => (Entry: entry, Target: TryGetHardLinkTargetPath(entry)))
+            .Where(item => item.Target is not null)
             .ToDictionary(
-                entry => entry.Path,
-                entry => GetHardLinkTargetPath(entry),
+                item => item.Entry.Path,
+                item => item.Target!,
                 StringComparer.Ordinal);
         HashSet<string> preservableHardLinks = selected
             .Where(entry =>
@@ -224,8 +233,8 @@ internal sealed class ImageFileSystem
                 entry.ContentLinkTarget is null)
             .Where(entry =>
             {
-                string targetPath = hardLinkTargets[entry.Path];
-                return destinations.ContainsKey(targetPath) &&
+                return hardLinkTargets.TryGetValue(entry.Path, out string? targetPath) &&
+                    destinations.ContainsKey(targetPath) &&
                     entries.TryGetValue(targetPath, out ImageFileSystemEntry? target) &&
                     target.ContentLayerIndex == entry.ContentLayerIndex &&
                     target.ContentPath == entry.ContentPath &&
@@ -312,8 +321,9 @@ internal sealed class ImageFileSystem
                     entry.ContentLinkTarget is not null))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                string targetPath = GetHardLinkTargetPath(hardLink);
-                bool targetsDirectory = TryResolvePath(targetPath)?.Type ==
+                string? targetPath = TryGetHardLinkTargetPath(hardLink);
+                bool targetsDirectory = targetPath is not null &&
+                    TryResolvePath(targetPath)?.Type ==
                     ImageFileType.Directory;
                 FileHelper.CreateSymbolicLink(
                     destinations[hardLink.Path],
@@ -526,6 +536,7 @@ internal sealed class ImageFileSystem
                 }
                 current = current with
                 {
+                    Size = target.Size,
                     ContentLayerIndex = target.ContentLayerIndex,
                     ContentPath = target.ContentPath,
                     ContentEntryIndex = target.ContentEntryIndex,
@@ -642,7 +653,9 @@ internal sealed class ImageFileSystem
         return entry;
     }
 
-    private ImageFileSystemEntry ResolvePath(string requestedPath)
+    private ImageFileSystemEntry ResolvePath(
+        string requestedPath,
+        bool followFinalSymbolicLink = true)
     {
         string current = ImagePath.NormalizeRequested(requestedPath);
         for (int hop = 0; hop < MaximumLinkHops; hop++)
@@ -658,7 +671,8 @@ internal sealed class ImageFileSystem
                         $"Path '/{requestedPath}' resolves to missing path '/{candidate}'.");
                 }
 
-                if (entry.Type != ImageFileType.SymbolicLink)
+                if (entry.Type != ImageFileType.SymbolicLink ||
+                    (!followFinalSymbolicLink && i == segments.Length - 1))
                 {
                     continue;
                 }
@@ -731,6 +745,22 @@ internal sealed class ImageFileSystem
                 $"Hard link '/{entry.Path}' targets path '/{targetPath}' with a non-directory parent.");
         }
         return $"{parent.Path}/{ImagePath.GetFileName(targetPath)}";
+    }
+
+    private string? TryGetHardLinkTargetPath(ImageFileSystemEntry entry)
+    {
+        try
+        {
+            return GetHardLinkTargetPath(entry);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (InvalidDataException)
+        {
+            return null;
+        }
     }
 
     private async Task CopyContentEntriesAsync(

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -137,6 +137,7 @@ internal sealed class ImageFileSystem
             CreateExtractionSubdirectories(plan, cancellationToken);
             List<(ImageFileSystemEntry Entry, string Destination)> content =
                 GetContentExtractionRequests(plan);
+            // A failed or canceled copy may leave a partial file that must be rolled back.
             state.OutputCreated |= content.Count > 0;
             await ExtractContentEntriesAsync(content, cancellationToken);
             CreatePreservedHardLinks(plan, state, cancellationToken);

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -463,7 +463,7 @@ internal sealed class ImageFileSystem
             string? linkTarget = type is ImageFileType.SymbolicLink or ImageFileType.HardLink
                 ? tarEntry.LinkName
                 : null;
-            if (linkTarget is not null && linkTarget.IndexOf('\0') >= 0)
+            if (linkTarget is not null && ImagePath.ContainsControlCharacter(linkTarget))
             {
                 throw new InvalidDataException(
                     $"Link '/{path}' has an invalid target.");
@@ -1191,7 +1191,7 @@ internal static class ImagePath
 {
     public static string NormalizeArchive(string value)
     {
-        if (string.IsNullOrEmpty(value) || value.IndexOf('\0') >= 0)
+        if (string.IsNullOrEmpty(value) || ContainsControlCharacter(value))
         {
             throw new InvalidDataException($"Invalid archive entry path '{value}'.");
         }
@@ -1206,7 +1206,7 @@ internal static class ImagePath
     public static string NormalizeRequested(string? value)
     {
         value = string.IsNullOrEmpty(value) ? string.Empty : value;
-        if (value.Contains('\\') || value.IndexOf('\0') >= 0)
+        if (value.Contains('\\') || ContainsControlCharacter(value))
         {
             throw new InvalidDataException($"Invalid image path '{value}'.");
         }
@@ -1219,7 +1219,7 @@ internal static class ImagePath
         string remainder,
         string linkPath)
     {
-        if (target.Contains('\\') || target.IndexOf('\0') >= 0)
+        if (target.Contains('\\') || ContainsControlCharacter(target))
         {
             throw new InvalidDataException(
                 $"Link '/{linkPath}' has invalid target '{target}'.");
@@ -1252,7 +1252,7 @@ internal static class ImagePath
             value is "." or ".." ||
             value.Contains('/') ||
             value.Contains('\\') ||
-            value.IndexOf('\0') >= 0)
+            ContainsControlCharacter(value))
         {
             throw new InvalidDataException($"Invalid {description} '{value}'.");
         }
@@ -1294,4 +1294,7 @@ internal static class ImagePath
         first.Length == 0 ? second :
         second.Length == 0 ? first :
         $"{first}/{second}";
+
+    internal static bool ContainsControlCharacter(string value) =>
+        value.Any(char.IsControl);
 }

--- a/src/Valleysoft.Dredge/ImageFileSystem.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystem.cs
@@ -113,13 +113,11 @@ internal sealed class ImageFileSystem
         ImageFileSystemEntry? selected = null;
         if (path.Length > 0)
         {
-            try
+            string lookupPath = ResolveParentComponents(path);
+            entries.TryGetValue(lookupPath, out selected);
+            if (selected is null && showDeleted)
             {
-                selected = ResolvePath(path, followFinalSymbolicLink: false);
-            }
-            catch (FileNotFoundException) when (
-                showDeleted && deletedEntries.TryGetValue(path, out selected))
-            {
+                deletedEntries.TryGetValue(lookupPath, out selected);
             }
             if (selected is null)
             {
@@ -180,7 +178,12 @@ internal sealed class ImageFileSystem
         ImageFileSystemEntry? source = null;
         if (!extractingRoot)
         {
-            source = ResolvePath(sourcePath, followFinalSymbolicLink: false);
+            string lookupPath = ResolveParentComponents(sourcePath);
+            if (!entries.TryGetValue(lookupPath, out source))
+            {
+                throw new FileNotFoundException(
+                    $"Path '/{sourcePath}' does not exist in the image.");
+            }
             sourcePath = source.Path;
         }
         if (source?.Type == ImageFileType.Other)
@@ -207,6 +210,13 @@ internal sealed class ImageFileSystem
                 .ThenBy(entry => entry.Path, StringComparer.Ordinal)
                 .ToList()
             : [source];
+        ImageFileSystemEntry? unsupported = selected.FirstOrDefault(
+            entry => entry.Type == ImageFileType.Other);
+        if (unsupported is not null)
+        {
+            throw new NotSupportedException(
+                $"Path '/{unsupported.Path}' has unsupported file type '{unsupported.Type}'.");
+        }
 
         Dictionary<string, string> destinations = selected.ToDictionary(
             entry => entry.Path,
@@ -653,9 +663,7 @@ internal sealed class ImageFileSystem
         return entry;
     }
 
-    private ImageFileSystemEntry ResolvePath(
-        string requestedPath,
-        bool followFinalSymbolicLink = true)
+    private ImageFileSystemEntry ResolvePath(string requestedPath)
     {
         string current = ImagePath.NormalizeRequested(requestedPath);
         for (int hop = 0; hop < MaximumLinkHops; hop++)
@@ -671,8 +679,7 @@ internal sealed class ImageFileSystem
                         $"Path '/{requestedPath}' resolves to missing path '/{candidate}'.");
                 }
 
-                if (entry.Type != ImageFileType.SymbolicLink ||
-                    (!followFinalSymbolicLink && i == segments.Length - 1))
+                if (entry.Type != ImageFileType.SymbolicLink)
                 {
                     continue;
                 }
@@ -703,6 +710,23 @@ internal sealed class ImageFileSystem
 
         throw new InvalidDataException(
             $"Link resolution for '/{requestedPath}' exceeded {MaximumLinkHops} hops.");
+    }
+
+    private string ResolveParentComponents(string path)
+    {
+        string parentPath = ImagePath.GetDirectoryName(path);
+        if (parentPath.Length == 0)
+        {
+            return path;
+        }
+
+        ImageFileSystemEntry parent = ResolvePath(parentPath);
+        if (parent.Type != ImageFileType.Directory)
+        {
+            throw new InvalidDataException(
+                $"Path '/{path}' has a non-directory parent '/{parent.Path}'.");
+        }
+        return $"{parent.Path}/{ImagePath.GetFileName(path)}";
     }
 
     private ImageFileSystemEntry? TryResolvePath(string requestedPath)

--- a/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Valleysoft.Dredge;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ImageFileType
+{
+    File,
+    Directory,
+    SymbolicLink,
+    HardLink,
+    Other
+}
+
+public sealed record ImageLayerReference(int Index, string Digest);
+
+public sealed record ImageFileSystemEntry
+{
+    public required string Path { get; init; }
+    public required ImageFileType Type { get; init; }
+    public int Mode { get; init; }
+    public int UserId { get; init; }
+    public int GroupId { get; init; }
+    public long Size { get; init; }
+    public DateTime? ModifiedTime { get; init; }
+    public string? LinkTarget { get; init; }
+    public required ImageLayerReference IntroducedLayer { get; init; }
+    public ImageLayerReference? ModifiedLayer { get; init; }
+    public ImageLayerReference? DeletedLayer { get; init; }
+
+    [JsonIgnore]
+    internal int ContentLayerIndex { get; init; }
+
+    [JsonIgnore]
+    internal string? ContentPath { get; init; }
+
+    [JsonIgnore]
+    // The ordinal disambiguates duplicate paths in non-conforming layers so content reads
+    // reopen the exact entry that produced the index metadata.
+    internal int ContentEntryIndex { get; init; }
+
+    [JsonIgnore]
+    internal string? ContentLinkTarget { get; init; }
+
+    [JsonIgnore]
+    internal bool IsDeleted => DeletedLayer is not null;
+}

--- a/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
@@ -29,6 +29,8 @@ public sealed record ImageFileSystemEntry
     public ImageLayerReference? ModifiedLayer { get; init; }
     public ImageLayerReference? DeletedLayer { get; init; }
 
+    // These coordinates reopen the exact content-producing tar entry. The ordinal
+    // disambiguates duplicate paths in non-conforming layers.
     [JsonIgnore]
     internal int ContentLayerIndex { get; init; }
 
@@ -36,10 +38,10 @@ public sealed record ImageFileSystemEntry
     internal string? ContentPath { get; init; }
 
     [JsonIgnore]
-    // The ordinal disambiguates duplicate paths in non-conforming layers so content reads
-    // reopen the exact entry that produced the index metadata.
     internal int ContentEntryIndex { get; init; }
 
+    // A hard link to a symlink shares its inode, so extraction must recreate the
+    // symlink instead of dereferencing it into ordinary file content.
     [JsonIgnore]
     internal string? ContentLinkTarget { get; init; }
 

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -1,6 +1,5 @@
-﻿using ICSharpCode.SharpZipLib.Tar;
+﻿using System.Formats.Tar;
 using System.IO.Compression;
-using System.Text;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
@@ -147,21 +146,21 @@ internal static class ImageHelper
 
         using GZipStream gZipStream = new(layerStream, CompressionMode.Decompress);
 
-        // Can't use System.Formats.Tar.TarReader because it fails to read certain types of tarballs:
-        // https://github.com/dotnet/runtime/issues/74316#issuecomment-1312227247
-        using TarInputStream tarStream = new(gZipStream, Encoding.UTF8);
+        using TarReader tarReader = new(gZipStream, leaveOpen: true);
 
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            TarEntry? entry = tarStream.GetNextEntry();
+            TarEntry? entry = await tarReader.GetNextEntryAsync(
+                copyData: false,
+                cancellationToken);
 
             if (entry is null)
             {
                 break;
             }
 
-            if (entry.IsDirectory)
+            if (entry.EntryType == TarEntryType.Directory)
             {
                 string directoryPath = GetContainedPath(layerDir, entry.Name);
                 if (!Directory.Exists(directoryPath))
@@ -193,7 +192,7 @@ internal static class ImageHelper
 
             entryName = Path.Combine(entryDirName, entryFileName);
             await ExtractTarEntry(
-                layerDir, tarStream, entry, entryName, hardLinks, cancellationToken);
+                layerDir, entry, entryName, hardLinks, cancellationToken);
         }
 
         while (hardLinks.Count > 0)
@@ -332,7 +331,6 @@ internal static class ImageHelper
 
     private static async Task ExtractTarEntry(
         string workingDir,
-        TarInputStream tarStream,
         TarEntry entry,
         string entryName,
         List<(string Path, string Target)> hardLinks,
@@ -345,25 +343,28 @@ internal static class ImageHelper
             Directory.CreateDirectory(directoryPath);
         }
 
-        if (entry.TarHeader.TypeFlag == TarHeader.LF_LINK && !string.IsNullOrEmpty(entry.TarHeader.LinkName))
+        if (entry.EntryType == TarEntryType.HardLink && !string.IsNullOrEmpty(entry.LinkName))
         {
-            hardLinks.Add((filePath, entry.TarHeader.LinkName));
+            hardLinks.Add((filePath, entry.LinkName));
         }
-        else if (entry.TarHeader.TypeFlag == TarHeader.LF_SYMLINK && !string.IsNullOrEmpty(entry.TarHeader.LinkName))
+        else if (entry.EntryType == TarEntryType.SymbolicLink && !string.IsNullOrEmpty(entry.LinkName))
         {
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
             }
 
-            string targetPath = GetLinkTargetPath(workingDir, filePath, entry.TarHeader.LinkName);
+            string targetPath = GetLinkTargetPath(workingDir, filePath, entry.LinkName);
             string relativeTarget = Path.GetRelativePath(directoryPath!, targetPath);
             FileHelper.CreateSymbolicLink(filePath, relativeTarget);
         }
         else
         {
             using FileStream outputStream = File.Create(filePath);
-            await tarStream.CopyEntryContentsAsync(outputStream, cancellationToken);
+            if (entry.DataStream is not null)
+            {
+                await entry.DataStream.CopyToAsync(outputStream, cancellationToken);
+            }
         }
     }
 

--- a/src/Valleysoft.Dredge/ImageLayerScanner.cs
+++ b/src/Valleysoft.Dredge/ImageLayerScanner.cs
@@ -1,0 +1,150 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+
+namespace Valleysoft.Dredge;
+
+internal static class ImageLayerScanner
+{
+    private const string WhiteoutPrefix = ".wh.";
+    private const string OpaqueWhiteout = ".wh..wh..opq";
+
+    public static async Task<LayerChanges> ScanAsync(
+        Stream blob,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        List<ScannedEntry> entries = [];
+        List<string> whiteouts = [];
+        List<string> opaqueDirectories = [];
+
+        using GZipStream gzip = new(blob, CompressionMode.Decompress, leaveOpen: true);
+        using TarReader tar = new(gzip, leaveOpen: true);
+        int entryIndex = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TarEntry? tarEntry = await ImageTarReader.GetNextEntryAsync(
+                tar,
+                layer,
+                cancellationToken);
+            if (tarEntry is null)
+            {
+                break;
+            }
+            int currentEntryIndex = entryIndex++;
+            await ImageTarReader.DrainEntryAsync(tarEntry, layer, cancellationToken);
+
+            string path = ImagePath.NormalizeArchive(tarEntry.Name);
+            if (path.Length == 0)
+            {
+                continue;
+            }
+
+            string fileName = ImagePath.GetFileName(path);
+            string parent = ImagePath.GetDirectoryName(path);
+            if (string.Equals(fileName, OpaqueWhiteout, StringComparison.Ordinal))
+            {
+                if (parent.Length == 0)
+                {
+                    throw new InvalidDataException(
+                        "The opaque whiteout marker cannot exist at the image root.");
+                }
+                opaqueDirectories.Add(parent);
+                continue;
+            }
+
+            if (fileName.StartsWith(WhiteoutPrefix, StringComparison.Ordinal))
+            {
+                string targetName = fileName[WhiteoutPrefix.Length..];
+                ImagePath.ValidateSegment(targetName, "whiteout target");
+                whiteouts.Add(
+                    parent.Length == 0 ? targetName : $"{parent}/{targetName}");
+                continue;
+            }
+
+            ImageFileType type = GetFileType(tarEntry);
+            string? linkTarget = type is ImageFileType.SymbolicLink or ImageFileType.HardLink
+                ? tarEntry.LinkName
+                : null;
+            if (linkTarget is not null && ImagePath.ContainsControlCharacter(linkTarget))
+            {
+                throw new InvalidDataException(
+                    $"Link '/{path}' has an invalid target.");
+            }
+            if (type == ImageFileType.SymbolicLink)
+            {
+                string basePath = ImagePath.IsAbsolute(linkTarget!)
+                    ? string.Empty
+                    : parent;
+                _ = ImagePath.ResolveLinkTarget(
+                    basePath,
+                    linkTarget!,
+                    string.Empty,
+                    path);
+            }
+
+            entries.Add(new ScannedEntry(
+                path,
+                type,
+                (int)tarEntry.Mode,
+                tarEntry.Uid,
+                tarEntry.Gid,
+                type == ImageFileType.File ? tarEntry.Length : 0,
+                tarEntry.ModificationTime.UtcDateTime,
+                linkTarget,
+                currentEntryIndex,
+                layer));
+        }
+        return new(entries, whiteouts, opaqueDirectories);
+    }
+
+    private static ImageFileType GetFileType(TarEntry entry) =>
+        entry.EntryType switch
+        {
+            TarEntryType.RegularFile or
+                TarEntryType.V7RegularFile or
+                TarEntryType.ContiguousFile => ImageFileType.File,
+            TarEntryType.SymbolicLink => ImageFileType.SymbolicLink,
+            TarEntryType.HardLink => ImageFileType.HardLink,
+            TarEntryType.Directory => ImageFileType.Directory,
+            _ => ImageFileType.Other
+        };
+}
+
+internal sealed record LayerChanges(
+    IReadOnlyList<ScannedEntry> Entries,
+    IReadOnlyList<string> Whiteouts,
+    IReadOnlyList<string> OpaqueDirectories);
+
+internal sealed record ScannedEntry(
+    string Path,
+    ImageFileType Type,
+    int Mode,
+    int UserId,
+    int GroupId,
+    long Size,
+    DateTime ModifiedTime,
+    string? LinkTarget,
+    int EntryIndex,
+    ImageLayerReference Layer)
+{
+    public ImageFileSystemEntry ToEntry(
+        ImageLayerReference introduced,
+        ImageLayerReference? modified) =>
+        new()
+        {
+            Path = Path,
+            Type = Type,
+            Mode = Mode,
+            UserId = UserId,
+            GroupId = GroupId,
+            Size = Size,
+            ModifiedTime = ModifiedTime,
+            LinkTarget = LinkTarget,
+            IntroducedLayer = introduced,
+            ModifiedLayer = modified,
+            ContentLayerIndex = Layer.Index,
+            ContentPath = Type == ImageFileType.File ? Path : null,
+            ContentEntryIndex = EntryIndex
+        };
+}

--- a/src/Valleysoft.Dredge/ImagePath.cs
+++ b/src/Valleysoft.Dredge/ImagePath.cs
@@ -1,0 +1,113 @@
+namespace Valleysoft.Dredge;
+
+internal static class ImagePath
+{
+    public static string NormalizeArchive(string value)
+    {
+        if (string.IsNullOrEmpty(value) || ContainsControlCharacter(value))
+        {
+            throw new InvalidDataException($"Invalid archive entry path '{value}'.");
+        }
+        if (IsAbsolute(value) || value.Contains('\\'))
+        {
+            throw new InvalidDataException(
+                $"Archive entry path '{value}' must be a relative Linux path.");
+        }
+        return Normalize(value, allowParentSegments: false, "archive entry");
+    }
+
+    public static string NormalizeRequested(string? value)
+    {
+        value = string.IsNullOrEmpty(value) ? string.Empty : value;
+        if (value.Contains('\\') || ContainsControlCharacter(value))
+        {
+            throw new InvalidDataException($"Invalid image path '{value}'.");
+        }
+        return Normalize(value.TrimStart('/'), allowParentSegments: false, "image");
+    }
+
+    public static string ResolveLinkTarget(
+        string basePath,
+        string target,
+        string remainder,
+        string linkPath)
+    {
+        if (target.Contains('\\') || ContainsControlCharacter(target))
+        {
+            throw new InvalidDataException(
+                $"Link '/{linkPath}' has invalid target '{target}'.");
+        }
+
+        string combined = IsAbsolute(target)
+            ? target.TrimStart('/')
+            : Join(basePath, target);
+        combined = Join(combined, remainder);
+        return Normalize(combined, allowParentSegments: true, $"link target for '/{linkPath}'");
+    }
+
+    public static bool IsAbsolute(string path) => path.StartsWith('/');
+
+    public static string GetDirectoryName(string path)
+    {
+        int separator = path.LastIndexOf('/');
+        return separator < 0 ? string.Empty : path[..separator];
+    }
+
+    public static string GetFileName(string path)
+    {
+        int separator = path.LastIndexOf('/');
+        return separator < 0 ? path : path[(separator + 1)..];
+    }
+
+    public static void ValidateSegment(string value, string description)
+    {
+        if (string.IsNullOrEmpty(value) ||
+            value is "." or ".." ||
+            value.Contains('/') ||
+            value.Contains('\\') ||
+            ContainsControlCharacter(value))
+        {
+            throw new InvalidDataException($"Invalid {description} '{value}'.");
+        }
+    }
+
+    private static string Normalize(
+        string value,
+        bool allowParentSegments,
+        string description)
+    {
+        List<string> segments = [];
+        foreach (string segment in value.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+            if (segment == "..")
+            {
+                if (!allowParentSegments)
+                {
+                    throw new InvalidDataException(
+                        $"The {description} path '{value}' escapes the image root.");
+                }
+                if (segments.Count > 0)
+                {
+                    segments.RemoveAt(segments.Count - 1);
+                }
+                // Linux clamps excess ".." segments at the filesystem root.
+                continue;
+            }
+            ValidateSegment(segment, $"{description} path segment");
+            segments.Add(segment);
+        }
+        return string.Join('/', segments);
+    }
+
+    private static string Join(string first, string second) =>
+        first.Length == 0 ? second :
+        second.Length == 0 ? first :
+        $"{first}/{second}";
+
+    internal static bool ContainsControlCharacter(string value) =>
+        value.Any(char.IsControl);
+}

--- a/src/Valleysoft.Dredge/ImageTarReader.cs
+++ b/src/Valleysoft.Dredge/ImageTarReader.cs
@@ -1,0 +1,74 @@
+using System.Formats.Tar;
+
+namespace Valleysoft.Dredge;
+
+internal static class ImageTarReader
+{
+    public static async ValueTask<TarEntry?> GetNextEntryAsync(
+        TarReader reader,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await reader.GetNextEntryAsync(
+                copyData: false,
+                cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    public static async Task DrainEntryAsync(
+        TarEntry entry,
+        ImageLayerReference layer,
+        CancellationToken cancellationToken)
+    {
+        if (entry.DataStream is null)
+        {
+            return;
+        }
+
+        // On .NET 9, GetNextEntryAsync(copyData: false) does not reliably advance past
+        // skipped data, so every unconsumed entry must be drained before reading the next.
+        try
+        {
+            await entry.DataStream.CopyToAsync(Stream.Null, cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    public static async Task CopyEntryAsync(
+        TarEntry entry,
+        Stream destination,
+        ImageLayerReference layer,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        Stream data = entry.DataStream ??
+            throw new InvalidDataException($"File '/{path}' has no content stream.");
+        try
+        {
+            await data.CopyToAsync(destination, cancellationToken);
+        }
+        catch (Exception exception) when (
+            exception is InvalidDataException or NotSupportedException)
+        {
+            throw CreateInvalidLayerException(layer, exception);
+        }
+    }
+
+    private static InvalidDataException CreateInvalidLayerException(
+        ImageLayerReference layer,
+        Exception innerException) =>
+        new(
+            $"Layer {layer.Index} ('{layer.Digest}') is not a supported gzip-compressed Linux tar layer.",
+            innerException);
+}

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -43,7 +43,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
Container images can currently be inspected at the manifest and layer level, but users cannot browse or retrieve files from the effective filesystem. This adds targeted Linux image filesystem access without materializing a fully squashed image.

- Add `image ls` with direct/recursive listing, text and JSON output, deleted-entry visibility, long metadata, and layer provenance.
- Add binary-safe `image cat` and selective `image extract`, including Linux link semantics, OCI whiteouts, metadata preservation, path safety, and transactional rollback.
- Build an effective filesystem index from gzip-compressed tar layers using `System.Formats.Tar`, replacing SharpZipLib and covering both .NET 9 and .NET 10.
- Document the commands with output captured from pinned Alpine and .NET runtime image tags.

Windows image layers remain unsupported because their `Files/` layout, case-insensitive namespace, reparse points, and `MSWINDOWS.*` metadata require a separate platform-specific model. Layer streams are currently rescanned as needed; persistent shared indexing and content caching are intentionally deferred.

Fixes #299

Cache follow-up: #320

Ranged download dependency: mthalman/DockerRegistryClient#149