### PR TITLE
Standardize CLI argument names and help descriptions

### DIFF
--- a/docs/commands/manifests.md
+++ b/docs/commands/manifests.md
@@ -11,7 +11,7 @@
 Returns the manifest of the specified image name.
 
 ```console
-dredge manifest get <name>
+dredge manifest get <image>
 ```
 
 Example:
@@ -58,7 +58,7 @@ dredge manifest get ubuntu:22.04
 Returns the digest of the specified image name.
 
 ```console
-dredge manifest digest <name>
+dredge manifest digest <image>
 ```
 
 Example:

--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -12,7 +12,7 @@
 Returns the referrers to the specified manifest. This uses the [OCI Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
 
 ```console
-dredge referrer list <name> [--artifact-type <type>]
+dredge referrer list <image> [--artifact-type <type>]
 ```
 
 | Option | Description |
@@ -54,7 +54,7 @@ for matching referrer descriptors; it does not inspect artifact payloads or
 verify signatures.
 
 ```console
-dredge referrer check <name> --artifact-type <type> [--artifact-type <type>]... [--output <format>]
+dredge referrer check <image> --artifact-type <type> [--artifact-type <type>]... [--output <format>]
 ```
 
 | Option | Description |
@@ -123,7 +123,7 @@ Displays metadata and payload information for an OCI artifact referenced by an
 image.
 
 ```console
-dredge referrer inspect <name> <artifact-digest> [--output <format>]
+dredge referrer inspect <image> <artifact-digest> [--output <format>]
 ```
 
 | Option | Description |
@@ -169,7 +169,7 @@ Payloads:
 Streams an artifact payload without modifying registry content.
 
 ```console
-dredge referrer get <name> <artifact-digest> [--payload <index-or-digest>] [--output <path>]
+dredge referrer get <image> <artifact-digest> [--payload <index-or-digest>] [--output <path>]
 ```
 
 | Option | Description |

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -20,7 +20,7 @@ dredge settings open
 Gets the value of a setting. Setting names use dot notation for hierarchical JSON paths.
 
 ```console
-dredge settings get <name>
+dredge settings get <setting>
 ```
 
 Example:
@@ -34,7 +34,7 @@ dredge settings get fileCompareTool.exePath
 Sets the value of a setting. Setting names use dot notation for hierarchical JSON paths.
 
 ```console
-dredge settings set <name> <value>
+dredge settings set <setting> <value>
 ```
 
 Example:

--- a/docs/commands/tags.md
+++ b/docs/commands/tags.md
@@ -9,7 +9,7 @@
 Returns the tags associated with the specified repository.
 
 ```console
-dredge tag list <repo>
+dredge tag list <repository>
 ```
 
 Example:

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -9,8 +9,17 @@ using Valleysoft.Dredge.Commands.Referrer;
 using Valleysoft.Dredge.Commands.Repo;
 using Valleysoft.Dredge.Commands.Settings;
 using Valleysoft.Dredge.Commands.Tag;
+using ImageInspectOptions = Valleysoft.Dredge.Commands.Image.InspectOptions;
+using ManifestDigestOptions = Valleysoft.Dredge.Commands.Manifest.DigestOptions;
+using ManifestGetOptions = Valleysoft.Dredge.Commands.Manifest.GetOptions;
+using ManifestResolveOptions = Valleysoft.Dredge.Commands.Manifest.SetOptions;
 using ReferrerGetOptions = Valleysoft.Dredge.Commands.Referrer.GetOptions;
 using ReferrerInspectOptions = Valleysoft.Dredge.Commands.Referrer.InspectOptions;
+using ReferrerListOptions = Valleysoft.Dredge.Commands.Referrer.ListOptions;
+using RepoListOptions = Valleysoft.Dredge.Commands.Repo.ListOptions;
+using SettingsGetOptions = Valleysoft.Dredge.Commands.Settings.GetOptions;
+using SettingsSetOptions = Valleysoft.Dredge.Commands.Settings.SetOptions;
+using TagListOptions = Valleysoft.Dredge.Commands.Tag.ListOptions;
 
 public class CommandStructureTests
 {
@@ -242,15 +251,86 @@ public class CommandStructureTests
     }
 
     [Fact]
-    public void ReferrerArtifactOptions_UseNameArgument()
+    public void PositionalArguments_UseConsistentNamesAndDescriptions()
     {
-        Command inspect = new("inspect");
-        new ReferrerInspectOptions().SetCommandOptions(inspect);
-        Command get = new("get");
-        new ReferrerGetOptions().SetCommandOptions(get);
+        const string ImageSyntax = "(<image>, <image>:<tag>, or <image>@<digest>)";
+        const string ImageDescription = "Container image reference " + ImageSyntax;
 
-        Assert.Equal(["name", "artifact-digest"], inspect.Arguments.Select(argument => argument.Name));
-        Assert.Equal(["name", "artifact-digest"], get.Arguments.Select(argument => argument.Name));
+        AssertArguments(new ImageInspectOptions(), ("image", ImageDescription));
+        AssertArguments(new OsOptions(), ("image", ImageDescription));
+        AssertArguments(
+            new LsOptions(),
+            ("image", ImageDescription),
+            ("path", "Image path to list"));
+        AssertArguments(
+            new CatOptions(),
+            ("image", ImageDescription),
+            ("path", "Image file path to write to standard output"));
+        AssertArguments(
+            new ExtractOptions(),
+            ("image", ImageDescription),
+            ("path", "Image file or directory path to extract"),
+            ("output-path", "New destination path"));
+        AssertArguments(
+            new CompareFilesOptions(),
+            ("base", "Base container image reference " + ImageSyntax),
+            ("target", "Target container image reference " + ImageSyntax));
+        AssertArguments(
+            new SaveLayersOptions(),
+            ("image", ImageDescription),
+            ("output-path", "Path to the output location"));
+        AssertArguments(new DockerfileOptions(), ("image", ImageDescription));
+
+        AssertArguments(new ManifestGetOptions(), ("image", ImageDescription));
+        AssertArguments(new ManifestDigestOptions(), ("image", ImageDescription));
+        AssertArguments(new ManifestResolveOptions(), ("image", ImageDescription));
+
+        AssertArguments(new ReferrerListOptions(), ("image", ImageDescription));
+        AssertArguments(
+            new CheckOptions(),
+            ("image", ImageDescription));
+        AssertArguments(
+            new ReferrerInspectOptions(),
+            ("image", ImageDescription),
+            ("artifact-digest", "Digest of the artifact manifest"));
+        AssertArguments(
+            new ReferrerGetOptions(),
+            ("image", ImageDescription),
+            ("artifact-digest", "Digest of the artifact manifest"));
+
+        AssertArguments(new RepoListOptions(), ("registry", "Container registry host"));
+        AssertArguments(new TagListOptions(), ("repository", "Container repository name"));
+        AssertArguments(new SettingsGetOptions(), ("setting", "Setting name to get"));
+        AssertArguments(
+            new SettingsSetOptions(),
+            ("setting", "Setting name to set"),
+            ("value", "Value to assign to the setting"));
+    }
+
+    [Fact]
+    public void CommandDescriptions_UseCorrectGrammar()
+    {
+        Mock<IDockerRegistryClientFactory> factory = new();
+
+        Assert.Equal(
+            "Lists the tags contained in the container repository",
+            new Valleysoft.Dredge.Commands.Tag.ListCommand(factory.Object).Description);
+        Assert.Equal(
+            "Returns low-level information on a container image",
+            new Valleysoft.Dredge.Commands.Image.InspectCommand(factory.Object).Description);
+    }
+
+    private static void AssertArguments(
+        OptionsBase options,
+        params (string Name, string Description)[] expected)
+    {
+        Command command = new("test");
+        options.SetCommandOptions(command);
+
+        Assert.Equal(
+            expected,
+            command.Arguments.Select(
+                argument => (argument.Name, argument.Description!)).ToArray());
     }
 
     private static TOptions Bind<TOptions>(TOptions options, params string[] args)

--- a/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
@@ -14,7 +14,7 @@ public class CatOptions : PlatformOptionsBase
     {
         imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         pathArgument = Add(new Argument<string>("path")
         {

--- a/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
@@ -15,8 +15,8 @@ public class CompareOptionsBase : PlatformOptionsBase
 
     public CompareOptionsBase()
     {
-        baseImageArg = Add(new Argument<string>(BaseArg) { Description = "Name of the base container image (<image>, <image>:<tag>, or <image>@<digest>)" });
-        targetImageArg = Add(new Argument<string>(TargetArg) { Description = "Name of the target container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        baseImageArg = Add(new Argument<string>(BaseArg) { Description = "Base container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        targetImageArg = Add(new Argument<string>(TargetArg) { Description = "Target container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
@@ -14,7 +14,7 @@ public class DockerfileOptions : PlatformOptionsBase
 
     public DockerfileOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
         noColorOption = Add(new Option<bool>("--no-color") { Description = "Disables use of syntax color in the output" });
         noFormatOption = Add(new Option<bool>("--no-format") { Description = "Disables use of heuristics to format the layer history for better readability" });
     }

--- a/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
@@ -16,7 +16,7 @@ public class ExtractOptions : PlatformOptionsBase
     {
         imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         pathArgument = Add(new Argument<string>("path")
         {

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -6,7 +6,7 @@ namespace Valleysoft.Dredge.Commands.Image;
 public class InspectCommand : RegistryCommandBase<InspectOptions>
 {
     public InspectCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
-        : base("inspect", "Return low-level information on a container image", dockerRegistryClientFactory, output)
+        : base("inspect", "Returns low-level information on a container image", dockerRegistryClientFactory, output)
     {
     }
 

--- a/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
@@ -10,7 +10,7 @@ public class InspectOptions : PlatformOptionsBase
 
     public InspectOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
@@ -28,7 +28,7 @@ public class LsOptions : PlatformOptionsBase
     {
         imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         pathArgument = Add(new Argument<string?>("path")
         {

--- a/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
@@ -10,7 +10,7 @@ public class OsOptions : PlatformOptionsBase
 
     public OsOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
@@ -18,7 +18,7 @@ public class SaveLayersOptions : PlatformOptionsBase
 
     public SaveLayersOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
         outputPathArg = Add(new Argument<string>("output-path") { Description = "Path to the output location" });
         noSquashOption = Add(new Option<bool>("--no-squash") { Description = "Do not squash the image layers" });
         layerIndexOption = Add(new Option<int?>(LayerIndexOptionName) { Description = "Index of the image layer to target" });

--- a/src/Valleysoft.Dredge/Commands/Manifest/DigestOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/DigestOptions.cs
@@ -10,7 +10,7 @@ public class DigestOptions : OptionsBase
 
     public DigestOptions()
     {
-        imageArg = Add(new Argument<string>("name") { Description = "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetOptions.cs
@@ -10,7 +10,7 @@ public class GetOptions : OptionsBase
 
     public GetOptions()
     {
-        imageArg = Add(new Argument<string>("name") { Description = "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
@@ -10,7 +10,7 @@ public class SetOptions : PlatformOptionsBase
 
     public SetOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Name of the container image (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Referrer;
 
 public class CheckOptions : OptionsBase
 {
-    private readonly Argument<string> nameArgument;
+    private readonly Argument<string> imageArgument;
     private readonly Option<string[]> artifactTypeOption;
     private readonly Option<CheckOutput> outputOption;
 
@@ -14,9 +14,9 @@ public class CheckOptions : OptionsBase
 
     public CheckOptions()
     {
-        nameArgument = Add(new Argument<string>("name")
+        imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         artifactTypeOption = Add(new Option<string[]>("--artifact-type")
         {
@@ -40,7 +40,7 @@ public class CheckOptions : OptionsBase
 
     protected override void GetValues()
     {
-        Image = GetValue(nameArgument);
+        Image = GetValue(imageArgument);
         ArtifactTypes = GetValue(artifactTypeOption) ?? [];
         OutputFormat = GetValue(outputOption);
     }

--- a/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Referrer;
 
 public class GetOptions : OptionsBase
 {
-    private readonly Argument<string> nameArgument;
+    private readonly Argument<string> imageArgument;
     private readonly Argument<string> artifactDigestArgument;
     private readonly Option<string> payloadOption;
     private readonly Option<string> outputOption;
@@ -16,9 +16,9 @@ public class GetOptions : OptionsBase
 
     public GetOptions()
     {
-        nameArgument = Add(new Argument<string>("name")
+        imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         artifactDigestArgument = Add(new Argument<string>("artifact-digest")
         {
@@ -36,7 +36,7 @@ public class GetOptions : OptionsBase
 
     protected override void GetValues()
     {
-        Image = GetValue(nameArgument);
+        Image = GetValue(imageArgument);
         ArtifactDigest = GetValue(artifactDigestArgument);
         Payload = GetValue(payloadOption);
         OutputPath = GetValue(outputOption);

--- a/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Referrer;
 
 public class InspectOptions : OptionsBase
 {
-    private readonly Argument<string> nameArgument;
+    private readonly Argument<string> imageArgument;
     private readonly Argument<string> artifactDigestArgument;
     private readonly Option<ArtifactInspectOutput> outputOption;
 
@@ -14,9 +14,9 @@ public class InspectOptions : OptionsBase
 
     public InspectOptions()
     {
-        nameArgument = Add(new Argument<string>("name")
+        imageArgument = Add(new Argument<string>("image")
         {
-            Description = "Name of the subject manifest (<name>, <name>:<tag>, or <name>@<digest>)"
+            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
         });
         artifactDigestArgument = Add(new Argument<string>("artifact-digest")
         {
@@ -31,7 +31,7 @@ public class InspectOptions : OptionsBase
 
     protected override void GetValues()
     {
-        Image = GetValue(nameArgument);
+        Image = GetValue(imageArgument);
         ArtifactDigest = GetValue(artifactDigestArgument);
         OutputFormat = GetValue(outputOption);
     }

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
@@ -12,7 +12,7 @@ public class ListOptions : OptionsBase
 
     public ListOptions()
     {
-        imageArg = Add(new Argument<string>("name") { Description = "Name of the manifest (<name>, <name>:<tag>, or <name>@<digest>)" });
+        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
         artifactTypeArg = Add(new Option<string>("--artifact-type") { Description = "Artifact media type to filter by" });
     }
 

--- a/src/Valleysoft.Dredge/Commands/Repo/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListOptions.cs
@@ -10,7 +10,7 @@ public class ListOptions : OptionsBase
 
     public ListOptions()
     {
-        registryArg = Add(new Argument<string>("repo") { Description = "Name of the container registry" });
+        registryArg = Add(new Argument<string>("registry") { Description = "Container registry host" });
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Settings/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetOptions.cs
@@ -4,17 +4,17 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 public class GetOptions : OptionsBase
 {
-    private readonly Argument<string> nameArg;
+    private readonly Argument<string> settingArg;
 
     public string Name { get; set; } = string.Empty;
 
     public GetOptions()
     {
-        nameArg = Add(new Argument<string>("name") { Description = "Name of the setting to set" });
+        settingArg = Add(new Argument<string>("setting") { Description = "Setting name to get" });
     }
 
     protected override void GetValues()
     {
-        Name = GetValue(nameArg);
+        Name = GetValue(settingArg);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Settings/SetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SetOptions.cs
@@ -4,7 +4,7 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 public class SetOptions : OptionsBase
 {
-    private readonly Argument<string> nameArg;
+    private readonly Argument<string> settingArg;
     private readonly Argument<string> valueArg;
 
     public string Name { get; set; } = string.Empty;
@@ -12,13 +12,13 @@ public class SetOptions : OptionsBase
 
     public SetOptions()
     {
-        nameArg = Add(new Argument<string>("name") { Description = "Name of the setting to set" });
+        settingArg = Add(new Argument<string>("setting") { Description = "Setting name to set" });
         valueArg = Add(new Argument<string>("value") { Description = "Value to assign to the setting" });
     }
 
     protected override void GetValues()
     {
-        Name = GetValue(nameArg);
+        Name = GetValue(settingArg);
         Value = GetValue(valueArg);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -7,7 +7,7 @@ namespace Valleysoft.Dredge.Commands.Tag;
 public class ListCommand : RegistryCommandBase<ListOptions>
 {
     public ListCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
-        : base("list", "Lists the tag contained in the container repository", dockerRegistryClientFactory, output)
+        : base("list", "Lists the tags contained in the container repository", dockerRegistryClientFactory, output)
     {
     }
 

--- a/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
@@ -4,17 +4,17 @@ namespace Valleysoft.Dredge.Commands.Tag;
 
 public class ListOptions : OptionsBase
 {
-    private readonly Argument<string> repoArg;
+    private readonly Argument<string> repositoryArg;
 
     public string Repo { get; set; } = string.Empty;
 
     public ListOptions()
     {
-        repoArg = Add(new Argument<string>("repo") { Description = "Name of the container repository" });
+        repositoryArg = Add(new Argument<string>("repository") { Description = "Container repository name" });
     }
 
     protected override void GetValues()
     {
-        Repo = GetValue(repoArg);
+        Repo = GetValue(repositoryArg);
     }
 }


### PR DESCRIPTION
Generated help used inconsistent or misleading positional names for registries, repositories, image references, and settings, making equivalent command contracts harder to understand.

This change:
- standardizes positional names to `registry`, `repository`, `image`, and `setting` while retaining role-specific names such as `base` and `artifact-digest`
- aligns argument and command descriptions with their actual contracts
- updates command-reference usage examples
- adds deterministic coverage for positional names and descriptions across all command groups

Validation: Release build and all 812 tests pass for `net9.0` and `net10.0`.

Fixes: #315