### PR TITLE
Use CLI-style output format values

### DIFF
--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -221,7 +221,7 @@ dredge image compare metadata <base> <target> [--output <format>] [--no-color] [
 
 | Option | Description |
 |--------|-------------|
-| `--output` | Output format: `SideBySide` (default), `Inline`, or `Json` |
+| `--output` | Output format: `side-by-side` (default), `inline`, or `json` |
 | `--no-color` | Disable color output and use text-based diff indicators instead |
 
 The comparison includes:
@@ -266,7 +266,7 @@ dredge image compare layers <base> <target> [--output <format>] [--history] [--c
 
 | Option | Description |
 |--------|-------------|
-| `--output` | Output format: `SideBySide` (default), `Inline`, or `Json` |
+| `--output` | Output format: `side-by-side` (default), `inline`, or `json` |
 | `--history` | Include the layer history (Dockerfile instructions) |
 | `--compressed-size` | Show compressed layer sizes |
 | `--no-color` | Disable color output and use text-based diff indicators instead |
@@ -339,7 +339,7 @@ dredge image compare files <base> <target> [--base-layer-index <n>] [--target-la
 |--------|-------------|
 | `--base-layer-index` | Apply base-image layers from index `0` through this zero-based index |
 | `--target-layer-index` | Apply target-image layers from index `0` through this zero-based index |
-| `--output` | Output type. The supported and default value is `ExternalTool` |
+| `--output` | Output type. The supported and default value is `external-tool` |
 
 Example — compare two images:
 

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -100,7 +100,7 @@ public class CommandStructureTests
             option => option.Name == "--output");
 
         Assert.Equal("text|json", outputOption.HelpName);
-        Assert.Empty(command.Parse(["image", "--output", "Json"]).Errors);
+        Assert.Empty(command.Parse(["image", "--output", "JSON"]).Errors);
     }
 
     [Fact]
@@ -139,7 +139,9 @@ public class CommandStructureTests
             "--base-layer-index",
             "1",
             "--target-layer-index",
-            "2");
+            "2",
+            "--output",
+            "EXTERNAL-TOOL");
 
         Assert.Equal("base", options.BaseImage);
         Assert.Equal("target", options.TargetImage);
@@ -157,6 +159,86 @@ public class CommandStructureTests
         Assert.False(options.IsColorDisabled);
         Assert.False(options.IncludeHistory);
         Assert.False(options.IncludeCompressedSize);
+    }
+
+    [Fact]
+    public void CompareOptions_BindCliStyleOutputValuesCaseInsensitively()
+    {
+        CompareLayersOptions layers = Bind(
+            new CompareLayersOptions(),
+            "base",
+            "target",
+            "--output",
+            "SIDE-BY-SIDE");
+        CompareMetadataOptions metadata = Bind(
+            new CompareMetadataOptions(),
+            "base",
+            "target",
+            "--output",
+            "INLINE");
+
+        Assert.Equal(CompareOutput.SideBySide, layers.OutputFormat);
+        Assert.Equal(CompareOutput.Inline, metadata.OutputFormat);
+    }
+
+    [Fact]
+    public void OutputOptions_AdvertiseCliStyleValues()
+    {
+        (OptionsBase Options, string ExpectedHelpName)[] cases =
+        [
+            (new CompareFilesOptions(), "external-tool"),
+            (new CompareLayersOptions(), "side-by-side|inline|json"),
+            (new CompareMetadataOptions(), "side-by-side|inline|json"),
+            (new LsOptions(), "text|json"),
+            (new CheckOptions(), "summary|json"),
+            (new ReferrerInspectOptions(), "summary|json")
+        ];
+
+        foreach ((OptionsBase options, string expectedHelpName) in cases)
+        {
+            Command command = new("test");
+            options.SetCommandOptions(command);
+            Option outputOption = Assert.Single(
+                command.Options,
+                option => option.Name == "--output");
+
+            Assert.Equal(expectedHelpName, outputOption.HelpName);
+        }
+    }
+
+    [Theory]
+    [InlineData("SideBySide", "side-by-side", "inline", "json")]
+    [InlineData("sidebyside", "side-by-side", "inline", "json")]
+    public void CompareLayersOptions_RejectLegacyOutputValues(
+        string value,
+        params string[] expectedValues)
+    {
+        Command command = new("test");
+        new CompareLayersOptions().SetCommandOptions(command);
+
+        ParseResult result = command.Parse(["base", "target", "--output", value]);
+
+        Assert.Single(result.Errors);
+        Assert.Equal(
+            $"Invalid output value '{value}'. Expected one of: " +
+            $"{string.Join(", ", expectedValues.Select(expected => $"'{expected}'"))}.",
+            result.Errors[0].Message);
+    }
+
+    [Theory]
+    [InlineData("ExternalTool")]
+    [InlineData("externaltool")]
+    public void CompareFilesOptions_RejectLegacyOutputValues(string value)
+    {
+        Command command = new("test");
+        new CompareFilesOptions().SetCommandOptions(command);
+
+        ParseResult result = command.Parse(["base", "target", "--output", value]);
+
+        Assert.Single(result.Errors);
+        Assert.Equal(
+            $"Invalid output value '{value}'. Expected one of: 'external-tool'.",
+            result.Errors[0].Message);
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge/Commands/CliOutputOption.cs
+++ b/src/Valleysoft.Dredge/Commands/CliOutputOption.cs
@@ -1,0 +1,50 @@
+using System.CommandLine;
+using System.CommandLine.Completions;
+
+namespace Valleysoft.Dredge.Commands;
+
+internal sealed class CliOutputOption<T>
+    where T : struct, Enum
+{
+    private readonly Dictionary<string, T> values;
+
+    public Option<string> Option { get; }
+
+    public CliOutputOption(
+        string description,
+        T defaultValue,
+        params (string Name, T Value)[] values)
+    {
+        this.values = values.ToDictionary(
+            item => item.Name,
+            item => item.Value,
+            StringComparer.OrdinalIgnoreCase);
+
+        string defaultName = values.Single(
+            item => EqualityComparer<T>.Default.Equals(item.Value, defaultValue)).Name;
+        string expectedValues = string.Join(", ", values.Select(item => $"'{item.Name}'"));
+
+        Option = new Option<string>("--output")
+        {
+            Description = description,
+            HelpName = string.Join('|', values.Select(item => item.Name)),
+            DefaultValueFactory = _ => defaultName
+        };
+        Option.CompletionSources.Add(
+            _ => values.Select(item => new CompletionItem(item.Name)).ToArray());
+        Option.Validators.Add(result =>
+        {
+            string? value = result.GetValueOrDefault<string>();
+            if (value is null || !this.values.ContainsKey(value))
+            {
+                result.AddError(
+                    $"Invalid output value '{value}'. Expected one of: {expectedValues}.");
+            }
+        });
+    }
+
+    public T GetValue(string? value) =>
+        value is not null && values.TryGetValue(value, out T mappedValue)
+            ? mappedValue
+            : throw new NotSupportedException($"Unsupported output value '{value}'.");
+}

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
@@ -8,7 +8,7 @@ public class CompareFilesOptions : CompareOptionsBase
 
     private readonly Option<int?> baseLayerIndex;
     private readonly Option<int?> targetLayerIndex;
-    private readonly Option<CompareFilesOutput> outputOption;
+    private readonly CliOutputOption<CompareFilesOutput> outputOption;
 
     public int? BaseLayerIndex { get; set; }
     public int? TargetLayerIndex { get; set; }
@@ -18,7 +18,11 @@ public class CompareFilesOptions : CompareOptionsBase
     {
         baseLayerIndex = Add(new Option<int?>($"--{BaseArg}{LayerIndexSuffix}") { Description = "Non-empty layer index of the base container image to compare with" });
         targetLayerIndex = Add(new Option<int?>($"--{TargetArg}{LayerIndexSuffix}") { Description = "Non-empty layer index of the target container image to compare against" });
-        outputOption = Add(new Option<CompareFilesOutput>("--output") { Description = "Output type", DefaultValueFactory = _ => CompareFilesOutput.ExternalTool });
+        outputOption = new CliOutputOption<CompareFilesOutput>(
+            "Output type",
+            CompareFilesOutput.ExternalTool,
+            ("external-tool", CompareFilesOutput.ExternalTool));
+        Add(outputOption.Option);
     }
 
     protected override void GetValues()
@@ -26,6 +30,6 @@ public class CompareFilesOptions : CompareOptionsBase
         base.GetValues();
         BaseLayerIndex = GetValue(baseLayerIndex);
         TargetLayerIndex = GetValue(targetLayerIndex);
-        OutputType = GetValue(outputOption);
+        OutputType = outputOption.GetValue(GetValue(outputOption.Option));
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class CompareLayersOptions : CompareOptionsBase
 {
-    private readonly Option<CompareOutput> outputOption;
+    private readonly CliOutputOption<CompareOutput> outputOption;
     private readonly Option<bool> noColorOption;
     private readonly Option<bool> historyOption;
     private readonly Option<bool> compressedSizeOption;
@@ -16,7 +16,13 @@ public class CompareLayersOptions : CompareOptionsBase
 
     public CompareLayersOptions()
     {
-        outputOption = Add(new Option<CompareOutput>("--output") { Description = "Output format", DefaultValueFactory = _ => CompareOutput.SideBySide });
+        outputOption = new CliOutputOption<CompareOutput>(
+            "Output format",
+            CompareOutput.SideBySide,
+            ("side-by-side", CompareOutput.SideBySide),
+            ("inline", CompareOutput.Inline),
+            ("json", CompareOutput.Json));
+        Add(outputOption.Option);
         noColorOption = Add(new Option<bool>("--no-color") { Description = "Disables dependency on color in comparison results" });
         historyOption = Add(new Option<bool>("--history") { Description = "Include layer history as part of the comparison" });
         compressedSizeOption = Add(new Option<bool>("--compressed-size") { Description = "Show the compressed size of the layer" });
@@ -25,7 +31,7 @@ public class CompareLayersOptions : CompareOptionsBase
     protected override void GetValues()
     {
         base.GetValues();
-        OutputFormat = GetValue(outputOption);
+        OutputFormat = outputOption.GetValue(GetValue(outputOption.Option));
         IsColorDisabled = GetValue(noColorOption);
         IncludeHistory = GetValue(historyOption);
         IncludeCompressedSize = GetValue(compressedSizeOption);

--- a/src/Valleysoft.Dredge/Commands/Image/CompareMetadataOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareMetadataOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class CompareMetadataOptions : CompareOptionsBase
 {
-    private readonly Option<CompareOutput> outputOption;
+    private readonly CliOutputOption<CompareOutput> outputOption;
     private readonly Option<bool> noColorOption;
 
     public CompareOutput OutputFormat { get; set; }
@@ -12,11 +12,13 @@ public class CompareMetadataOptions : CompareOptionsBase
 
     public CompareMetadataOptions()
     {
-        outputOption = Add(new Option<CompareOutput>("--output")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => CompareOutput.SideBySide
-        });
+        outputOption = new CliOutputOption<CompareOutput>(
+            "Output format",
+            CompareOutput.SideBySide,
+            ("side-by-side", CompareOutput.SideBySide),
+            ("inline", CompareOutput.Inline),
+            ("json", CompareOutput.Json));
+        Add(outputOption.Option);
         noColorOption = Add(new Option<bool>("--no-color")
         {
             Description = "Disables dependency on color in comparison results"
@@ -26,7 +28,7 @@ public class CompareMetadataOptions : CompareOptionsBase
     protected override void GetValues()
     {
         base.GetValues();
-        OutputFormat = GetValue(outputOption);
+        OutputFormat = outputOption.GetValue(GetValue(outputOption.Option));
         IsColorDisabled = GetValue(noColorOption);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
@@ -1,20 +1,16 @@
 using System.CommandLine;
-using System.CommandLine.Completions;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
 public class LsOptions : PlatformOptionsBase
 {
-    private const string TextOutput = "text";
-    private const string JsonOutput = "json";
-
     private readonly Argument<string> imageArgument;
     private readonly Argument<string?> pathArgument;
     private readonly Option<bool> recursiveOption;
     private readonly Option<bool> showDeletedOption;
     private readonly Option<bool> longOption;
     private readonly Option<bool> provenanceOption;
-    private readonly Option<string> outputOption;
+    private readonly CliOutputOption<LsOutput> outputOption;
 
     public string Image { get; set; } = string.Empty;
     public string? Path { get; set; }
@@ -52,24 +48,12 @@ public class LsOptions : PlatformOptionsBase
         {
             Description = "Show layer provenance"
         });
-        outputOption = Add(new Option<string>("--output")
-        {
-            Description = "Output format",
-            HelpName = $"{TextOutput}|{JsonOutput}",
-            DefaultValueFactory = _ => TextOutput
-        });
-        outputOption.CompletionSources.Add(
-            _ => [new CompletionItem(TextOutput), new CompletionItem(JsonOutput)]);
-        outputOption.Validators.Add(result =>
-        {
-            string? value = result.GetValueOrDefault<string>();
-            if (!string.Equals(value, TextOutput, StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(value, JsonOutput, StringComparison.OrdinalIgnoreCase))
-            {
-                result.AddError(
-                    $"Invalid output format '{value}'. Expected '{TextOutput}' or '{JsonOutput}'.");
-            }
-        });
+        outputOption = new CliOutputOption<LsOutput>(
+            "Output format",
+            LsOutput.Text,
+            ("text", LsOutput.Text),
+            ("json", LsOutput.Json));
+        Add(outputOption.Option);
     }
 
     protected override void GetValues()
@@ -81,12 +65,6 @@ public class LsOptions : PlatformOptionsBase
         ShowDeleted = GetValue(showDeletedOption);
         Long = GetValue(longOption);
         ShowProvenance = GetValue(provenanceOption);
-        OutputFormat = GetValue(outputOption)?.ToLowerInvariant() switch
-        {
-            TextOutput => LsOutput.Text,
-            JsonOutput => LsOutput.Json,
-            var value => throw new NotSupportedException(
-                $"Unsupported output format '{value}'.")
-        };
+        OutputFormat = outputOption.GetValue(GetValue(outputOption.Option));
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
@@ -6,7 +6,7 @@ public class CheckOptions : OptionsBase
 {
     private readonly Argument<string> nameArgument;
     private readonly Option<string[]> artifactTypeOption;
-    private readonly Option<CheckOutput> outputOption;
+    private readonly CliOutputOption<CheckOutput> outputOption;
 
     public string Image { get; set; } = string.Empty;
     public string[] ArtifactTypes { get; set; } = [];
@@ -31,17 +31,18 @@ public class CheckOptions : OptionsBase
                 result.AddError("Artifact types cannot be empty or whitespace.");
             }
         });
-        outputOption = Add(new Option<CheckOutput>("--output")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => CheckOutput.Summary
-        });
+        outputOption = new CliOutputOption<CheckOutput>(
+            "Output format",
+            CheckOutput.Summary,
+            ("summary", CheckOutput.Summary),
+            ("json", CheckOutput.Json));
+        Add(outputOption.Option);
     }
 
     protected override void GetValues()
     {
         Image = GetValue(nameArgument);
         ArtifactTypes = GetValue(artifactTypeOption) ?? [];
-        OutputFormat = GetValue(outputOption);
+        OutputFormat = outputOption.GetValue(GetValue(outputOption.Option));
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
@@ -6,7 +6,7 @@ public class InspectOptions : OptionsBase
 {
     private readonly Argument<string> nameArgument;
     private readonly Argument<string> artifactDigestArgument;
-    private readonly Option<ArtifactInspectOutput> outputOption;
+    private readonly CliOutputOption<ArtifactInspectOutput> outputOption;
 
     public string Image { get; set; } = string.Empty;
     public string ArtifactDigest { get; set; } = string.Empty;
@@ -22,17 +22,18 @@ public class InspectOptions : OptionsBase
         {
             Description = "Digest of the artifact manifest"
         });
-        outputOption = Add(new Option<ArtifactInspectOutput>("--output")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => ArtifactInspectOutput.Summary
-        });
+        outputOption = new CliOutputOption<ArtifactInspectOutput>(
+            "Output format",
+            ArtifactInspectOutput.Summary,
+            ("summary", ArtifactInspectOutput.Summary),
+            ("json", ArtifactInspectOutput.Json));
+        Add(outputOption.Option);
     }
 
     protected override void GetValues()
     {
         Image = GetValue(nameArgument);
         ArtifactDigest = GetValue(artifactDigestArgument);
-        OutputFormat = GetValue(outputOption);
+        OutputFormat = outputOption.GetValue(GetValue(outputOption.Option));
     }
 }


### PR DESCRIPTION
Enum-backed `--output` options currently expose .NET member names such as `SideBySide` and `ExternalTool` in generated help. This makes the public CLI inconsistent with the lowercase, kebab-case values users expect.

This change introduces a shared mapped output option that:

- advertises canonical values such as `side-by-side` and `external-tool` in help and completions
- parses canonical values case-insensitively while preserving internal enum-based behavior and defaults
- rejects legacy non-kebab-case spellings with clear accepted-value diagnostics
- applies the same behavior across image comparison, image listing, and referrer commands

Command documentation and parser/help tests are updated to match the public spellings.

**Validation:** Release build succeeded and all 822 tests passed across .NET 9 and .NET 10.

Fixes: #312