### PR TITLE
Replace Newtonsoft.Json with System.Text.Json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Settings classes (`AppSettings`, `FileCompareToolSettings`, `PlatformSettings`) 
 
 - C# 12, nullable reference types enabled, implicit usings enabled.
 - `IDE0290` (primary constructor suggestion) is suppressed — the codebase uses traditional constructors.
-- JSON serialization uses Newtonsoft.Json (not System.Text.Json). Shared settings are in `JsonHelper.Settings`.
+- JSON serialization uses System.Text.Json. Shared settings are in `JsonHelper.Settings`.
 - Console output uses `Spectre.Console` for rich rendering (tables, colors, markup).
 - `ImageName.Parse()` is the standard way to parse image reference strings (`image`, `image:tag`, `registry/image@digest`).
 - Test assertions compare rendered output against expected text files, using `TestHelper.Normalize()` to strip `\r` and trailing whitespace.

--- a/src/Valleysoft.Dredge.Analyzers/SettingsPropertyGenerator.cs
+++ b/src/Valleysoft.Dredge.Analyzers/SettingsPropertyGenerator.cs
@@ -47,7 +47,6 @@ public class SettingsSourceGenerator : IIncrementalGenerator
             sourceBuilder.AppendLine("#nullable enable");
             sourceBuilder.AppendLine("using System;");
             sourceBuilder.AppendLine("using System.Collections.Generic;");
-            sourceBuilder.AppendLine("using Newtonsoft.Json;");
 
             sourceBuilder.AppendLine($"namespace {classSymbol.ContainingNamespace}");
             sourceBuilder.AppendLine("{");
@@ -96,7 +95,7 @@ public class SettingsSourceGenerator : IIncrementalGenerator
         {
             AttributeSyntax jsonPropertyAttribute = property.AttributeLists
                 .SelectMany(a => a.Attributes)
-                .FirstOrDefault(a => a.Name.ToString() == "JsonProperty");
+                .FirstOrDefault(a => a.Name.ToString() == "JsonPropertyName");
 
             if (jsonPropertyAttribute != null)
             {

--- a/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
+++ b/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
@@ -1,6 +1,6 @@
 namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json;
+using System.Text.Json;
 
 public class AppSettingsTests
 {
@@ -27,7 +27,7 @@ public class AppSettingsTests
             string persistedContent = await File.ReadAllTextAsync(
                 settingsPath, TestContext.Current.CancellationToken);
             AppSettings? persistedSettings =
-                JsonConvert.DeserializeObject<AppSettings>(persistedContent);
+                JsonSerializer.Deserialize<AppSettings>(persistedContent, JsonHelper.Settings);
             Assert.NotNull(persistedSettings);
             Assert.NotNull(persistedSettings.Platform);
         }
@@ -50,6 +50,94 @@ public class AppSettingsTests
 
         Assert.Equal("arm64", settings.GetProperty(new Queue<string>(["platform", "arch"])));
         Assert.Equal("compare.exe", settings.GetProperty(new Queue<string>(["fileCompareTool", "exePath"])));
+    }
+
+    [Fact]
+    public void Load_CoercesNumericSettingsToStrings()
+    {
+        string settingsPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(settingsPath, """{"platform":{"os":5}}""");
+
+            AppSettings settings = AppSettings.Load(settingsPath);
+
+            Assert.Equal("5", settings.Platform.Os);
+        }
+        finally
+        {
+            File.Delete(settingsPath);
+        }
+    }
+
+    [Fact]
+    public void SettingsSerializationPreservesArchPropertyName()
+    {
+        AppSettings settings = CreateSettings();
+        settings.Platform.Architecture = "arm64";
+
+        string json = JsonHelper.Serialize(settings);
+
+        Assert.Contains("\"arch\": \"arm64\"", json);
+        Assert.DoesNotContain("\"architecture\"", json);
+    }
+
+    [Fact]
+    public void Load_MergesDuplicateSettingsObjects()
+    {
+        string settingsPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(
+                settingsPath,
+                """{"platform":{"os":"linux"},"platform":{"arch":"arm64"}}""");
+
+            AppSettings settings = AppSettings.Load(settingsPath);
+
+            Assert.Equal("linux", settings.Platform.Os);
+            Assert.Equal("arm64", settings.Platform.Architecture);
+        }
+        finally
+        {
+            File.Delete(settingsPath);
+        }
+    }
+
+    [Fact]
+    public void Load_MergesDuplicateSettingsObjectsCaseInsensitively()
+    {
+        string settingsPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(
+                settingsPath,
+                """{"platform":{"os":"linux"},"PLATFORM":{"arch":"arm64"}}""");
+
+            AppSettings settings = AppSettings.Load(settingsPath);
+
+            Assert.Equal("linux", settings.Platform.Os);
+            Assert.Equal("arm64", settings.Platform.Architecture);
+        }
+        finally
+        {
+            File.Delete(settingsPath);
+        }
+    }
+
+    [Fact]
+    public void Load_WhitespaceContentReturnsNull()
+    {
+        string settingsPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(settingsPath, " ");
+
+            Assert.Null(AppSettings.Load(settingsPath));
+        }
+        finally
+        {
+            File.Delete(settingsPath);
+        }
     }
 
     [Theory]

--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -1,6 +1,6 @@
 namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using System.CommandLine;
@@ -785,7 +785,7 @@ public class CompareLayersCommandTests
 
         Assert.Equal(0, exitCode);
         CompareLayersResult? result =
-            JsonConvert.DeserializeObject<CompareLayersResult>(output.ToString());
+            JsonSerializer.Deserialize<CompareLayersResult>(output.ToString(), JsonHelper.Settings);
         Assert.NotNull(result);
         Assert.Equal(longHistory, result.LayerComparisons.First().Base!.History);
     }
@@ -917,7 +917,7 @@ public class CompareLayersCommandTests
         Assert.Equal(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(actual));
 
     private static T GetJson<T>(IEnumerable<Segment> segments) =>
-        JsonConvert.DeserializeObject<T>(TestHelper.GetString(segments))!;
+        JsonSerializer.Deserialize<T>(TestHelper.GetString(segments), JsonHelper.Settings)!;
 
     private static void SetupDockerRegistryClient(
         Mock<IDockerRegistryClient> registryClientMock, ImageName imageName, Image imageConfig, ManifestLayer[] layers)

--- a/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
@@ -1,11 +1,11 @@
 namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using System.CommandLine;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Valleysoft.DockerRegistryClient.Models.Images;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
@@ -221,9 +221,132 @@ public class CompareMetadataCommandTests
             "Config",
             "labels[\"org.opencontainers.image.created\"]");
         Assert.Equal(CompareDiff.NotEqual, comparison.Diff);
-        Assert.Equal(JTokenType.String, comparison.BaseValue!.Type);
-        Assert.Equal(BaseTimestamp, comparison.BaseValue.Value<string>());
-        Assert.Equal(TargetTimestamp, comparison.TargetValue!.Value<string>());
+        Assert.IsAssignableFrom<JsonValue>(comparison.BaseValue);
+        Assert.Equal(BaseTimestamp, comparison.BaseValue!.GetValue<string>());
+        Assert.Equal(TargetTimestamp, comparison.TargetValue!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DisplaysMetadataValuesAndPathsWithoutHtmlEscaping()
+    {
+        const string LabelName = "a&b";
+        const string LabelValue = "https://example.com?a=1&b=2";
+        ImageSetup setup = CreateSingleManifestSetup(CreateImageConfig(
+            labels: new Dictionary<string, string> { [LabelName] = LabelValue }));
+        CompareMetadataCommand command = CreateCommand(setup, setup, CompareOutput.Inline);
+
+        IRenderable output = await command.GetOutputAsync(TestContext.Current.CancellationToken);
+        string text = TestHelper.GetString(output.GetSegments(AnsiConsole.Console));
+
+        Assert.Contains($"Config.labels[\"{LabelName}\"] = \"{LabelValue}\"", text);
+    }
+
+    [Fact]
+    public async Task DisplaysDuplicateEnvironmentValuesOnOneLine()
+    {
+        ImageSetup setup = CreateSingleManifestSetup(CreateImageConfig(
+            environmentVariables: ["A=first", "A=second"]));
+        CompareMetadataCommand command = CreateCommand(setup, setup, CompareOutput.Inline);
+
+        IRenderable output = await command.GetOutputAsync(TestContext.Current.CancellationToken);
+        string text = TestHelper.GetString(output.GetSegments(AnsiConsole.Console));
+
+        Assert.Contains("Config.environment[\"A\"] = [\"first\",\"second\"]", text);
+    }
+
+    [Fact]
+    public async Task TreatsDifferentNumericRepresentationsAsChanged()
+    {
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("1")),
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("1.0")));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "labels[\"number\"]", CompareDiff.NotEqual);
+    }
+
+    [Fact]
+    public async Task NormalizesEquivalentFloatingPointRepresentations()
+    {
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("1.0")),
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("1.00")));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+        MetadataComparison comparison = FindComparison(result, "Config", "labels[\"number\"]");
+
+        Assert.Equal(CompareDiff.Equal, comparison.Diff);
+        Assert.Equal("1.0", comparison.BaseValue!.ToJsonString(JsonHelper.CompactSettings));
+        Assert.Equal("1.0", comparison.TargetValue!.ToJsonString(JsonHelper.CompactSettings));
+    }
+
+    [Fact]
+    public async Task TreatsPositiveAndNegativeFloatingPointZeroAsEqual()
+    {
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("-0.0")),
+            CreateSingleManifestSetup(CreateConfigWithLabelValue("0.0")));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "labels[\"number\"]", CompareDiff.Equal);
+    }
+
+    [Theory]
+    [InlineData("1.0", "1.0000000000000002")]
+    [InlineData("0.0", "5e-324")]
+    [InlineData("100.0", "100.00000000000001")]
+    public async Task UsesNewtonsoftApproximateFloatingPointEquality(string baseValue, string targetValue)
+    {
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(CreateConfigWithLabelValue(baseValue)),
+            CreateSingleManifestSetup(CreateConfigWithLabelValue(targetValue)));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "labels[\"number\"]", CompareDiff.Equal);
+    }
+
+    [Fact]
+    public async Task DuplicateConfigurationPropertiesUseLastValue()
+    {
+        const string Config = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": { "User": "first", "User": "last" },
+              "rootfs": { "type": "layers", "diff_ids": [] }
+            }
+            """;
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(Config),
+            CreateSingleManifestSetup(Config));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+        MetadataComparison comparison = FindComparison(result, "Config", "user");
+
+        Assert.Equal("last", comparison.BaseValue!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task CoercesBooleanEnvironmentValuesLikeNewtonsoft()
+    {
+        const string Config = """
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": { "Env": [true] },
+              "rootfs": { "type": "layers", "diff_ids": [] }
+            }
+            """;
+        CompareMetadataCommand command = CreateCommand(
+            CreateSingleManifestSetup(Config),
+            CreateSingleManifestSetup(Config));
+
+        CompareMetadataResult result = await command.GetResultAsync(TestContext.Current.CancellationToken);
+
+        AssertComparison(result, "Config", "environment[\"True\"]", CompareDiff.Equal);
     }
 
     [Fact]
@@ -350,11 +473,13 @@ public class CompareMetadataCommandTests
 
         Assert.Equal(0, exitCode);
         CompareMetadataResult? result =
-            JsonConvert.DeserializeObject<CompareMetadataResult>(output.ToString());
+            JsonSerializer.Deserialize<CompareMetadataResult>(output.ToString(), JsonHelper.Settings);
         Assert.NotNull(result);
         Assert.Contains(
             result.Comparisons,
-            comparison => comparison.BaseValue?.Value<string>() == longValue);
+            comparison => comparison.BaseValue is JsonValue value &&
+                value.TryGetValue(out string? actualValue) &&
+                actualValue == longValue);
     }
 
     [Fact]
@@ -603,6 +728,16 @@ public class CompareMetadataCommandTests
                 }
             ]
         };
+
+    private static string CreateConfigWithLabelValue(string value) =>
+        $$"""
+            {
+              "architecture": "amd64",
+              "os": "linux",
+              "config": { "Labels": { "number": {{value}} } },
+              "rootfs": { "type": "layers", "diff_ids": [] }
+            }
+            """;
 
     private sealed record ImageSetup(
         ManifestInfo InitialManifest,

--- a/src/Valleysoft.Dredge.Tests/JsonHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/JsonHelperTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Valleysoft.Dredge.Tests;
+
+public class JsonHelperTests
+{
+    [Fact]
+    public void Serialize_UsesClrPropertyNamesAndCamelCasesDictionaryKeys()
+    {
+        SerializerContract value = new()
+        {
+            OsVersion = "1",
+            Values = new Dictionary<string, string>
+            {
+                ["Vendor"] = "value",
+                ["Mixed.Case.Key"] = "value"
+            }
+        };
+
+        string json = JsonHelper.Serialize(value);
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal("1", document.RootElement.GetProperty("osVersion").GetString());
+        Assert.False(document.RootElement.TryGetProperty("os.version", out _));
+        JsonElement values = document.RootElement.GetProperty("values");
+        Assert.True(values.TryGetProperty("vendor", out _));
+        Assert.True(values.TryGetProperty("mixed.Case.Key", out _));
+    }
+
+    [Theory]
+    [InlineData("AB\u2028C", "ab\u2028C")]
+    [InlineData("FOO\u00a0bar", "foo\u00a0bar")]
+    [InlineData("AB\u2029C", "ab\u2029C")]
+    [InlineData("IoT", "ioT")]
+    [InlineData("MiB", "miB")]
+    [InlineData("IdP", "idP")]
+    public void Serialize_CamelCasesDictionaryKeysLikeNewtonsoft(string key, string expected)
+    {
+        string json = JsonHelper.Serialize(new Dictionary<string, string> { [key] = "value" });
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal(expected, document.RootElement.EnumerateObject().Single().Name);
+    }
+
+    [Fact]
+    public void Serialize_UsesNewtonsoftCompatibleEscaping()
+    {
+        const string Value = "\u000b\u001f\u007f\u0080\u0085\u00a0\u2028\u2029\ufeff\uffff😀";
+
+        string json = JsonSerializer.Serialize(Value, JsonHelper.CompactSettings);
+
+        Assert.Equal(
+            "\"\\u000b\\u001f\u007f\u0080\\u0085\u00a0\\u2028\\u2029\ufeff\uffff😀\"",
+            json);
+    }
+
+    [Fact]
+    public void Deserialize_CoercesScalarValuesToStrings()
+    {
+        SerializerContract value = JsonHelper.Deserialize<SerializerContract>(
+            """{"osVersion":5,"values":{"enabled":true}}""")!;
+
+        Assert.Equal("5", value.OsVersion);
+        Assert.Equal("true", value.Values["enabled"]);
+    }
+
+    [Fact]
+    public void FormatJson_IndentsNumericArrays()
+    {
+        string json = JsonHelper.FormatJson("[1,2,3]")!;
+
+        Assert.Equal(
+            $"[{Environment.NewLine}  1,{Environment.NewLine}  2,{Environment.NewLine}  3{Environment.NewLine}]",
+            json);
+    }
+
+    [Fact]
+    public void FormatJson_UsesLastDuplicateProperty()
+    {
+        string json = JsonHelper.FormatJson("""{"first":1,"dup":1,"last":2,"dup":3}""")!;
+
+        Assert.Equal(
+            $"{{{Environment.NewLine}  \"first\": 1,{Environment.NewLine}  \"last\": 2,{Environment.NewLine}  \"dup\": 3{Environment.NewLine}}}",
+            json);
+    }
+
+    [Fact]
+    public void FormatJson_DoesNotReplaceEscapedSurrogateText()
+    {
+        string json = JsonHelper.FormatJson("""{"value":"\\ud83d\\ude00"}""")!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal(@"\ud83d\ude00", document.RootElement.GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public void FormatJson_ReplacesOnlyRealSurrogateEscapeAfterLiteralText()
+    {
+        string json = JsonHelper.FormatJson("""{"value":"\\ud83d\ude00"}""")!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal("\\ud83d\ufffd", document.RootElement.GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public void FormatJson_ReplacesInvalidSurrogateEscapes()
+    {
+        string json = JsonHelper.FormatJson("""{"value":"\ud800"}""")!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal("\ufffd", document.RootElement.GetProperty("value").GetString());
+    }
+
+    [Theory]
+    [InlineData("2023-01-02T03:04")]
+    [InlineData("2023-01-02T03:04:05+5")]
+    [InlineData("2023-01-02T03:04:05.")]
+    [InlineData("2023-01-02T03:04:05.Z")]
+    [InlineData("2023-01-02T03:04:05.+01:00")]
+    [InlineData("2023-01-02T03:04:05.111111111Z")]
+    [InlineData("2023-01-02T03:04:05.111111111+01:00")]
+    [InlineData("Mon, 02 Jan 2023 03:04:05 GMT")]
+    [InlineData("2023-01-02 03:04:05 GMT")]
+    public void FormatJson_DoesNotConvertNonNewtonsoftDates(string value)
+    {
+        string json = JsonHelper.FormatJson(JsonSerializer.Serialize(value))!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal(value, document.RootElement.GetString());
+    }
+
+    [Theory]
+    [InlineData("2023-01-02T03:04:05+05")]
+    [InlineData("2023-01-02T03:04:05z")]
+    [InlineData("2023-01-02T03:04:05+0100")]
+    [InlineData("2023-01-02T03:04:05-0800")]
+    [InlineData("2023-01-02T24:00:00Z")]
+    [InlineData("2023-01-02T03:04:05+99:00")]
+    [InlineData("2023-01-02T03:04:05.111111111")]
+    public void FormatJson_ConvertsNewtonsoftDateVariants(string value)
+    {
+        string json = JsonHelper.FormatJson(JsonSerializer.Serialize(value))!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.NotEqual(value, document.RootElement.GetString());
+    }
+
+    [Fact]
+    public void FormatJson_ConvertsMicrosoftDates()
+    {
+        string json = JsonHelper.FormatJson(JsonSerializer.Serialize("/Date(1198908717056)/"))!;
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        Assert.Equal(
+            "2007-12-29T06:11:57.056Z",
+            document.RootElement.GetString());
+    }
+
+    [Theory]
+    [InlineData("/Date(253402300800000)/")]
+    [InlineData("/Date(-62135596800001)/")]
+    public void FormatJson_ThrowsForOutOfRangeMicrosoftDates(string value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => JsonHelper.FormatJson(JsonSerializer.Serialize(value)));
+    }
+
+    [Fact]
+    public void FormatJson_RejectsUppercaseUnicodeEscape()
+    {
+        Assert.ThrowsAny<JsonException>(() => JsonHelper.FormatJson("\"\\Ud800\""));
+    }
+
+    private sealed class SerializerContract
+    {
+        [JsonPropertyName("os.version")]
+        public string OsVersion { get; set; } = string.Empty;
+
+        public Dictionary<string, string> Values { get; set; } = [];
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/JsonHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/JsonHelperTests.cs
@@ -6,6 +6,12 @@ namespace Valleysoft.Dredge.Tests;
 public class JsonHelperTests
 {
     [Fact]
+    public void Serialize_NullReturnsNullLiteral()
+    {
+        Assert.Equal("null", JsonHelper.Serialize(null));
+    }
+
+    [Fact]
     public void Serialize_UsesClrPropertyNamesAndCamelCasesDictionaryKeys()
     {
         SerializerContract value = new()

--- a/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
@@ -1,6 +1,6 @@
 namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
@@ -157,13 +157,13 @@ public class ReferrerCheckCommandTests
         };
 
         await command.RunAsync();
-        JObject json = JObject.Parse(output.ToString());
+        JsonObject json = JsonNode.Parse(output.ToString())!.AsObject();
 
-        Assert.True((bool)json["succeeded"]!);
-        Assert.True((bool)json["results"]![0]!["found"]!);
-        Assert.Equal("application/spdx+json", (string?)json["results"]![0]!["artifactType"]);
-        Assert.Equal("sha256:sbom", (string?)json["results"]![0]!["referrers"]![0]!["digest"]);
-        Assert.Equal(123, (int)json["results"]![0]!["referrers"]![0]!["size"]!);
+        Assert.True(json["succeeded"]!.GetValue<bool>());
+        Assert.True(json["results"]![0]!["found"]!.GetValue<bool>());
+        Assert.Equal("application/spdx+json", json["results"]![0]!["artifactType"]!.GetValue<string>());
+        Assert.Equal("sha256:sbom", json["results"]![0]!["referrers"]![0]!["digest"]!.GetValue<string>());
+        Assert.Equal(123, json["results"]![0]!["referrers"]![0]!["size"]!.GetValue<int>());
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Valleysoft.Dredge.Tests;
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text;
 using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
@@ -82,10 +83,10 @@ public class RegistryCommandTests
         };
 
         await command.RunAsync();
-        JObject json = JObject.Parse(output.ToString());
+        JsonObject json = JsonNode.Parse(output.ToString())!.AsObject();
 
-        Assert.Equal(2, json["schemaVersion"]);
-        Assert.Equal("application/test", json["mediaType"]);
+        Assert.Equal(2, json["schemaVersion"]!.GetValue<int>());
+        Assert.Equal("application/test", json["mediaType"]!.GetValue<string>());
     }
 
     [Fact]
@@ -123,10 +124,46 @@ public class RegistryCommandTests
         };
 
         await command.RunAsync();
-        JObject json = JObject.Parse(output.ToString());
+        JsonObject json = JsonNode.Parse(output.ToString())!.AsObject();
 
-        Assert.Equal("today", json["created"]);
-        Assert.Equal("A=B", json["config"]?["Env"]?[0]);
+        Assert.Equal("today", json["created"]!.GetValue<string>());
+        Assert.Equal("A=B", json["config"]!["Env"]![0]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InspectCommand_NormalizesJsonLikeNewtonsoft()
+    {
+        const string Timestamp = "2021-08-31T21:19:56.930000+02:00";
+        const string Content =
+            """{"timestamp":"2021-08-31T21:19:56.930000+02:00","exponent":1e10,"decimal":1.10,"negativeZero":-0,"dup":1,"dup":2}""";
+        Mock<IDockerRegistryClient> client = CreateClient();
+        client
+            .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateManifestInfo("sha256:manifest", "sha256:config"));
+        client
+            .Setup(o => o.Blobs.GetAsync("repo", "sha256:config", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(Content)));
+        using StringWriter output = new();
+        TestInspectCommand command = new(CreateFactory(client.Object), output)
+        {
+            Options = new InspectOptions { Image = $"{Registry}/repo:tag" }
+        };
+
+        await command.RunAsync();
+        string json = output.ToString();
+        DateTime expectedTimestamp = DateTime.Parse(
+            Timestamp,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind);
+
+        Assert.Contains(
+            $"\"timestamp\": {JsonSerializer.Serialize(expectedTimestamp, JsonHelper.CompactSettings)}",
+            json);
+        Assert.Contains("\"exponent\": 10000000000.0", json);
+        Assert.Contains("\"decimal\": 1.1", json);
+        Assert.Contains("\"negativeZero\": 0", json);
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(json, "\"dup\":"));
+        Assert.Contains("\"dup\": 2", json);
     }
 
     [Fact]
@@ -151,7 +188,9 @@ public class RegistryCommandTests
 
         await command.RunAsync();
 
-        Assert.Equal(["alpha", "middle", "zebra"], JArray.Parse(output.ToString()).Values<string>());
+        Assert.Equal(
+            ["alpha", "middle", "zebra"],
+            JsonSerializer.Deserialize<string[]>(output.ToString())!);
     }
 
     [Fact]
@@ -171,7 +210,9 @@ public class RegistryCommandTests
 
         await command.RunAsync();
 
-        Assert.Equal(["alpha", "zebra"], JArray.Parse(output.ToString()).Values<string>());
+        Assert.Equal(
+            ["alpha", "zebra"],
+            JsonSerializer.Deserialize<string[]>(output.ToString())!);
         client.Verify(
             o => o.Catalog.GetNextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
@@ -199,7 +240,9 @@ public class RegistryCommandTests
 
         await command.RunAsync();
 
-        Assert.Equal(["a", "m", "z"], JArray.Parse(output.ToString()).Values<string>());
+        Assert.Equal(
+            ["a", "m", "z"],
+            JsonSerializer.Deserialize<string[]>(output.ToString())!);
     }
 
     [Fact]
@@ -224,7 +267,9 @@ public class RegistryCommandTests
 
         await command.RunAsync();
 
-        Assert.Equal(["a", "y", "z"], JArray.Parse(output.ToString()).Values<string>());
+        Assert.Equal(
+            ["a", "y", "z"],
+            JsonSerializer.Deserialize<string[]>(output.ToString())!);
         client.Verify(
             o => o.Tags.GetNextAsync("next", It.IsAny<CancellationToken>()),
             Times.Once);
@@ -260,8 +305,8 @@ public class RegistryCommandTests
         };
 
         await command.RunAsync();
-        string[] digests = JObject.Parse(output.ToString())["manifests"]!
-            .Select(manifest => (string)manifest["digest"]!)
+        string[] digests = JsonNode.Parse(output.ToString())!["manifests"]!.AsArray()
+            .Select(manifest => manifest!["digest"]!.GetValue<string>())
             .ToArray();
 
         Assert.Equal(["sha256:first", "sha256:second"], digests);
@@ -294,12 +339,13 @@ public class RegistryCommandTests
         };
 
         await command.RunAsync();
-        JObject json = JObject.Parse(output.ToString());
+        JsonObject json = JsonNode.Parse(output.ToString())!.AsObject();
 
         Assert.Equal(
             ["sha256:first", "sha256:second"],
-            json["manifests"]!.Select(manifest => (string)manifest["digest"]!));
-        Assert.Equal("first-page", (string?)json["annotations"]?["source"]);
+            json["manifests"]!.AsArray().Select(
+                manifest => manifest!["digest"]!.GetValue<string>()));
+        Assert.Equal("first-page", json["annotations"]!["source"]!.GetValue<string>());
         client.Verify(
             o => o.Referrers.GetNextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);

--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.Dredge;
 
@@ -11,12 +11,13 @@ internal partial class AppSettings
 
     public const string FileCompareToolName = "fileCompareTool";
 
-    [JsonProperty(FileCompareToolName)]
+    [JsonPropertyName(FileCompareToolName)]
     public FileCompareToolSettings FileCompareTool { get; set; } = new();
 
-    [JsonProperty("platform")]
+    [JsonPropertyName("platform")]
     public PlatformSettings Platform { get; set; } = new();
 
+    [JsonConstructor]
     private AppSettings() {}
 
     public static AppSettings Load() => Load(SettingsPath);
@@ -28,7 +29,7 @@ internal partial class AppSettings
             if (!File.Exists(settingsPath))
             {
                 AppSettings settings = new();
-                string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
+                string settingsStr = JsonHelper.Serialize(settings);
 
                 string? dirName = Path.GetDirectoryName(settingsPath);
                 if (!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
@@ -41,7 +42,13 @@ internal partial class AppSettings
             }
 
             string settingsContent = File.ReadAllText(settingsPath);
-            return JsonConvert.DeserializeObject<AppSettings>(settingsContent)!;
+            if (string.IsNullOrWhiteSpace(settingsContent))
+            {
+                return null!;
+            }
+
+            return JsonHelper.Deserialize<AppSettings>(
+                JsonHelper.MergeDuplicateObjects(settingsContent))!;
         }
     }
 
@@ -49,7 +56,7 @@ internal partial class AppSettings
     {
         lock (settingsFileLock)
         {
-            string settingsStr = JsonConvert.SerializeObject(this, JsonHelper.Settings);
+            string settingsStr = JsonHelper.Serialize(this);
             File.WriteAllText(SettingsPath, settingsStr);
         }
     }
@@ -57,21 +64,21 @@ internal partial class AppSettings
 
 internal partial class FileCompareToolSettings
 {
-    [JsonProperty("exePath")]
+    [JsonPropertyName("exePath")]
     public string ExePath { get; set; } = string.Empty;
 
-    [JsonProperty("args")]
+    [JsonPropertyName("args")]
     public string Args { get; set; } = string.Empty;
 }
 
 internal partial class PlatformSettings
 {
-    [JsonProperty("os")]
+    [JsonPropertyName("os")]
     public string Os { get; set; } = string.Empty;
 
-    [JsonProperty("osVersion")]
+    [JsonPropertyName("osVersion")]
     public string OsVersion { get; set; } = string.Empty;
 
-    [JsonProperty("arch")]
+    [JsonPropertyName("arch")]
     public string Architecture { get; set; } = string.Empty;
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Text.Json;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using Valleysoft.DockerRegistryClient;
@@ -31,7 +30,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
             if (Options.OutputFormat == CompareOutput.Json)
             {
                 ansiConsole.Profile.Out.Writer.WriteLine(
-                    JsonConvert.SerializeObject(result, JsonHelper.Settings));
+                    JsonHelper.Serialize(result));
             }
             else
             {
@@ -460,7 +459,7 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
                 CompareLayersOptions options,
                 bool isColorDisabled)
             {
-                string output = JsonConvert.SerializeObject(result, JsonHelper.Settings);
+                string output = JsonHelper.Serialize(result);
 
                 return new Text(output);
             }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
@@ -1,7 +1,7 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Spectre.Console;
 using Spectre.Console.Rendering;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Valleysoft.DockerRegistryClient.Models.Manifests;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
@@ -9,11 +9,6 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions>
 {
-    private static readonly JsonSerializerSettings imageConfigJsonSettings = new()
-    {
-        DateParseHandling = DateParseHandling.None
-    };
-
     private readonly IAnsiConsole ansiConsole;
     private readonly Func<PlatformSettings> platformSettingsProvider;
 
@@ -76,7 +71,7 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         GetOutput(await GetResultAsync(cancellationToken));
 
     private void WriteJson(CompareMetadataResult result) =>
-        ansiConsole.Profile.Out.Writer.WriteLine(JsonConvert.SerializeObject(result, JsonHelper.Settings));
+        ansiConsole.Profile.Out.Writer.WriteLine(JsonHelper.Serialize(result));
 
     private IRenderable GetOutput(CompareMetadataResult result)
     {
@@ -89,7 +84,7 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         {
             CompareOutput.SideBySide => GetSideBySideOutput(result, isColorDisabled),
             CompareOutput.Inline => GetInlineOutput(result, isColorDisabled),
-            CompareOutput.Json => new Text(JsonConvert.SerializeObject(result, JsonHelper.Settings)),
+            CompareOutput.Json => new Text(JsonHelper.Serialize(result)),
             _ => throw new NotSupportedException($"Unsupported metadata comparison output format '{Options.OutputFormat}'.")
         };
     }
@@ -162,11 +157,11 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         return new Rows(rows);
     }
 
-    private static Markup GetInlineMarkup(string prefix, string path, JToken? value, Color color) =>
+    private static Markup GetInlineMarkup(string prefix, string path, JsonNode? value, Color color) =>
         new(Markup.Escape($"{prefix}{path} = {FormatValue(value)}"), new Style(color));
 
     private static Markup GetValueMarkup(
-        JToken? value,
+        JsonNode? value,
         CompareDiff diff,
         bool isBase,
         bool isColorDisabled)
@@ -182,8 +177,8 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         return new Markup(Markup.Escape(FormatValue(value)), new Style(color));
     }
 
-    private static string FormatValue(JToken? value) =>
-        value is null ? string.Empty : value.ToString(Formatting.None);
+    private static string FormatValue(JsonNode? value) =>
+        value is null ? string.Empty : value.ToJsonString(JsonHelper.CompactSettings);
 
     private static string GetDiffDisplayName(CompareDiff diff) =>
         diff switch
@@ -217,8 +212,15 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         using Stream configBlob = await client.Blobs.GetAsync(imageName.Repo, configDigest, cancellationToken);
         using StreamReader configReader = new(configBlob);
         string configContent = await configReader.ReadToEndAsync(cancellationToken);
-        JObject imageConfig = JsonConvert.DeserializeObject<JObject>(configContent, imageConfigJsonSettings) ??
+        JsonObject imageConfig;
+        try
+        {
+            imageConfig = JsonHelper.ParseObject(configContent);
+        }
+        catch (JsonException)
+        {
             throw new JsonException($"Could not deserialize the image config of '{image}'.");
+        }
 
         MetadataDocument document = new();
         AddInitialManifest(document, initialManifest);
@@ -259,7 +261,7 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
             for (int i = 0; i < references.Length; i++)
             {
                 string id = references.Length == 1 ? platformGroup.Key : $"{platformGroup.Key}#{i + 1}";
-                string path = $"available[{JsonConvert.ToString(id)}]";
+                string path = $"available[{JsonSerializer.Serialize(id, JsonHelper.Settings)}]";
                 AddDescriptor(document, "Platforms", path, references[i]);
                 AddPlatform(document, "Platforms", $"{path}.platform", references[i].Platform);
             }
@@ -346,133 +348,136 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
                 .Where(value => !string.IsNullOrEmpty(value)));
     }
 
-    private static void AddImageConfig(MetadataDocument document, JObject image)
+    private static void AddImageConfig(MetadataDocument document, JsonObject image)
     {
-        foreach (JProperty property in image.Properties().OrderBy(property => property.Name, StringComparer.Ordinal))
+        foreach ((string name, JsonNode? value) in image.OrderBy(property => property.Key, StringComparer.Ordinal))
         {
-            switch (property.Name)
+            switch (name)
             {
                 case "config":
-                    AddExecutionConfig(document, property.Value);
+                    AddExecutionConfig(document, value);
                     break;
                 case "rootfs":
-                    AddRootFilesystem(document, property.Value);
+                    AddRootFilesystem(document, value);
                     break;
                 case "history":
-                    AddHistory(document, property.Value);
+                    AddHistory(document, value);
                     break;
                 case "os.features":
-                    document.AddTokenSet("Image", "osFeatures", property.Value);
+                    document.AddTokenSet("Image", "osFeatures", value);
                     break;
                 case "os.version":
-                    document.AddToken("Image", "osVersion", property.Value);
+                    document.AddToken("Image", "osVersion", value);
                     break;
                 default:
-                    document.AddToken("Image", LowerFirstCharacter(property.Name), property.Value);
+                    document.AddToken("Image", LowerFirstCharacter(name), value);
                     break;
             }
         }
     }
 
-    private static void AddRootFilesystem(MetadataDocument document, JToken rootFilesystem)
+    private static void AddRootFilesystem(MetadataDocument document, JsonNode? rootFilesystem)
     {
-        if (rootFilesystem is not JObject rootFilesystemObject)
+        if (rootFilesystem is not JsonObject rootFilesystemObject)
         {
             return;
         }
 
-        foreach (JProperty property in rootFilesystemObject.Properties()
-            .OrderBy(property => property.Name, StringComparer.Ordinal))
+        foreach ((string name, JsonNode? value) in rootFilesystemObject
+            .OrderBy(property => property.Key, StringComparer.Ordinal))
         {
-            string path = property.Name == "diff_ids" ? "diffIds" : LowerFirstCharacter(property.Name);
-            document.AddToken("RootFilesystem", path, property.Value);
+            string path = name == "diff_ids" ? "diffIds" : LowerFirstCharacter(name);
+            document.AddToken("RootFilesystem", path, value);
         }
     }
 
-    private static void AddHistory(MetadataDocument document, JToken history)
+    private static void AddHistory(MetadataDocument document, JsonNode? history)
     {
-        if (history is not JArray historyArray)
+        if (history is not JsonArray historyArray)
         {
             return;
         }
 
         for (int i = 0; i < historyArray.Count; i++)
         {
-            if (historyArray[i] is not JObject historyEntry)
+            if (historyArray[i] is not JsonObject historyEntry)
             {
                 document.AddToken("History", $"entries[{i}]", historyArray[i]);
                 continue;
             }
 
-            foreach (JProperty property in historyEntry.Properties()
-                .OrderBy(property => property.Name, StringComparer.Ordinal))
+            foreach ((string name, JsonNode? value) in historyEntry
+                .OrderBy(property => property.Key, StringComparer.Ordinal))
             {
-                string propertyName = property.Name switch
+                string propertyName = name switch
                 {
                     "created_by" => "createdBy",
                     "empty_layer" => "emptyLayer",
-                    _ => LowerFirstCharacter(property.Name)
+                    _ => LowerFirstCharacter(name)
                 };
-                document.AddToken("History", $"entries[{i}].{propertyName}", property.Value);
+                document.AddToken("History", $"entries[{i}].{propertyName}", value);
             }
         }
     }
 
-    private static void AddExecutionConfig(MetadataDocument document, JToken config)
+    private static void AddExecutionConfig(MetadataDocument document, JsonNode? config)
     {
-        if (config is not JObject configObject)
+        if (config is not JsonObject configObject)
         {
             return;
         }
 
-        foreach (JProperty property in configObject.Properties()
-            .OrderBy(property => property.Name, StringComparer.Ordinal))
+        foreach ((string name, JsonNode? value) in configObject
+            .OrderBy(property => property.Key, StringComparer.Ordinal))
         {
-            switch (property.Name)
+            switch (name)
             {
                 case "Env":
-                    AddEnvironment(document, property.Value);
+                    AddEnvironment(document, value);
                     break;
                 case "ExposedPorts":
-                    document.AddObjectKeys("Config", "exposedPorts", property.Value);
+                    document.AddObjectKeys("Config", "exposedPorts", value);
                     break;
                 case "Volumes":
-                    document.AddObjectKeys("Config", "volumes", property.Value);
+                    document.AddObjectKeys("Config", "volumes", value);
                     break;
                 default:
-                    string path = property.Name switch
+                    string path = name switch
                     {
                         "Cmd" => "command",
                         "WorkingDir" => "workingDirectory",
-                        _ => LowerFirstCharacter(property.Name)
+                        _ => LowerFirstCharacter(name)
                     };
-                    document.AddToken("Config", path, property.Value);
+                    document.AddToken("Config", path, value);
                     break;
             }
         }
     }
 
-    private static void AddEnvironment(MetadataDocument document, JToken environment)
+    private static void AddEnvironment(MetadataDocument document, JsonNode? environment)
     {
-        if (environment is not JArray environmentArray)
+        if (environment is not JsonArray environmentArray)
         {
             return;
         }
 
         // Environment order is not significant, but duplicate names remain ordered because the last assignment can affect runtime behavior.
         foreach (IGrouping<string, string> group in environmentArray
-            .Values<string>()
-            .Where(variable => variable is not null)
-            .Select(variable => ParseEnvironmentVariable(variable!))
+            .Select(GetStringValue)
+            .Where(value => value is not null)
+            .Cast<string>()
+            .Select(ParseEnvironmentVariable)
             .GroupBy(variable => variable.Name, variable => variable.Value)
             .OrderBy(group => group.Key, StringComparer.Ordinal))
         {
-            string path = $"environment[{JsonConvert.ToString(group.Key)}]";
+            string path = $"environment[{JsonSerializer.Serialize(group.Key, JsonHelper.Settings)}]";
             string[] values = [.. group];
             document.Add(
                 "Config",
                 path,
-                values.Length == 1 ? JValue.CreateString(values[0]) : JArray.FromObject(values));
+                values.Length == 1
+                    ? JsonValue.Create(values[0])
+                    : new JsonArray(values.Select(value => JsonValue.Create(value)).ToArray()));
         }
     }
 
@@ -525,9 +530,95 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
             return CompareDiff.Removed;
         }
 
-        return JToken.DeepEquals(baseItem.Value, targetItem.Value)
+        return MetadataValuesEqual(baseItem.Value, targetItem.Value)
             ? CompareDiff.Equal
             : CompareDiff.NotEqual;
+    }
+
+    private static bool MetadataValuesEqual(JsonNode left, JsonNode right)
+    {
+        if (left.GetValueKind() == JsonValueKind.Number &&
+            right.GetValueKind() == JsonValueKind.Number)
+        {
+            string leftValue = left.ToJsonString(JsonHelper.CompactSettings);
+            string rightValue = right.ToJsonString(JsonHelper.CompactSettings);
+            bool leftIsFloat = leftValue.Contains('.') || leftValue.IndexOfAny(['e', 'E']) >= 0;
+            bool rightIsFloat = rightValue.Contains('.') || rightValue.IndexOfAny(['e', 'E']) >= 0;
+            return leftIsFloat == rightIsFloat &&
+                (!leftIsFloat ||
+                    ApproximatelyEqual(
+                        double.Parse(
+                            leftValue,
+                            System.Globalization.CultureInfo.InvariantCulture),
+                        double.Parse(
+                            rightValue,
+                            System.Globalization.CultureInfo.InvariantCulture))) &&
+                (leftIsFloat ||
+                    string.Equals(leftValue, rightValue, StringComparison.Ordinal));
+        }
+
+        return JsonNode.DeepEquals(left, right);
+    }
+
+    private static bool ApproximatelyEqual(double left, double right)
+    {
+        if (left.Equals(right))
+        {
+            return true;
+        }
+
+        double tolerance =
+            (Math.Abs(left) + Math.Abs(right) + 10.0) * 2.2204460492503131e-16;
+        double difference = left - right;
+        return -tolerance < difference && tolerance > difference;
+    }
+
+    private static string? GetStringValue(JsonNode? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (value is not JsonValue jsonValue)
+        {
+            throw new InvalidCastException($"Cannot cast {value.GetType().Name} to string.");
+        }
+
+        if (jsonValue.TryGetValue(out string? stringValue))
+        {
+            return stringValue;
+        }
+
+        if (jsonValue.TryGetValue(out bool boolValue))
+        {
+            return boolValue.ToString();
+        }
+
+        if (jsonValue.GetValueKind() == JsonValueKind.Number)
+        {
+            string rawValue = jsonValue.ToJsonString(JsonHelper.CompactSettings);
+            if (!rawValue.Contains('.') && rawValue.IndexOfAny(['e', 'E']) < 0)
+            {
+                return long.TryParse(
+                    rawValue,
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out long integer)
+                        ? integer.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        : throw new InvalidCastException("Object must implement IConvertible.");
+            }
+
+            return double.TryParse(
+                rawValue,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out double number)
+                    ? number.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : rawValue;
+        }
+
+        throw new InvalidCastException($"Cannot cast {jsonValue.GetValueKind()} to string.");
     }
 
     private sealed class MetadataDocument
@@ -542,27 +633,36 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
                 return;
             }
 
-            JToken token = value as JToken ?? JToken.FromObject(value);
+            JsonNode token = value as JsonNode ??
+                JsonSerializer.SerializeToNode(value, value.GetType(), JsonHelper.Settings)!;
+            if (value is JsonNode && token.GetValueKind() == JsonValueKind.Number)
+            {
+                token = JsonNode.Parse(JsonHelper.NormalizeNewtonsoftNumber(
+                    token.ToJsonString(JsonHelper.CompactSettings)))!;
+            }
             // A null separator cannot collide with the JSON-escaped user keys embedded in paths.
             Items[$"{category}\0{path}"] = new MetadataItem(category, path, token);
         }
 
-        public void AddToken(string category, string path, JToken? value)
+        public void AddToken(string category, string path, JsonNode? value)
         {
-            if (value is null || value.Type is JTokenType.Null or JTokenType.Undefined)
+            if (value is null)
             {
                 return;
             }
 
-            if (value is JObject valueObject)
+            if (value is JsonObject valueObject)
             {
-                foreach (JProperty property in valueObject.Properties()
-                    .OrderBy(property => property.Name, StringComparer.Ordinal))
+                foreach ((string name, JsonNode? propertyValue) in valueObject
+                    .OrderBy(property => property.Key, StringComparer.Ordinal))
                 {
-                    AddToken(category, $"{path}[{JsonConvert.ToString(property.Name)}]", property.Value);
+                    AddToken(
+                        category,
+                        $"{path}[{JsonSerializer.Serialize(name, JsonHelper.Settings)}]",
+                        propertyValue);
                 }
             }
-            else if (value is JArray valueArray)
+            else if (value is JsonArray valueArray)
             {
                 for (int i = 0; i < valueArray.Count; i++)
                 {
@@ -575,24 +675,27 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
             }
         }
 
-        public void AddTokenSet(string category, string path, JToken value)
+        public void AddTokenSet(string category, string path, JsonNode? value)
         {
-            if (value is not JArray valueArray)
+            if (value is not JsonArray valueArray)
             {
                 return;
             }
 
-            AddSet(category, path, valueArray.Values<string>().Where(item => item is not null).Cast<string>());
+            AddSet(
+                category,
+                path,
+                valueArray.Select(GetStringValue).Where(item => item is not null).Cast<string>());
         }
 
-        public void AddObjectKeys(string category, string path, JToken value)
+        public void AddObjectKeys(string category, string path, JsonNode? value)
         {
-            if (value is not JObject valueObject)
+            if (value is not JsonObject valueObject)
             {
                 return;
             }
 
-            AddKeys(category, path, valueObject.Properties().Select(property => property.Name));
+            AddKeys(category, path, valueObject.Select(property => property.Key));
         }
 
         public void AddDictionary(
@@ -607,7 +710,7 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
 
             foreach ((string key, string value) in values.OrderBy(item => item.Key, StringComparer.Ordinal))
             {
-                Add(category, $"{path}[{JsonConvert.ToString(key)}]", value);
+                Add(category, $"{path}[{JsonSerializer.Serialize(key, JsonHelper.Settings)}]", value);
             }
         }
 
@@ -625,10 +728,10 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
         {
             foreach (string value in values.OrderBy(value => value, StringComparer.Ordinal))
             {
-                Add(category, $"{path}[{JsonConvert.ToString(value)}]", true);
+                Add(category, $"{path}[{JsonSerializer.Serialize(value, JsonHelper.Settings)}]", true);
             }
         }
     }
 
-    private sealed record MetadataItem(string Category, string Path, JToken Value);
+    private sealed record MetadataItem(string Category, string Path, JsonNode Value);
 }

--- a/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectCommand.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
+﻿using Valleysoft.DockerRegistryClient.Models.Manifests;
 
 namespace Valleysoft.Dredge.Commands.Image;
 
@@ -23,9 +22,8 @@ public class InspectCommand : RegistryCommandBase<InspectOptions>
             Stream blob = await client.Blobs.GetAsync(imageName.Repo, digest, ct);
             using StreamReader reader = new(blob);
             string content = await reader.ReadToEndAsync(ct);
-            object? json = JsonConvert.DeserializeObject(content) ??
+            string output = JsonHelper.FormatJson(content) ??
                 throw new Exception($"Unable to deserialize content into JSON:\n{content}");
-            string output = JsonConvert.SerializeObject(json, JsonHelper.Settings);
             Output.WriteLine(output);
         });
     }

--- a/src/Valleysoft.Dredge/Commands/Image/LsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsCommand.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using System.Globalization;
@@ -36,7 +35,7 @@ public class LsCommand : RegistryCommandBase<LsOptions>
             if (Options.OutputFormat == LsOutput.Json)
             {
                 ansiConsole.Profile.Out.Writer.WriteLine(
-                    JsonConvert.SerializeObject(entries, JsonHelper.Settings));
+                    JsonHelper.Serialize(entries));
             }
             else
             {

--- a/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.Formats.Tar;
-using Newtonsoft.Json;
 using System.IO.Compression;
 using System.Text.RegularExpressions;
 using Valleysoft.DockerRegistryClient;
@@ -60,7 +59,7 @@ public partial class OsCommand : RegistryCommandBase<OsOptions>
                 throw new Exception("Unable to derive OS information from the image.");
             }
 
-            string output = JsonConvert.SerializeObject(osInfo, JsonHelper.SettingsNoCamelCase);
+            string output = JsonHelper.Serialize(osInfo, JsonHelper.SettingsNoCamelCase);
             Output.WriteLine(output);
         });
     }

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetCommand.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Valleysoft.DockerRegistryClient.Models.Manifests;
+﻿using Valleysoft.DockerRegistryClient.Models.Manifests;
 
 namespace Valleysoft.Dredge.Commands.Manifest;
 
@@ -20,7 +19,7 @@ public class GetCommand : RegistryCommandBase<GetOptions>
             ManifestInfo manifestInfo = await client.Manifests.GetAsync(
                 imageName.Repo, (imageName.Tag ?? imageName.Digest)!, ct);
 
-            string output = JsonConvert.SerializeObject(manifestInfo.Manifest, JsonHelper.Settings);
+            string output = JsonHelper.Serialize(manifestInfo.Manifest);
 
             Output.WriteLine(output);
         });

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckCommand.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 namespace Valleysoft.Dredge.Commands.Referrer;
@@ -50,7 +49,7 @@ public class CheckCommand : RegistryCommandBase<CheckOptions>
     {
         if (Options.OutputFormat == CheckOutput.Json)
         {
-            Output.WriteLine(JsonConvert.SerializeObject(result, JsonHelper.Settings));
+            Output.WriteLine(JsonHelper.Serialize(result));
             return;
         }
 

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListCommand.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using Valleysoft.DockerRegistryClient.Models.Manifests.Oci;
 
 namespace Valleysoft.Dredge.Commands.Referrer;
@@ -23,7 +22,7 @@ public class ListCommand : RegistryCommandBase<ListOptions>
                     Options.ArtifactType,
                     ct,
                     Options.Limit);
-            string output = JsonConvert.SerializeObject(index, JsonHelper.Settings);
+            string output = JsonHelper.Serialize(index);
 
             Output.WriteLine(output);
         });

--- a/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Repo/ListCommand.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Valleysoft.DockerRegistryClient;
+﻿using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Repo;
@@ -30,7 +29,7 @@ public class ListCommand : RegistryCommandBase<ListOptions>
 
             repoNames.Sort();
 
-            string output = JsonConvert.SerializeObject(repoNames, JsonHelper.Settings);
+            string output = JsonHelper.Serialize(repoNames);
 
             Output.WriteLine(output);
         });

--- a/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace Valleysoft.Dredge.Commands.Settings;
+﻿namespace Valleysoft.Dredge.Commands.Settings;
 
 internal partial class GetCommand : CommandWithOptions<GetOptions>
 {
@@ -26,7 +24,7 @@ internal partial class GetCommand : CommandWithOptions<GetOptions>
             }
             else
             {
-                Console.WriteLine(JsonConvert.SerializeObject(value, JsonHelper.Settings));
+                Console.WriteLine(JsonHelper.Serialize(value));
             }
         }
 

--- a/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListCommand.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Valleysoft.DockerRegistryClient;
+﻿using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge.Commands.Tag;
@@ -32,7 +31,7 @@ public class ListCommand : RegistryCommandBase<ListOptions>
 
             tags.Sort();
 
-            string output = JsonConvert.SerializeObject(tags, JsonHelper.Settings);
+            string output = JsonHelper.Serialize(tags);
 
             Output.WriteLine(output);
         });

--- a/src/Valleysoft.Dredge/CompareDiff.cs
+++ b/src/Valleysoft.Dredge/CompareDiff.cs
@@ -1,18 +1,16 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Valleysoft.Dredge;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<CompareDiff>))]
 public enum CompareDiff
 {
-    [EnumMember(Value = "equal")]
+    [JsonStringEnumMemberName("equal")]
     Equal,
-    [EnumMember(Value = "notEqual")]
+    [JsonStringEnumMemberName("notEqual")]
     NotEqual,
-    [EnumMember(Value = "added")]
+    [JsonStringEnumMemberName("added")]
     Added,
-    [EnumMember(Value = "removed")]
+    [JsonStringEnumMemberName("removed")]
     Removed
 }

--- a/src/Valleysoft.Dredge/CompareMetadataResult.cs
+++ b/src/Valleysoft.Dredge/CompareMetadataResult.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace Valleysoft.Dredge;
 
@@ -37,8 +37,8 @@ public class MetadataComparison
     public MetadataComparison(
         string category,
         string path,
-        JToken? baseValue,
-        JToken? targetValue,
+        JsonNode? baseValue,
+        JsonNode? targetValue,
         CompareDiff diff)
     {
         Category = category;
@@ -50,7 +50,7 @@ public class MetadataComparison
 
     public string Category { get; }
     public string Path { get; }
-    public JToken? BaseValue { get; }
-    public JToken? TargetValue { get; }
+    public JsonNode? BaseValue { get; }
+    public JsonNode? TargetValue { get; }
     public CompareDiff Diff { get; }
 }

--- a/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
+++ b/src/Valleysoft.Dredge/ImageFileSystemEntry.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Valleysoft.Dredge;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<ImageFileType>))]
 public enum ImageFileType
 {
     File,

--- a/src/Valleysoft.Dredge/JsonHelper.cs
+++ b/src/Valleysoft.Dredge/JsonHelper.cs
@@ -50,8 +50,10 @@ internal static class JsonHelper
         TypeInfoResolver = CreateTypeInfoResolver(namingPolicy: null),
     };
 
-    public static string Serialize(object value, JsonSerializerOptions? options = null) =>
-        JsonSerializer.Serialize(value, value.GetType(), options ?? Settings);
+    public static string Serialize(object? value, JsonSerializerOptions? options = null) =>
+        value is null
+            ? JsonSerializer.Serialize(value, options ?? Settings)
+            : JsonSerializer.Serialize(value, value.GetType(), options ?? Settings);
 
     public static T? Deserialize<T>(string json, JsonSerializerOptions? options = null) =>
         JsonSerializer.Deserialize<T>(json, options ?? Settings);

--- a/src/Valleysoft.Dredge/JsonHelper.cs
+++ b/src/Valleysoft.Dredge/JsonHelper.cs
@@ -1,20 +1,632 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+﻿using System.Buffers;
+using System.Globalization;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.RegularExpressions;
 
 namespace Valleysoft.Dredge;
 
 internal static class JsonHelper
 {
-    public static readonly JsonSerializerSettings Settings = new()
+    private static readonly JsonNamingPolicy camelCaseNamingPolicy =
+        new NewtonsoftCompatibleCamelCaseNamingPolicy();
+
+    public static readonly JsonSerializerOptions Settings = new()
     {
-        NullValueHandling = NullValueHandling.Ignore,
-        Formatting = Formatting.Indented,
-        ContractResolver = new CamelCasePropertyNamesContractResolver()
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = NewtonsoftCompatibleJavaScriptEncoder.Instance,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        WriteIndented = true,
+        DictionaryKeyPolicy = camelCaseNamingPolicy,
+        PropertyNamingPolicy = camelCaseNamingPolicy,
+        TypeInfoResolver = CreateTypeInfoResolver(camelCaseNamingPolicy),
+        Converters =
+        {
+            new NewtonsoftCompatibleStringConverter()
+        }
     };
 
-    public static readonly JsonSerializerSettings SettingsNoCamelCase = new()
+    public static readonly JsonSerializerOptions CompactSettings = new(Settings)
     {
-        NullValueHandling = NullValueHandling.Ignore,
-        Formatting = Formatting.Indented
+        WriteIndented = false
     };
+
+    public static readonly JsonSerializerOptions SettingsNoCamelCase = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = NewtonsoftCompatibleJavaScriptEncoder.Instance,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        WriteIndented = true,
+        TypeInfoResolver = CreateTypeInfoResolver(namingPolicy: null),
+    };
+
+    public static string Serialize(object value, JsonSerializerOptions? options = null) =>
+        JsonSerializer.Serialize(value, value.GetType(), options ?? Settings);
+
+    public static T? Deserialize<T>(string json, JsonSerializerOptions? options = null) =>
+        JsonSerializer.Deserialize<T>(json, options ?? Settings);
+
+    public static string? FormatJson(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(
+            ReplaceInvalidSurrogateEscapes(json),
+            new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip
+            });
+        if (document.RootElement.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        StringBuilder output = new();
+        WriteJsonValue(document.RootElement, output, depth: 0);
+        return output.ToString();
+    }
+
+    public static JsonObject ParseObject(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(
+            ReplaceInvalidSurrogateEscapes(json),
+            new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip
+            });
+        return CreateNode(document.RootElement) as JsonObject ??
+            throw new JsonException("The JSON value could not be converted to an object.");
+    }
+
+    public static string MergeDuplicateObjects(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(
+            ReplaceInvalidSurrogateEscapes(json),
+            new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip
+            });
+        return CreateMergedNode(document.RootElement)?.ToJsonString(CompactSettings) ?? "null";
+    }
+
+    public static string NormalizeNewtonsoftNumber(string rawValue)
+    {
+        if (!rawValue.Contains('.') &&
+            rawValue.IndexOfAny(['e', 'E']) < 0)
+        {
+            return BigInteger.Parse(rawValue, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture);
+        }
+
+        double value = double.Parse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture);
+        if (!double.IsFinite(value))
+        {
+            return JsonSerializer.Serialize(
+                value > 0 ? "Infinity" : "-Infinity",
+                CompactSettings);
+        }
+
+        string formatted = value.ToString("R", CultureInfo.InvariantCulture);
+        return formatted.Contains('.') || formatted.IndexOfAny(['e', 'E']) >= 0
+            ? formatted.Replace('e', 'E')
+            : $"{formatted}.0";
+    }
+
+    private static IJsonTypeInfoResolver CreateTypeInfoResolver(JsonNamingPolicy? namingPolicy)
+    {
+        DefaultJsonTypeInfoResolver resolver = new();
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            foreach (JsonPropertyInfo property in typeInfo.Properties)
+            {
+                if (property.AttributeProvider is MemberInfo member)
+                {
+                    JsonPropertyNameAttribute? propertyName =
+                        member.GetCustomAttribute<JsonPropertyNameAttribute>();
+                    string name = propertyName is not null &&
+                        member.DeclaringType?.Assembly == typeof(JsonHelper).Assembly
+                            ? propertyName.Name
+                            : member.Name;
+                    property.Name = namingPolicy?.ConvertName(name) ?? name;
+                }
+            }
+        });
+        return resolver;
+    }
+
+    private static void WriteJsonValue(JsonElement value, StringBuilder output, int depth)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                JsonProperty[] properties = GetLastProperties(value);
+                if (properties.Length == 0)
+                {
+                    output.Append("{}");
+                    break;
+                }
+
+                output.AppendLine("{");
+                for (int i = 0; i < properties.Length; i++)
+                {
+                    AppendIndent(output, depth + 1);
+                    output.Append(JsonSerializer.Serialize(properties[i].Name, CompactSettings));
+                    output.Append(": ");
+                    WriteJsonValue(properties[i].Value, output, depth + 1);
+                    output.AppendLine(i == properties.Length - 1 ? string.Empty : ",");
+                }
+                AppendIndent(output, depth);
+                output.Append('}');
+                break;
+            case JsonValueKind.Array:
+                JsonElement[] items = [.. value.EnumerateArray()];
+                if (items.Length == 0)
+                {
+                    output.Append("[]");
+                    break;
+                }
+
+                output.AppendLine("[");
+                for (int i = 0; i < items.Length; i++)
+                {
+                    AppendIndent(output, depth + 1);
+                    WriteJsonValue(items[i], output, depth + 1);
+                    output.AppendLine(i == items.Length - 1 ? string.Empty : ",");
+                }
+                AppendIndent(output, depth);
+                output.Append(']');
+                break;
+            case JsonValueKind.String:
+                string stringValue = value.GetString()!;
+                if (TryParseNewtonsoftDate(stringValue, out DateTime date))
+                {
+                    output.Append(JsonSerializer.Serialize(date, CompactSettings));
+                }
+                else
+                {
+                    output.Append(JsonSerializer.Serialize(stringValue, CompactSettings));
+                }
+                break;
+            case JsonValueKind.Number:
+                output.Append(NormalizeNewtonsoftNumber(value.GetRawText()));
+                break;
+            case JsonValueKind.True:
+                output.Append("true");
+                break;
+            case JsonValueKind.False:
+                output.Append("false");
+                break;
+            case JsonValueKind.Null:
+                output.Append("null");
+                break;
+            default:
+                throw new JsonException($"Unexpected JSON value kind '{value.ValueKind}'.");
+        }
+    }
+
+    private static JsonProperty[] GetLastProperties(JsonElement value)
+    {
+        List<JsonProperty> properties = [];
+        foreach (JsonProperty property in value.EnumerateObject())
+        {
+            properties.RemoveAll(existing =>
+                string.Equals(existing.Name, property.Name, StringComparison.Ordinal));
+            properties.Add(property);
+        }
+
+        return [.. properties];
+    }
+
+    private static bool TryParseNewtonsoftDate(string value, out DateTime date)
+    {
+        date = default;
+        Match microsoftDate = Regex.Match(
+            value,
+            @"^/Date\((?<milliseconds>-?\d+)(?<offset>[+-]\d+)?\)/$",
+            RegexOptions.CultureInvariant);
+        if (microsoftDate.Success)
+        {
+            if (!long.TryParse(
+                microsoftDate.Groups["milliseconds"].Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out long milliseconds))
+            {
+                return false;
+            }
+
+            DateTimeOffset dateTime = DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+            date = microsoftDate.Groups["offset"].Success
+                ? dateTime.LocalDateTime
+                : dateTime.UtcDateTime;
+            return true;
+        }
+
+        if (value.Length is < 19 or > 40 ||
+            value[10] != 'T' ||
+            !char.IsDigit(value[0]))
+        {
+            return false;
+        }
+
+        string normalizedValue = value.EndsWith('z')
+            ? $"{value[..^1]}Z"
+            : value;
+        Match shortOffset = Regex.Match(
+            normalizedValue,
+            @"(?<offset>[+-]\d{2})$",
+            RegexOptions.CultureInvariant);
+        if (shortOffset.Success)
+        {
+            normalizedValue = $"{normalizedValue}:00";
+        }
+        Match compactOffset = Regex.Match(
+            normalizedValue,
+            @"(?<sign>[+-])(?<hours>\d{2})(?<minutes>\d{2})$",
+            RegexOptions.CultureInvariant);
+        if (compactOffset.Success)
+        {
+            normalizedValue = normalizedValue[..compactOffset.Index] +
+                $"{compactOffset.Groups["sign"].Value}{compactOffset.Groups["hours"].Value}:{compactOffset.Groups["minutes"].Value}";
+        }
+
+        Match isoDate = Regex.Match(
+            normalizedValue,
+            @"^(?<date>\d{4}-\d{2}-\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?<fraction>\.\d+)?(?<zone>Z|[+-]\d{2}:\d{2})?$",
+            RegexOptions.CultureInvariant);
+        if (!isoDate.Success)
+        {
+            return false;
+        }
+
+        string fraction = isoDate.Groups["fraction"].Value;
+        string zone = isoDate.Groups["zone"].Value;
+        if (fraction.Length == 10 && zone.Length == 0)
+        {
+            fraction = fraction[..8];
+        }
+        else if (fraction.Length > 8)
+        {
+            return false;
+        }
+
+        bool endOfDay = isoDate.Groups["hour"].Value == "24";
+        if (endOfDay &&
+            (isoDate.Groups["minute"].Value != "00" ||
+             isoDate.Groups["second"].Value != "00" ||
+             fraction.Any(character => character != '.' && character != '0')))
+        {
+            return false;
+        }
+
+        string hour = endOfDay ? "00" : isoDate.Groups["hour"].Value;
+        Match offset = Regex.Match(zone, @"^(?<sign>[+-])(?<hours>\d{2}):(?<minutes>\d{2})$");
+        if (offset.Success &&
+            int.Parse(offset.Groups["hours"].Value, CultureInfo.InvariantCulture) > 14)
+        {
+            if (!DateTime.TryParseExact(
+                $"{isoDate.Groups["date"].Value}T{hour}:{isoDate.Groups["minute"].Value}:{isoDate.Groups["second"].Value}{fraction}",
+                ["yyyy-MM-ddTHH:mm:ss.FFFFFFF", "yyyy-MM-ddTHH:mm:ss"],
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out DateTime localDate))
+            {
+                return false;
+            }
+
+            int offsetMinutes =
+                int.Parse(offset.Groups["hours"].Value, CultureInfo.InvariantCulture) * 60 +
+                int.Parse(offset.Groups["minutes"].Value, CultureInfo.InvariantCulture);
+            if (offset.Groups["sign"].Value == "-")
+            {
+                offsetMinutes = -offsetMinutes;
+            }
+            date = DateTime.SpecifyKind(localDate.AddMinutes(-offsetMinutes), DateTimeKind.Utc)
+                .ToLocalTime();
+        }
+        else if (!DateTime.TryParseExact(
+            $"{isoDate.Groups["date"].Value}T{hour}:{isoDate.Groups["minute"].Value}:{isoDate.Groups["second"].Value}{fraction}{zone}",
+            ["yyyy-MM-ddTHH:mm:ss.FFFFFFFK", "yyyy-MM-ddTHH:mm:ssK"],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out date))
+        {
+            return false;
+        }
+
+        if (endOfDay)
+        {
+            date = date.AddDays(1);
+        }
+        return true;
+    }
+
+    private static JsonNode? CreateNode(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.Object => CreateObject(value),
+            JsonValueKind.Array => new JsonArray(value.EnumerateArray().Select(CreateNode).ToArray()),
+            JsonValueKind.String => JsonValue.Create(value.GetString()),
+            JsonValueKind.Number => JsonNode.Parse(value.GetRawText()),
+            JsonValueKind.True => JsonValue.Create(true),
+            JsonValueKind.False => JsonValue.Create(false),
+            JsonValueKind.Null => null,
+            _ => throw new JsonException($"Unexpected JSON value kind '{value.ValueKind}'.")
+        };
+
+    private static JsonObject CreateObject(JsonElement value)
+    {
+        JsonObject result = [];
+        foreach (JsonProperty property in GetLastProperties(value))
+        {
+            result[property.Name] = CreateNode(property.Value);
+        }
+        return result;
+    }
+
+    private static JsonNode? CreateMergedNode(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.Object => CreateMergedObject(value),
+            JsonValueKind.Array => new JsonArray(
+                value.EnumerateArray().Select(CreateMergedNode).ToArray()),
+            JsonValueKind.String => JsonValue.Create(value.GetString()),
+            JsonValueKind.Number => JsonNode.Parse(value.GetRawText()),
+            JsonValueKind.True => JsonValue.Create(true),
+            JsonValueKind.False => JsonValue.Create(false),
+            JsonValueKind.Null => null,
+            _ => throw new JsonException($"Unexpected JSON value kind '{value.ValueKind}'.")
+        };
+
+    private static JsonObject CreateMergedObject(JsonElement value)
+    {
+        JsonObject result = [];
+        foreach (JsonProperty property in value.EnumerateObject())
+        {
+            JsonNode? propertyValue = CreateMergedNode(property.Value);
+            string? existingName = result
+                .Select(item => item.Key)
+                .FirstOrDefault(name =>
+                    string.Equals(name, property.Name, StringComparison.OrdinalIgnoreCase));
+            if (existingName is not null &&
+                result[existingName] is JsonObject existingObject &&
+                propertyValue is JsonObject newObject)
+            {
+                MergeObjects(existingObject, newObject);
+            }
+            else
+            {
+                if (existingName is not null)
+                {
+                    result.Remove(existingName);
+                }
+                result[property.Name] = propertyValue;
+            }
+        }
+        return result;
+    }
+
+    private static void MergeObjects(JsonObject target, JsonObject source)
+    {
+        foreach ((string name, JsonNode? value) in source.ToArray())
+        {
+            string? targetName = target
+                .Select(item => item.Key)
+                .FirstOrDefault(existingName =>
+                    string.Equals(existingName, name, StringComparison.OrdinalIgnoreCase));
+            if (targetName is not null &&
+                target[targetName] is JsonObject targetObject &&
+                value is JsonObject sourceObject)
+            {
+                MergeObjects(targetObject, sourceObject);
+            }
+            else
+            {
+                if (targetName is not null)
+                {
+                    target.Remove(targetName);
+                }
+                target[name] = value?.DeepClone();
+            }
+        }
+    }
+
+    private static void AppendIndent(StringBuilder output, int depth) =>
+        output.Append(' ', depth * 2);
+
+    private static string ReplaceInvalidSurrogateEscapes(string json)
+    {
+        StringBuilder result = new(json.Length);
+        for (int i = 0; i < json.Length;)
+        {
+            if (TryGetUnicodeEscape(json, i, out char value))
+            {
+                if (char.IsHighSurrogate(value) &&
+                    TryGetUnicodeEscape(json, i + 6, out char lowSurrogate) &&
+                    char.IsLowSurrogate(lowSurrogate))
+                {
+                    result.Append(json, i, 12);
+                    i += 12;
+                    continue;
+                }
+
+                if (char.IsSurrogate(value))
+                {
+                    result.Append(@"\ufffd");
+                    i += 6;
+                    continue;
+                }
+            }
+
+            result.Append(json[i]);
+            i++;
+        }
+        return result.ToString();
+    }
+
+    private static bool TryGetUnicodeEscape(string json, int index, out char value)
+    {
+        value = default;
+        if (index + 6 > json.Length ||
+            json[index] != '\\' ||
+            json[index + 1] != 'u')
+        {
+            return false;
+        }
+
+        int precedingSlashes = 0;
+        for (int i = index - 1; i >= 0 && json[i] == '\\'; i--)
+        {
+            precedingSlashes++;
+        }
+        if (precedingSlashes % 2 != 0)
+        {
+            return false;
+        }
+
+        bool parsed = ushort.TryParse(
+            json.AsSpan(index + 2, 4),
+            NumberStyles.HexNumber,
+            CultureInfo.InvariantCulture,
+            out ushort scalar);
+        value = (char)scalar;
+        return parsed;
+    }
+
+    private sealed class NewtonsoftCompatibleStringConverter : JsonConverter<string>
+    {
+        public override string? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options) =>
+            reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => GetRawValue(ref reader),
+                JsonTokenType.True => bool.TrueString.ToLowerInvariant(),
+                JsonTokenType.False => bool.FalseString.ToLowerInvariant(),
+                JsonTokenType.Null => null,
+                _ => throw new JsonException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Unexpected token {0} when parsing a string.",
+                        reader.TokenType))
+            };
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            string value,
+            JsonSerializerOptions options) =>
+            writer.WriteStringValue(value);
+
+    }
+
+    private sealed unsafe class NewtonsoftCompatibleJavaScriptEncoder : JavaScriptEncoder
+    {
+        public static readonly NewtonsoftCompatibleJavaScriptEncoder Instance = new();
+
+        public override int MaxOutputCharactersPerInputCharacter => 6;
+
+        public override bool WillEncode(int unicodeScalar) =>
+            unicodeScalar is '"' or '\\' or < 0x20 or 0x85 or 0x2028 or 0x2029 ||
+            unicodeScalar is >= 0xD800 and <= 0xDFFF;
+
+        public override int FindFirstCharacterToEncode(char* text, int textLength)
+        {
+            for (int i = 0; i < textLength; i++)
+            {
+                if (char.IsHighSurrogate(text[i]) &&
+                    i + 1 < textLength &&
+                    char.IsLowSurrogate(text[i + 1]))
+                {
+                    i++;
+                    continue;
+                }
+
+                if (WillEncode(text[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public override bool TryEncodeUnicodeScalar(
+            int unicodeScalar,
+            char* buffer,
+            int bufferLength,
+            out int numberOfCharactersWritten)
+        {
+            string encoded = unicodeScalar switch
+            {
+                '"' => "\\\"",
+                '\\' => "\\\\",
+                '\b' => "\\b",
+                '\f' => "\\f",
+                '\n' => "\\n",
+                '\r' => "\\r",
+                '\t' => "\\t",
+                _ => $"\\u{unicodeScalar:x4}"
+            };
+            if (encoded.Length > bufferLength)
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+
+            encoded.AsSpan().CopyTo(new Span<char>(buffer, bufferLength));
+            numberOfCharactersWritten = encoded.Length;
+            return true;
+        }
+    }
+
+    private sealed class NewtonsoftCompatibleCamelCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+        {
+            if (string.IsNullOrEmpty(name) || !char.IsUpper(name[0]))
+            {
+                return name;
+            }
+
+            char[] chars = name.ToCharArray();
+            for (int i = 0; i < chars.Length; i++)
+            {
+                bool hasNext = i + 1 < chars.Length;
+                if (i == 1 && !char.IsUpper(chars[i]))
+                {
+                    break;
+                }
+
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                {
+                    if (char.IsSeparator(chars[i + 1]))
+                    {
+                        chars[i] = char.ToLowerInvariant(chars[i]);
+                    }
+                    break;
+                }
+
+                chars[i] = char.ToLowerInvariant(chars[i]);
+            }
+            return new string(chars);
+        }
+    }
+
+    private static string GetRawValue(ref Utf8JsonReader reader) =>
+        reader.HasValueSequence
+            ? Encoding.UTF8.GetString(reader.ValueSequence.ToArray())
+            : Encoding.UTF8.GetString(reader.ValueSpan);
 }

--- a/src/Valleysoft.Dredge/LinuxOsInfo.cs
+++ b/src/Valleysoft.Dredge/LinuxOsInfo.cs
@@ -1,58 +1,58 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.Dredge;
 
 public record LinuxOsInfo
 {
-    [JsonProperty("PRETTY_NAME")]
+    [JsonPropertyName("PRETTY_NAME")]
     public string? PrettyName { get; private set; }
 
-    [JsonProperty("NAME")]
+    [JsonPropertyName("NAME")]
     public string? Name { get; private set; }
 
-    [JsonProperty("ID")]
+    [JsonPropertyName("ID")]
     public string? Id { get; private set; }
 
-    [JsonProperty("ID_LIKE")]
+    [JsonPropertyName("ID_LIKE")]
     public string[]? IdLike { get; private set; }
 
-    [JsonProperty("VERSION")]
+    [JsonPropertyName("VERSION")]
     public string? Version { get; private set; }
 
-    [JsonProperty("VERSION_ID")]
+    [JsonPropertyName("VERSION_ID")]
     public string? VersionId { get; private set; }
 
-    [JsonProperty("VERSION_CODENAME")]
+    [JsonPropertyName("VERSION_CODENAME")]
     public string? VersionCodeName { get; private set; }
 
-    [JsonProperty("BUILD_ID")]
+    [JsonPropertyName("BUILD_ID")]
     public string? BuildId { get; private set; }
 
-    [JsonProperty("IMAGE_ID")]
+    [JsonPropertyName("IMAGE_ID")]
     public string? ImageId { get; private set; }
 
-    [JsonProperty("IMAGE_VERSION")]
+    [JsonPropertyName("IMAGE_VERSION")]
     public string? ImageVersion { get; private set; }
 
-    [JsonProperty("VARIANT")]
+    [JsonPropertyName("VARIANT")]
     public string? Variant { get; private set; }
 
-    [JsonProperty("VARIANT_ID")]
+    [JsonPropertyName("VARIANT_ID")]
     public string? VariantId { get; private set; }
 
-    [JsonProperty("HOME_URL")]
+    [JsonPropertyName("HOME_URL")]
     public string? HomeUrl { get; private set; }
 
-    [JsonProperty("SUPPORT_URL")]
+    [JsonPropertyName("SUPPORT_URL")]
     public string? SupportUrl { get; private set; }
 
-    [JsonProperty("BUG_REPORT_URL")]
+    [JsonPropertyName("BUG_REPORT_URL")]
     public string? BugReportUrl { get; private set; }
 
-    [JsonProperty("PRIVACY_POLICY_URL")]
+    [JsonPropertyName("PRIVACY_POLICY_URL")]
     public string? PrivacyPolicyUrl { get; private set; }
 
-    [JsonProperty("CPE_NAME")]
+    [JsonPropertyName("CPE_NAME")]
     public string? CpeName { get; private set; }
 
     public static LinuxOsInfo Parse(string osInfoContent)

--- a/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
+++ b/src/Valleysoft.Dredge/Valleysoft.Dredge.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>dredge</AssemblyName>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -42,7 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/Valleysoft.Dredge/WindowsOsInfo.cs
+++ b/src/Valleysoft.Dredge/WindowsOsInfo.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System.Runtime.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Valleysoft.Dredge;
 
@@ -17,18 +15,18 @@ public record WindowsOsInfo
     public string? Version { get; private set; }
 }
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<WindowsType>))]
 public enum WindowsType
 {
-    [EnumMember(Value = "Nano Server")]
+    [JsonStringEnumMemberName("Nano Server")]
     NanoServer,
 
-    [EnumMember(Value = "Server Core")]
+    [JsonStringEnumMemberName("Server Core")]
     ServerCore,
 
-    [EnumMember(Value = "Server")]
+    [JsonStringEnumMemberName("Server")]
     Server,
 
-    [EnumMember(Value = "Windows")]
+    [JsonStringEnumMemberName("Windows")]
     Windows
 }


### PR DESCRIPTION
## Summary

Replace Newtonsoft.Json with System.Text.Json to remove the redundant JSON dependency while preserving Dredge's existing serialized behavior and CLI output.

- Migrate settings, command output, model attributes, enum converters, source generation, and metadata comparison to System.Text.Json.
- Add a focused compatibility layer for Newtonsoft-equivalent naming, escaping, scalar coercion, duplicate properties, date and number normalization, and metadata equality.
- Add characterization coverage for settings and every affected output boundary.

## Compatibility

An isolated old-versus-new differential harness compared 25,807 cases on each of .NET 9 and .NET 10 with zero output or behavior differences in the supported JSON surface. The full test suite passes 936 tests across both target frameworks.

Exact parser exception text and Newtonsoft-only nonstandard JSON syntax are not reproduced.