### PR TITLE
Add bounded output controls for registry lists

### DIFF
--- a/docs/commands/referrers.md
+++ b/docs/commands/referrers.md
@@ -12,12 +12,19 @@
 Returns the referrers to the specified manifest. This uses the [OCI Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
 
 ```console
-dredge referrer list <image> [--artifact-type <type>]
+dredge referrer list <image> [--artifact-type <type>] [--limit <count>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--artifact-type` | Filter results by artifact media type |
+| `--limit` | Return at most this many referrers; must be greater than zero |
+
+Without `--limit`, Dredge retrieves all result pages. With `--limit <count>`,
+Dredge returns the first `<count>` referrers in the order provided by the
+registry. Dredge stops requesting pages once it has collected the requested
+number of referrers. The command does not return a continuation value for
+retrieving later referrers. Output remains an OCI image index JSON document.
 
 Example:
 

--- a/docs/commands/repositories.md
+++ b/docs/commands/repositories.md
@@ -11,8 +11,18 @@ Returns the list of repositories from the specified registry.
 > **Note:** Not supported for Docker Hub.
 
 ```console
-dredge repo list <registry>
+dredge repo list <registry> [--limit <count>]
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Return at most this many repositories; must be greater than zero |
+
+Without `--limit`, Dredge retrieves all result pages. With `--limit <count>`,
+Dredge returns the first `<count>` repositories provided by the registry, then
+sorts those repositories before writing JSON. Dredge stops requesting pages
+once it has collected the requested number of repositories. The command does
+not return a continuation value for retrieving later repositories.
 
 Example:
 

--- a/docs/commands/tags.md
+++ b/docs/commands/tags.md
@@ -9,8 +9,18 @@
 Returns the tags associated with the specified repository.
 
 ```console
-dredge tag list <repository>
+dredge tag list <repository> [--limit <count>]
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Return at most this many tags; must be greater than zero |
+
+Without `--limit`, Dredge retrieves all result pages. With `--limit <count>`,
+Dredge returns the first `<count>` tags provided by the registry, then sorts
+those tags before writing JSON. Dredge stops requesting pages once it has
+collected the requested number of tags. The command does not return a
+continuation value for retrieving later tags.
 
 Example:
 

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -315,6 +315,46 @@ public class CommandStructureTests
     }
 
     [Fact]
+    public void BoundedListOptions_BindLimit()
+    {
+        RepoListOptions repo = Bind(new RepoListOptions(), "registry.example", "--limit", "3");
+        TagListOptions tag = Bind(new TagListOptions(), "registry.example/repo", "--limit", "3");
+        ReferrerListOptions referrer = Bind(
+            new ReferrerListOptions(),
+            "registry.example/repo:tag",
+            "--limit",
+            "3");
+
+        Assert.Equal(3, repo.Limit);
+        Assert.Equal(3, tag.Limit);
+        Assert.Equal(3, referrer.Limit);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public void BoundedListOptions_RejectNonPositiveLimit(string limit)
+    {
+        OptionsBase[] options =
+        [
+            new RepoListOptions(),
+            new TagListOptions(),
+            new ReferrerListOptions()
+        ];
+
+        foreach (OptionsBase listOptions in options)
+        {
+            Command command = new("list");
+            listOptions.SetCommandOptions(command);
+
+            ParseResult parseResult = command.Parse(["registry.example/repo:tag", "--limit", limit]);
+
+            Assert.Single(parseResult.Errors);
+            Assert.Equal("Limit must be greater than zero.", parseResult.Errors[0].Message);
+        }
+    }
+
+    [Fact]
     public void ReferrerGetOptions_BindArgumentsAndOptions()
     {
         ReferrerGetOptions options = Bind(

--- a/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
@@ -155,6 +155,29 @@ public class RegistryCommandTests
     }
 
     [Fact]
+    public async Task RepoListCommand_LimitWithinFirstPage_TruncatesAndDoesNotRequestNextPage()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Catalog.GetAsync(2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<Catalog>(
+                new Catalog { RepositoryNames = ["zebra", "alpha", "middle"] },
+                "next"));
+        using StringWriter output = new();
+        TestRepoListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new RepoListOptions { Registry = Registry, Limit = 2 }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(["alpha", "zebra"], JArray.Parse(output.ToString()).Values<string>());
+        client.Verify(
+            o => o.Catalog.GetNextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task TagListCommand_CombinesPagesAndSortsTags()
     {
         Mock<IDockerRegistryClient> client = CreateClient();
@@ -177,6 +200,37 @@ public class RegistryCommandTests
         await command.RunAsync();
 
         Assert.Equal(["a", "m", "z"], JArray.Parse(output.ToString()).Values<string>());
+    }
+
+    [Fact]
+    public async Task TagListCommand_LimitWithinLaterPage_StopsAfterLimitAndSortsSubset()
+    {
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Tags.GetAsync("library/repo", 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<RepositoryTags>(
+                new RepositoryTags { RepositoryName = "library/repo", Tags = ["z", "a"] },
+                "next"));
+        client
+            .Setup(o => o.Tags.GetNextAsync("next", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<RepositoryTags>(
+                new RepositoryTags { RepositoryName = "library/repo", Tags = ["y", "m"] },
+                "unused"));
+        using StringWriter output = new();
+        TestTagListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new TagListOptions { Repo = "repo", Limit = 3 }
+        };
+
+        await command.RunAsync();
+
+        Assert.Equal(["a", "y", "z"], JArray.Parse(output.ToString()).Values<string>());
+        client.Verify(
+            o => o.Tags.GetNextAsync("next", It.IsAny<CancellationToken>()),
+            Times.Once);
+        client.Verify(
+            o => o.Tags.GetNextAsync("unused", It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -212,6 +266,43 @@ public class RegistryCommandTests
 
         Assert.Equal(["sha256:first", "sha256:second"], digests);
         client.Verify(o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReferrerListCommand_LimitAtPageBoundary_DoesNotRequestNextPage()
+    {
+        OciManifestReference first = new() { Digest = "sha256:first" };
+        OciManifestReference second = new() { Digest = "sha256:second" };
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page<OciImageIndex>(
+                new OciImageIndex
+                {
+                    Manifests = [first, second],
+                    Annotations = new Dictionary<string, string> { ["source"] = "first-page" }
+                },
+                "next"));
+        using StringWriter output = new();
+        TestReferrerListCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new ReferrerListOptions
+            {
+                Image = $"{Registry}/repo@sha256:image",
+                Limit = 2
+            }
+        };
+
+        await command.RunAsync();
+        JObject json = JObject.Parse(output.ToString());
+
+        Assert.Equal(
+            ["sha256:first", "sha256:second"],
+            json["manifests"]!.Select(manifest => (string)manifest["digest"]!));
+        Assert.Equal("first-page", (string?)json["annotations"]?["source"]);
+        client.Verify(
+            o => o.Referrers.GetNextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static Mock<IDockerRegistryClient> CreateClient() =>

--- a/src/Valleysoft.Dredge/Commands/BoundedListHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/BoundedListHelper.cs
@@ -1,0 +1,13 @@
+namespace Valleysoft.Dredge.Commands;
+
+internal static class BoundedListHelper
+{
+    public static void AddItems<T>(List<T> items, IEnumerable<T> pageItems, int? limit)
+    {
+        int remaining = limit is null ? int.MaxValue : Math.Max(0, limit.Value - items.Count);
+        items.AddRange(pageItems.Take(remaining));
+    }
+
+    public static bool IsLimitReached<T>(List<T> items, int? limit) =>
+        limit is not null && items.Count >= limit.Value;
+}

--- a/src/Valleysoft.Dredge/Commands/BoundedListOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/BoundedListOptionsBase.cs
@@ -1,0 +1,30 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands;
+
+public abstract class BoundedListOptionsBase : OptionsBase
+{
+    private readonly Option<int?> limitOption;
+
+    protected BoundedListOptionsBase()
+    {
+        limitOption = Add(new Option<int?>("--limit")
+        {
+            Description = "Maximum number of results to return"
+        });
+        limitOption.Validators.Add(result =>
+        {
+            if (result.GetValueOrDefault<int?>() is <= 0)
+            {
+                result.AddError("Limit must be greater than zero.");
+            }
+        });
+    }
+
+    public int? Limit { get; set; }
+
+    protected void GetBoundedListValues()
+    {
+        Limit = GetValue(limitOption);
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -17,7 +17,12 @@ public class ListCommand : RegistryCommandBase<ListOptions>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             OciImageIndex index =
-                await ReferrerHelper.GetReferrersAsync(client, imageName, Options.ArtifactType, ct);
+                await ReferrerHelper.GetReferrersAsync(
+                    client,
+                    imageName,
+                    Options.ArtifactType,
+                    ct,
+                    Options.Limit);
             string output = JsonConvert.SerializeObject(index, JsonHelper.Settings);
 
             Output.WriteLine(output);

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Referrer;
 
-public class ListOptions : OptionsBase
+public class ListOptions : BoundedListOptionsBase
 {
     private readonly Argument<string> imageArg;
     private readonly Option<string> artifactTypeArg;
@@ -20,5 +20,6 @@ public class ListOptions : OptionsBase
     {
         Image = GetValue(imageArg);
         ArtifactType = GetValue(artifactTypeArg);
+        GetBoundedListValues();
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Referrer/ReferrerHelper.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ReferrerHelper.cs
@@ -10,7 +10,8 @@ internal static class ReferrerHelper
         IDockerRegistryClient client,
         ImageName imageName,
         string? artifactType,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? limit = null)
     {
         string digest;
         if (!string.IsNullOrEmpty(imageName.Digest))
@@ -27,16 +28,16 @@ internal static class ReferrerHelper
         Page<OciImageIndex> indexPage =
             await client.Referrers.GetAsync(imageName.Repo, digest, artifactType, cancellationToken);
         OciImageIndex index = indexPage.Value;
-        while (indexPage.NextPageLink is not null)
+        List<ManifestReference> manifests = [];
+        BoundedListHelper.AddItems(manifests, index.Manifests, limit);
+        while (!BoundedListHelper.IsLimitReached(manifests, limit) &&
+            indexPage.NextPageLink is not null)
         {
             indexPage = await client.Referrers.GetNextAsync(indexPage.NextPageLink, cancellationToken);
-            index.Manifests =
-            [
-                .. index.Manifests,
-                .. indexPage.Value.Manifests
-            ];
+            BoundedListHelper.AddItems(manifests, indexPage.Value.Manifests, limit);
         }
 
+        index.Manifests = manifests.ToArray();
         return index;
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
@@ -19,12 +19,13 @@ public class ListCommand : RegistryCommandBase<ListOptions>
 
             List<string> repoNames = [];
 
-            Page<Catalog> catalogPage = await client.Catalog.GetAsync(null, ct);
-            repoNames.AddRange(catalogPage.Value.RepositoryNames);
-            while (catalogPage.NextPageLink is not null)
+            Page<Catalog> catalogPage = await client.Catalog.GetAsync(Options.Limit, ct);
+            BoundedListHelper.AddItems(repoNames, catalogPage.Value.RepositoryNames, Options.Limit);
+            while (!BoundedListHelper.IsLimitReached(repoNames, Options.Limit) &&
+                catalogPage.NextPageLink is not null)
             {
                 catalogPage = await client.Catalog.GetNextAsync(catalogPage.NextPageLink, ct);
-                repoNames.AddRange(catalogPage.Value.RepositoryNames);
+                BoundedListHelper.AddItems(repoNames, catalogPage.Value.RepositoryNames, Options.Limit);
             }
 
             repoNames.Sort();

--- a/src/Valleysoft.Dredge/Commands/Repo/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Repo;
 
-public class ListOptions : OptionsBase
+public class ListOptions : BoundedListOptionsBase
 {
     private readonly Argument<string> registryArg;
 
@@ -16,5 +16,6 @@ public class ListOptions : OptionsBase
     protected override void GetValues()
     {
         Registry = GetValue(registryArg);
+        GetBoundedListValues();
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -21,12 +21,13 @@ public class ListCommand : RegistryCommandBase<ListOptions>
             List<string> tags = [];
 
             Page<RepositoryTags> tagsPage =
-                await client.Tags.GetAsync(imageName.Repo, null, ct);
-            tags.AddRange(tagsPage.Value.Tags);
-            while (tagsPage.NextPageLink is not null)
+                await client.Tags.GetAsync(imageName.Repo, Options.Limit, ct);
+            BoundedListHelper.AddItems(tags, tagsPage.Value.Tags, Options.Limit);
+            while (!BoundedListHelper.IsLimitReached(tags, Options.Limit) &&
+                tagsPage.NextPageLink is not null)
             {
                 tagsPage = await client.Tags.GetNextAsync(tagsPage.NextPageLink, ct);
-                tags.AddRange(tagsPage.Value.Tags);
+                BoundedListHelper.AddItems(tags, tagsPage.Value.Tags, Options.Limit);
             }
 
             tags.Sort();

--- a/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Valleysoft.Dredge.Commands.Tag;
 
-public class ListOptions : OptionsBase
+public class ListOptions : BoundedListOptionsBase
 {
     private readonly Argument<string> repositoryArg;
 
@@ -16,5 +16,6 @@ public class ListOptions : OptionsBase
     protected override void GetValues()
     {
         Repo = GetValue(repositoryArg);
+        GetBoundedListValues();
     }
 }


### PR DESCRIPTION
Large registry listings currently follow every continuation page before producing output, which can consume excessive time and memory for registries with many repositories, tags, or referrers.

This adds an optional positive `--limit` to `repo list`, `tag list`, and `referrer list`. Repository and tag requests pass the limit through as the registry page size, while all three commands stop following continuation links once enough entries have been collected. Existing JSON shapes are preserved, repository and tag subsets retain their existing sorted output, and referrer descriptor order remains unchanged. `referrer check` continues to retrieve all pages.

`--limit` is intentionally a non-resumable safety cap: these commands do not return a continuation value for fetching a subsequent batch. Tests cover option validation and binding, within-page and page-boundary truncation, ordering, metadata retention, and suppression of unnecessary continuation requests.

Fixes: #311