### PR TITLE
Add comprehensive container integration tests

### DIFF
--- a/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
+++ b/src/Valleysoft.Dredge.Tests/AppSettingsTests.cs
@@ -5,6 +5,30 @@ using Newtonsoft.Json;
 public class AppSettingsTests
 {
     [Fact]
+    public async Task Load_WhenSettingsJsonIsMalformedThrows()
+    {
+        string settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-invalid-settings-{Guid.NewGuid():N}",
+            "settings.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+        await File.WriteAllTextAsync(
+            settingsPath,
+            "{ invalid json",
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            Assert.Throws<Newtonsoft.Json.JsonReaderException>(
+                () => AppSettings.Load(settingsPath));
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(settingsPath)!, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task ConcurrentLoadCreatesValidSettingsFile()
     {
         string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+
+namespace Valleysoft.Dredge.Tests;
+
+public sealed class CliProcessTests
+{
+    [Fact]
+    public async Task Help_ListsTopLevelCommands()
+    {
+        ProcessResult result = await InvokeDredgeProcessAsync("--help");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("image", result.StandardOutput);
+        Assert.Contains("manifest", result.StandardOutput);
+        Assert.Contains("referrer", result.StandardOutput);
+        Assert.Contains("settings", result.StandardOutput);
+    }
+
+    [Fact]
+    public async Task UnknownCommand_ReturnsParseFailure()
+    {
+        ProcessResult result = await InvokeDredgeProcessAsync("not-a-command");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("not-a-command", result.StandardError);
+    }
+
+    private static async Task<ProcessResult> InvokeDredgeProcessAsync(params string[] args)
+    {
+        ProcessStartInfo startInfo = new("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(GetDredgeAssemblyPath());
+        foreach (string arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using Process process = Process.Start(startInfo)!;
+        Task<string> standardOutput = process.StandardOutput.ReadToEndAsync(
+            TestContext.Current.CancellationToken);
+        Task<string> standardError = process.StandardError.ReadToEndAsync(
+            TestContext.Current.CancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw;
+        }
+
+        return new(process.ExitCode, await standardOutput, await standardError);
+    }
+
+    private static string GetDredgeAssemblyPath()
+    {
+        DirectoryInfo targetFrameworkDirectory = new(AppContext.BaseDirectory);
+        string targetFramework = targetFrameworkDirectory.Name;
+        DirectoryInfo configurationDirectory = targetFrameworkDirectory.Parent!;
+        string configuration = configurationDirectory.Name;
+        DirectoryInfo testProjectDirectory = configurationDirectory.Parent!.Parent!;
+        string path = Path.Combine(
+            testProjectDirectory.Parent!.FullName,
+            "Valleysoft.Dredge",
+            "bin",
+            configuration,
+            targetFramework,
+            "dredge.dll");
+        Assert.True(File.Exists(path), $"Dredge assembly was not found at '{path}'.");
+        return path;
+    }
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError);
+}

--- a/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareMetadataCommandTests.cs
@@ -404,11 +404,14 @@ public class CompareMetadataCommandTests
         factory
             .Setup(clientFactory => clientFactory.GetClientAsync(Registry))
             .ReturnsAsync(client.Object);
+        AppSettings settings = (AppSettings)Activator.CreateInstance(
+            typeof(AppSettings),
+            nonPublic: true)!;
 
         CompareMetadataCommand command = new(
             factory.Object,
             CreateConsole(ansiSupported, outputWriter),
-            () => new PlatformSettings());
+            new TestAppSettingsStore(settings));
         command.Options.BaseImage = baseImageName.ToString();
         command.Options.TargetImage = targetImageName.ToString();
         command.Options.OutputFormat = output;

--- a/src/Valleysoft.Dredge.Tests/ImageCommandIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageCommandIntegrationTests.cs
@@ -1,0 +1,466 @@
+using Newtonsoft.Json.Linq;
+using Spectre.Console;
+using System.CommandLine;
+using System.Text;
+using Valleysoft.Dredge.Commands.Image;
+
+namespace Valleysoft.Dredge.Tests;
+
+internal sealed class ImageCommandIntegrationScenarios
+{
+    private readonly RegistryFixture fixture;
+
+    public ImageCommandIntegrationScenarios(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    public async Task FileSystemCommands_ReadAndExtractLiveImageLayers()
+    {
+        ImageSeed image = await SeedFileSystemImageAsync(
+            nameof(FileSystemCommands_ReadAndExtractLiveImageLayers));
+        string imageName = $"{fixture.Registry}/{image.Repository}:{image.Reference}";
+        IDockerRegistryClientFactory factory = fixture.CreateClientFactory();
+        string tempRoot = GetTempPath();
+        IDredgePathProvider pathProvider = new TestDredgePathProvider(tempRoot);
+
+        try
+        {
+            using MemoryStream catOutput = new();
+            int catExitCode = await InvokeAsync(
+                new CatCommand(factory, catOutput),
+                imageName,
+                "app/value");
+
+            StringWriter listOutput = new();
+            int listExitCode = await InvokeAsync(
+                new LsCommand(factory, CreateConsole(listOutput)),
+                imageName,
+                "--recursive",
+                "--show-deleted",
+                "--output",
+                "json");
+
+            string extractPath = Path.Combine(tempRoot, "extract");
+            string savePath = Path.Combine(tempRoot, "save");
+            string firstLayerPath = Path.Combine(tempRoot, "first-layer");
+            string separateLayersPath = Path.Combine(tempRoot, "separate-layers");
+            string selectedSeparateLayerPath = Path.Combine(tempRoot, "selected-separate-layer");
+            int extractExitCode = await InvokeAsync(
+                new ExtractCommand(factory),
+                imageName,
+                "app",
+                extractPath);
+            int saveExitCode = await InvokeAsync(
+                new SaveLayersCommand(factory, pathProvider),
+                imageName,
+                savePath);
+            int firstLayerExitCode = await InvokeAsync(
+                new SaveLayersCommand(factory, pathProvider),
+                imageName,
+                firstLayerPath,
+                "--layer-index",
+                "0");
+            int separateLayersExitCode = await InvokeAsync(
+                new SaveLayersCommand(factory, pathProvider),
+                imageName,
+                separateLayersPath,
+                "--no-squash");
+            int selectedSeparateLayerExitCode = await InvokeAsync(
+                new SaveLayersCommand(factory, pathProvider),
+                imageName,
+                selectedSeparateLayerPath,
+                "--no-squash",
+                "--layer-index",
+                "1");
+
+            Assert.Equal(0, extractExitCode);
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(extractPath, "value"),
+                TestContext.Current.CancellationToken));
+            Assert.False(File.Exists(Path.Combine(extractPath, "removed")));
+            Assert.Equal(0, saveExitCode);
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(savePath, "app", "value"),
+                TestContext.Current.CancellationToken));
+            Assert.False(File.Exists(Path.Combine(savePath, "app", "removed")));
+            Assert.Equal(0, firstLayerExitCode);
+            Assert.Equal("old", await File.ReadAllTextAsync(
+                Path.Combine(firstLayerPath, "app", "value"),
+                TestContext.Current.CancellationToken));
+            Assert.Equal("remove me", await File.ReadAllTextAsync(
+                Path.Combine(firstLayerPath, "app", "removed"),
+                TestContext.Current.CancellationToken));
+            Assert.Equal(0, separateLayersExitCode);
+            string[] layerDirectories = Directory.GetDirectories(separateLayersPath);
+            Assert.Equal(2, layerDirectories.Length);
+            string firstLayerDirectory = Assert.Single(
+                layerDirectories,
+                path => Path.GetFileName(path).StartsWith("layer0-", StringComparison.Ordinal));
+            string secondLayerDirectory = Assert.Single(
+                layerDirectories,
+                path => Path.GetFileName(path).StartsWith("layer1-", StringComparison.Ordinal));
+            Assert.Equal("old", await File.ReadAllTextAsync(
+                Path.Combine(firstLayerDirectory, "app", "value"),
+                TestContext.Current.CancellationToken));
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(secondLayerDirectory, "app", "value"),
+                TestContext.Current.CancellationToken));
+            Assert.True(File.Exists(Path.Combine(secondLayerDirectory, "app", ".wh.removed")));
+            Assert.Equal(0, selectedSeparateLayerExitCode);
+            string selectedLayerDirectory = Assert.Single(
+                Directory.GetDirectories(selectedSeparateLayerPath));
+            Assert.StartsWith(
+                "layer1-",
+                Path.GetFileName(selectedLayerDirectory),
+                StringComparison.Ordinal);
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(selectedLayerDirectory, "app", "value"),
+                TestContext.Current.CancellationToken));
+            Assert.True(File.Exists(Path.Combine(selectedLayerDirectory, "app", ".wh.removed")));
+
+            Assert.Equal(0, catExitCode);
+            Assert.Equal("new", Encoding.UTF8.GetString(catOutput.ToArray()));
+            Assert.Equal(0, listExitCode);
+            JArray entries = JArray.Parse(listOutput.ToString());
+            Assert.Contains(entries, entry =>
+                (string?)entry["path"] == "app/value" &&
+                (int?)entry["modifiedLayer"]?["index"] == 1);
+            Assert.Contains(entries, entry =>
+                (string?)entry["path"] == "app/removed" &&
+                (int?)entry["deletedLayer"]?["index"] == 1);
+        }
+        finally
+        {
+            DeleteDirectory(tempRoot);
+        }
+    }
+
+    public async Task InspectionCommands_ReadLiveImageMetadata()
+    {
+        string repository = fixture.GetRepositoryName(
+            nameof(InspectionCommands_ReadLiveImageMetadata));
+        LayerSeed layer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File(
+                "etc/os-release",
+                """
+                NAME="Integration Linux"
+                VERSION="1.0"
+                ID=integration
+                PRETTY_NAME="Integration Linux 1.0"
+                """));
+        object[] history =
+        [
+            new { created_by = "/bin/sh -c #(nop) ADD file:abc in /", empty_layer = false },
+            new { created_by = "/bin/sh -c echo hello", empty_layer = true }
+        ];
+        ImageSeed image = await fixture.PutImageAsync(
+            repository,
+            "latest",
+            [layer],
+            history: history);
+        string imageName = $"{fixture.Registry}/{repository}:latest";
+        IDockerRegistryClientFactory factory = fixture.CreateClientFactory();
+
+        using StringWriter inspectOutput = new();
+        int inspectExitCode = await InvokeAsync(
+            new InspectCommand(factory, inspectOutput),
+            imageName);
+
+        using StringWriter osOutput = new();
+        int osExitCode = await InvokeAsync(
+            new OsCommand(factory, osOutput),
+            imageName);
+
+        using StringWriter dockerfileOutput = new();
+        int dockerfileExitCode = await InvokeAsync(
+            new DockerfileCommand(factory, CreateConsole(dockerfileOutput)),
+            imageName,
+            "--no-color");
+        string dockerfile = dockerfileOutput.ToString();
+
+        Assert.Equal(0, inspectExitCode);
+        JObject config = JObject.Parse(inspectOutput.ToString());
+        Assert.Equal("amd64", (string?)config["architecture"]);
+        Assert.Equal("linux", (string?)config["os"]);
+        Assert.Equal(layer.DiffId, (string?)config["rootfs"]?["diff_ids"]?[0]);
+        Assert.Equal(0, osExitCode);
+        JObject os = JObject.Parse(osOutput.ToString());
+        Assert.Equal("Integration Linux", (string?)os.GetValue("name", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("1.0", (string?)os.GetValue("version", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, dockerfileExitCode);
+        Assert.Contains("FROM scratch", dockerfile);
+        Assert.Contains("ADD file:abc /", dockerfile);
+        Assert.Contains("RUN echo hello", dockerfile);
+    }
+
+    public async Task CompareCommands_UseLiveLayerAndConfigurationData()
+    {
+        string repository = fixture.GetRepositoryName(
+            nameof(CompareCommands_UseLiveLayerAndConfigurationData));
+        LayerSeed common = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("common", "same"));
+        LayerSeed changed = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("changed", "target"));
+        ImageSeed baseImage = await fixture.PutImageAsync(
+            repository,
+            "base",
+            [common],
+            config: new
+            {
+                Env = new[] { "VALUE=base" },
+                Labels = new Dictionary<string, string> { ["shared"] = "yes" }
+            });
+        ImageSeed targetImage = await fixture.PutImageAsync(
+            repository,
+            "target",
+            [common, changed],
+            config: new
+            {
+                Env = new[] { "VALUE=target", "ADDED=true" },
+                Labels = new Dictionary<string, string> { ["shared"] = "yes" }
+            });
+        string baseName = $"{fixture.Registry}/{repository}:{baseImage.Reference}";
+        string targetName = $"{fixture.Registry}/{repository}:{targetImage.Reference}";
+        IDockerRegistryClientFactory factory = fixture.CreateClientFactory();
+
+        StringWriter layerOutput = new();
+        int layerExitCode = await InvokeAsync(
+            new CompareLayersCommand(factory, CreateConsole(layerOutput)),
+            baseName,
+            targetName,
+            "--output",
+            "json",
+            "--history",
+            "--compressed-size");
+
+        StringWriter metadataOutput = new();
+        string settingsRoot = GetTempPath();
+        int metadataExitCode;
+        try
+        {
+            metadataExitCode = await InvokeAsync(
+                new CompareMetadataCommand(
+                    factory,
+                    CreateConsole(metadataOutput),
+                    new AppSettingsStore(Path.Combine(settingsRoot, "settings.json"))),
+                baseName,
+                targetName,
+                "--output",
+                "json");
+        }
+        finally
+        {
+            DeleteDirectory(settingsRoot);
+        }
+
+        Assert.Equal(0, layerExitCode);
+        JObject layers = JObject.Parse(layerOutput.ToString());
+        Assert.False((bool)layers["summary"]!["areEqual"]!);
+        Assert.True((bool)layers["summary"]!["targetIncludesAllBaseLayers"]!);
+        Assert.Equal("added", (string?)layers["layerComparisons"]?[1]?["layerDiff"]);
+        Assert.Equal(0, metadataExitCode);
+        JObject metadata = JObject.Parse(metadataOutput.ToString());
+        Assert.False((bool)metadata["summary"]!["areEqual"]!);
+        Assert.Contains(
+            metadata["comparisons"]!,
+            comparison => (string?)comparison["path"] == "environment[\"VALUE\"]");
+        Assert.Contains(
+            metadata["comparisons"]!,
+            comparison => (string?)comparison["path"] == "environment[\"ADDED\"]");
+    }
+
+    public async Task CompareFilesCommand_ExtractsLiveImagesForConfiguredTool()
+    {
+        string repository = fixture.GetRepositoryName(
+            nameof(CompareFilesCommand_ExtractsLiveImagesForConfiguredTool));
+        LayerSeed baseLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("value", "base-initial"));
+        LayerSeed baseUpdateLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("value", "base-final"));
+        LayerSeed targetLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("value", "target-initial"));
+        LayerSeed targetUpdateLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("value", "target-final"));
+        await fixture.PutImageAsync(repository, "base", [baseLayer, baseUpdateLayer]);
+        await fixture.PutImageAsync(repository, "target", [targetLayer, targetUpdateLayer]);
+
+        string tempRoot = GetTempPath();
+        string settingsPath = Path.Combine(tempRoot, "settings.json");
+        string comparePath = Path.Combine(tempRoot, "compare");
+        AppSettings settings = AppSettings.Load(settingsPath);
+        settings.FileCompareTool.ExePath = "comparison-tool";
+        settings.FileCompareTool.Args = "\"{0}\" \"{1}\"";
+        settings.Save();
+        string? launchedFile = null;
+        string? launchedArguments = null;
+        string? baseContent = null;
+        string? targetContent = null;
+        TestProcessLauncher processLauncher = new();
+        CompareFilesCommand command = new(
+            fixture.CreateClientFactory(),
+            new AppSettingsStore(settingsPath),
+            new TestDredgePathProvider(tempRoot),
+            processLauncher);
+
+        try
+        {
+            int exitCode = await InvokeAsync(
+                command,
+                $"{fixture.Registry}/{repository}:base",
+                $"{fixture.Registry}/{repository}:target",
+                "--base-layer-index",
+                "0",
+                "--target-layer-index",
+                "0");
+
+            Assert.Equal(0, exitCode);
+            launchedFile = processLauncher.StartInfo?.FileName;
+            launchedArguments = processLauncher.StartInfo?.Arguments;
+            baseContent = File.ReadAllText(Path.Combine(comparePath, "base", "value"));
+            targetContent = File.ReadAllText(Path.Combine(comparePath, "target", "value"));
+            Assert.Equal("comparison-tool", launchedFile);
+            Assert.Contains(Path.Combine(comparePath, "base"), launchedArguments);
+            Assert.Contains(Path.Combine(comparePath, "target"), launchedArguments);
+            Assert.Equal("base-initial", baseContent);
+            Assert.Equal("target-initial", targetContent);
+        }
+        finally
+        {
+            DeleteDirectory(tempRoot);
+        }
+    }
+
+    private async Task<ImageSeed> SeedFileSystemImageAsync(string testName)
+    {
+        string repository = fixture.GetRepositoryName(testName);
+        LayerSeed baseLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("app/value", "old"),
+            LayerEntry.File("app/removed", "remove me"));
+        LayerSeed updateLayer = await fixture.UploadLayerAsync(
+            repository,
+            LayerEntry.File("app/value", "new"),
+            LayerEntry.File("app/.wh.removed", string.Empty));
+        return await fixture.PutImageAsync(repository, "latest", [baseLayer, updateLayer]);
+    }
+
+    private static IAnsiConsole CreateConsole(TextWriter output) =>
+        AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output)
+        });
+
+    private static Task<int> InvokeAsync(Command command, params string[] args) =>
+        InvokeCoreAsync(command, args);
+
+    private static Task<int> InvokeCoreAsync(Command command, string[] args)
+    {
+        if (command is IProcessTerminationAware terminationAware)
+        {
+            terminationAware.ProcessTerminator = new TestProcessTerminator();
+        }
+
+        return command
+            .Parse(args)
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+    }
+
+    private static string GetTempPath() =>
+        Path.Combine(Path.GetTempPath(), $"dredge-integration-{Guid.NewGuid():N}");
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ImageFileSystemCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ImageFileSystemCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task FileSystemCommands_ReadAndExtractLiveImageLayers()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new ImageCommandIntegrationScenarios(fixture)
+            .FileSystemCommands_ReadAndExtractLiveImageLayers();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ImageInspectionCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ImageInspectionCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task InspectionCommands_ReadLiveImageMetadata()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new ImageCommandIntegrationScenarios(fixture)
+            .InspectionCommands_ReadLiveImageMetadata();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ImageComparisonCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ImageComparisonCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CompareCommands_UseLiveLayerAndConfigurationData()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new ImageCommandIntegrationScenarios(fixture)
+            .CompareCommands_UseLiveLayerAndConfigurationData();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ImageCompareFilesCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ImageCompareFilesCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CompareFilesCommand_ExtractsLiveImagesForConfiguredTool()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new ImageCommandIntegrationScenarios(fixture)
+            .CompareFilesCommand_ExtractsLiveImagesForConfiguredTool();
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
@@ -94,6 +94,88 @@ public class ImageHelperTests
         }
     }
 
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_ConcurrentCallsPublishSameLayerAtomically()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"dredge-concurrent-cache-{id}");
+        string firstOutput = Path.Combine(tempRoot, "first-output");
+        string secondOutput = Path.Combine(tempRoot, "second-output");
+        string layersPath = Path.Combine(tempRoot, "layers");
+        TaskCompletionSource bothDownloadsStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int downloadCount = 0;
+        Mock<IDockerRegistryClient> client = CreateSingleLayerClient(
+            digest,
+            () => CreateLayer(("file.txt", "content")));
+        client
+            .Setup(o => o.Blobs.GetAsync(
+                "library/image",
+                digest,
+                It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                if (Interlocked.Increment(ref downloadCount) == 2)
+                {
+                    bothDownloadsStarted.SetResult();
+                }
+                await bothDownloadsStarted.Task.WaitAsync(
+                    TestContext.Current.CancellationToken);
+                return CreateLayer(("file.txt", "content"));
+            });
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+        TestDredgePathProvider pathProvider = new(tempRoot);
+
+        try
+        {
+            Task first = ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                firstOutput,
+                layerIndex: null,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken,
+                pathProvider);
+            Task second = ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                secondOutput,
+                layerIndex: null,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken,
+                pathProvider);
+
+            await Task.WhenAll(first, second);
+
+            Assert.Equal(2, downloadCount);
+            Assert.Equal(
+                "content",
+                await File.ReadAllTextAsync(
+                    Path.Combine(firstOutput, "file.txt"),
+                    TestContext.Current.CancellationToken));
+            Assert.Equal(
+                "content",
+                await File.ReadAllTextAsync(
+                    Path.Combine(secondOutput, "file.txt"),
+                    TestContext.Current.CancellationToken));
+            Assert.True(Directory.Exists(Path.Combine(layersPath, id)));
+            Assert.Empty(Directory.EnumerateDirectories(layersPath, "*.tmp"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(2)]

--- a/src/Valleysoft.Dredge.Tests/InjectedDependencyCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/InjectedDependencyCommandTests.cs
@@ -1,0 +1,63 @@
+using System.CommandLine;
+using Valleysoft.Dredge.Commands;
+using Valleysoft.Dredge.Commands.Image;
+
+namespace Valleysoft.Dredge.Tests;
+
+public sealed class InjectedDependencyCommandTests
+{
+    [Fact]
+    public async Task CompareFilesCommand_WhenToolIsNotConfiguredDoesNotAccessRegistryOrLaunchProcess()
+    {
+        string tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-compare-files-{Guid.NewGuid():N}");
+        string settingsPath = Path.Combine(tempRoot, "settings.json");
+        Mock<IDockerRegistryClientFactory> clientFactory = new(MockBehavior.Strict);
+        TestProcessLauncher processLauncher = new();
+        TestCompareFilesCommand command = new(
+            clientFactory.Object,
+            new AppSettingsStore(settingsPath),
+            new TestDredgePathProvider(tempRoot),
+            processLauncher);
+        RecordingProcessTerminator processTerminator = new();
+        ((IProcessTerminationAware)command).ProcessTerminator = processTerminator;
+
+        try
+        {
+            await command
+                .Parse(["registry.example/base:latest", "registry.example/target:latest"])
+                .InvokeAsync(
+                    new InvocationConfiguration(),
+                    TestContext.Current.CancellationToken);
+
+            Assert.Equal(1, processTerminator.ExitCode);
+            Assert.Contains(settingsPath, command.ErrorOutput.ToString());
+            Assert.Null(processLauncher.StartInfo);
+            clientFactory.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestCompareFilesCommand : CompareFilesCommand
+    {
+        public TestCompareFilesCommand(
+            IDockerRegistryClientFactory dockerRegistryClientFactory,
+            IAppSettingsStore settingsStore,
+            IDredgePathProvider pathProvider,
+            IProcessLauncher processLauncher)
+            : base(dockerRegistryClientFactory, settingsStore, pathProvider, processLauncher)
+        {
+        }
+
+        public StringWriter ErrorOutput { get; } = new();
+
+        protected override TextWriter Error => ErrorOutput;
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/ManifestHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ManifestHelperTests.cs
@@ -71,7 +71,7 @@ public class ManifestHelperTests
                 Os = "linux",
                 OsVersion = "1"
             },
-            settings);
+            settingsStore: new TestAppSettingsStore(settings));
 
         Assert.Same(resolvedManifest, result.Manifest);
         Assert.Equal("sha256:arm64", result.ManifestInfo.DockerContentDigest);

--- a/src/Valleysoft.Dredge.Tests/RegistryAuthenticationIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryAuthenticationIntegrationTests.cs
@@ -1,0 +1,73 @@
+using System.Security.Authentication;
+using Valleysoft.DockerRegistryClient;
+using Valleysoft.DockerRegistryClient.Models;
+
+namespace Valleysoft.Dredge.Tests;
+
+[Trait("Category", "Integration")]
+public sealed class RegistryAuthenticationIntegrationTests
+{
+    private readonly AuthenticatedRegistryFixture fixture;
+
+    public RegistryAuthenticationIntegrationTests(AuthenticatedRegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ProductionFactory_AuthenticatesToLiveRegistryWithEnvironmentCredentials()
+    {
+        await fixture.EnsureInitializedAsync();
+        DictionaryEnvironmentVariableProvider environment = new(
+            new Dictionary<string, string>
+            {
+                ["DREDGE_USERNAME"] = AuthenticatedRegistryFixture.Username,
+                ["DREDGE_PASSWORD"] = AuthenticatedRegistryFixture.Password
+            });
+        DockerRegistryClientFactory factory = new(environment);
+
+        using IDockerRegistryClient client =
+            await factory.GetClientAsync(fixture.BaseUri.AbsoluteUri);
+        Page<Catalog> catalog = await client.Catalog.GetAsync(
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Empty(catalog.Value.RepositoryNames);
+        Assert.Equal(
+            ["DREDGE_TOKEN", "DREDGE_USERNAME", "DREDGE_PASSWORD"],
+            environment.RequestedVariables);
+    }
+
+    [Fact]
+    public async Task ProductionFactory_WithInvalidCredentialsIsRejectedByLiveRegistry()
+    {
+        await fixture.EnsureInitializedAsync();
+        DictionaryEnvironmentVariableProvider environment = new(
+            new Dictionary<string, string>
+            {
+                ["DREDGE_USERNAME"] = AuthenticatedRegistryFixture.Username,
+                ["DREDGE_PASSWORD"] = "wrong-password"
+            });
+        DockerRegistryClientFactory factory = new(environment);
+
+        using IDockerRegistryClient client =
+            await factory.GetClientAsync(fixture.BaseUri.AbsoluteUri);
+
+        await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.Catalog.GetAsync(
+                null,
+                TestContext.Current.CancellationToken));
+    }
+
+    private sealed class DictionaryEnvironmentVariableProvider(
+        IReadOnlyDictionary<string, string> variables) : IEnvironmentVariableProvider
+    {
+        public List<string> RequestedVariables { get; } = [];
+
+        public string? GetVariable(string name)
+        {
+            RequestedVariables.Add(name);
+            return variables.GetValueOrDefault(name);
+        }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/RegistryFixture.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryFixture.cs
@@ -1,0 +1,491 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Valleysoft.DockerRegistryClient;
+
+namespace Valleysoft.Dredge.Tests;
+
+public class RegistryFixture : IAsyncLifetime
+{
+    protected const ushort RegistryPort = 5000;
+    private readonly Lazy<Task> initialization;
+    private readonly Func<string, Task<RegistryInstance>> registryStarter;
+    private IAsyncDisposable? container;
+    private string? fixtureDirectory;
+
+    public RegistryFixture()
+        : this(StartRegistryContainerAsync)
+    {
+    }
+
+    internal RegistryFixture(Func<string, Task<RegistryInstance>> registryStarter)
+    {
+        this.registryStarter = registryStarter;
+        initialization = new(StartRegistryAsync);
+    }
+
+    public string Registry { get; private set; } = null!;
+    public Uri BaseUri { get; private set; } = null!;
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public Task EnsureInitializedAsync() => initialization.Value;
+
+    private async Task StartRegistryAsync()
+    {
+        fixtureDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-registry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDirectory);
+        string configPath = Path.Combine(fixtureDirectory, "config.json");
+        await File.WriteAllTextAsync(
+            configPath,
+            """
+            {
+              "distSpecVersion": "1.1.1",
+              "storage": {
+                "rootDirectory": "/var/lib/registry"
+              },
+              "http": {
+                "address": "0.0.0.0",
+                "port": "5000"
+              },
+              "log": {
+                "level": "warn"
+              }
+            }
+            """);
+
+        RegistryInstance instance = await registryStarter(configPath);
+        container = instance.Container;
+        Registry = instance.Registry;
+        BaseUri = new Uri($"http://{Registry}/");
+    }
+
+    private static Task<RegistryInstance> StartRegistryContainerAsync(string configPath) =>
+        StartContainerAsync(
+            new ContainerBuilder("registry:3.1.1")
+                .WithPortBinding(RegistryPort, true)
+                .WithWaitStrategy(
+                    Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(
+                        request => request.ForPort(RegistryPort).ForPath("/v2/")))
+                .Build());
+
+    internal static Task<RegistryInstance> StartZotContainerAsync(string configPath) =>
+        StartContainerAsync(
+            new ContainerBuilder("ghcr.io/project-zot/zot:v2.1.18")
+                .WithPortBinding(RegistryPort, true)
+                .WithResourceMapping(configPath, "/etc/zot/")
+                .WithWaitStrategy(
+                    Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(
+                        request => request.ForPort(RegistryPort).ForPath("/v2/")))
+                .Build());
+
+    internal static async Task<RegistryInstance> StartContainerAsync(IContainer container)
+    {
+        try
+        {
+            await container.StartAsync();
+            return new(
+                container,
+                $"{container.Hostname}:{container.GetMappedPublicPort(RegistryPort)}");
+        }
+        catch
+        {
+            await container.DisposeAsync();
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (initialization.IsValueCreated && !initialization.Value.IsCompleted)
+        {
+            await initialization.Value.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+
+        if (container is not null)
+        {
+            await container.DisposeAsync();
+        }
+        if (fixtureDirectory is not null && Directory.Exists(fixtureDirectory))
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    internal sealed record RegistryInstance(
+        IAsyncDisposable Container,
+        string Registry);
+
+    public RegistryClient CreateClient() => new(BaseUri.AbsoluteUri);
+
+    public IDockerRegistryClientFactory CreateClientFactory() =>
+        new RegistryClientFactory(BaseUri);
+
+    public string GetRepositoryName(string testName) =>
+        $"integration/{testName.ToLowerInvariant().Replace('_', '-')}-{Guid.NewGuid():N}";
+
+    public async Task<BlobSeed> UploadBlobAsync(string repository, byte[] content)
+    {
+        string digest = GetDigest(content);
+        using HttpClient client = new() { BaseAddress = BaseUri };
+        using ByteArrayContent requestContent = new(content);
+        requestContent.Headers.ContentType = new("application/octet-stream");
+        using HttpResponseMessage response = await client.PostAsync(
+            $"v2/{repository}/blobs/uploads/?digest={Uri.EscapeDataString(digest)}",
+            requestContent,
+            TestContext.Current.CancellationToken);
+        if (response.StatusCode == System.Net.HttpStatusCode.Accepted)
+        {
+            Uri uploadLocation = response.Headers.Location ??
+                throw new InvalidDataException(
+                    "Registry accepted the blob upload without returning an upload location.");
+            UriBuilder finalLocation = new(new Uri(BaseUri, uploadLocation));
+            string existingQuery = finalLocation.Query.TrimStart('?');
+            string digestQuery = $"digest={Uri.EscapeDataString(digest)}";
+            finalLocation.Query = string.IsNullOrEmpty(existingQuery)
+                ? digestQuery
+                : $"{existingQuery}&{digestQuery}";
+            using ByteArrayContent finalContent = new(content);
+            finalContent.Headers.ContentType = new("application/octet-stream");
+            using HttpResponseMessage finalResponse = await client.PutAsync(
+                finalLocation.Uri,
+                finalContent,
+                TestContext.Current.CancellationToken);
+            finalResponse.EnsureSuccessStatusCode();
+        }
+        else
+        {
+            response.EnsureSuccessStatusCode();
+        }
+        return new BlobSeed(digest, content.LongLength);
+    }
+
+    public async Task<LayerSeed> UploadLayerAsync(
+        string repository,
+        params LayerEntry[] entries)
+    {
+        using MemoryStream tar = new();
+        using (TarWriter writer = new(tar, TarEntryFormat.Pax, leaveOpen: true))
+        {
+            foreach (LayerEntry definition in entries)
+            {
+                PaxTarEntry entry = new(definition.Type, definition.Path)
+                {
+                    Mode = (UnixFileMode)Convert.ToInt32("755", 8),
+                    ModificationTime = DateTimeOffset.FromUnixTimeSeconds(1)
+                };
+                if (definition.LinkTarget is not null)
+                {
+                    entry.LinkName = definition.LinkTarget;
+                }
+                if (definition.Content is not null)
+                {
+                    entry.DataStream = new MemoryStream(definition.Content);
+                }
+                writer.WriteEntry(entry);
+            }
+        }
+
+        byte[] tarBytes = tar.ToArray();
+        using MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            await gzip.WriteAsync(tarBytes, TestContext.Current.CancellationToken);
+        }
+
+        BlobSeed blob = await UploadBlobAsync(repository, compressed.ToArray());
+        string diffId = GetDigest(tarBytes);
+        return new LayerSeed(blob.Digest, blob.Size, diffId);
+    }
+
+    public async Task<ImageSeed> PutImageAsync(
+        string repository,
+        string reference,
+        IReadOnlyList<LayerSeed> layers,
+        string architecture = "amd64",
+        string os = "linux",
+        object? config = null,
+        object[]? history = null)
+    {
+        object imageConfig = new
+        {
+            architecture,
+            os,
+            config = config ?? new
+            {
+                Env = new[] { "APP_ENV=integration" },
+                Labels = new Dictionary<string, string> { ["test"] = "true" }
+            },
+            rootfs = new
+            {
+                type = "layers",
+                diff_ids = layers.Select(layer => layer.DiffId).ToArray()
+            },
+            history = history ?? layers
+                .Select((_, index) => (object)new
+                {
+                    created_by = $"/bin/sh -c echo layer-{index}",
+                    empty_layer = false
+                })
+                .ToArray()
+        };
+        BlobSeed configBlob = await UploadBlobAsync(
+            repository,
+            JsonSerializer.SerializeToUtf8Bytes(imageConfig));
+        object manifest = new
+        {
+            schemaVersion = 2,
+            mediaType = ManifestMediaTypes.OciManifestSchema1,
+            config = new
+            {
+                mediaType = "application/vnd.oci.image.config.v1+json",
+                size = configBlob.Size,
+                digest = configBlob.Digest
+            },
+            layers = layers.Select(layer => new
+            {
+                mediaType = "application/vnd.oci.image.layer.v1.tar+gzip",
+                size = layer.Size,
+                digest = layer.Digest
+            })
+        };
+        ManifestSeed manifestSeed = await PutManifestSeedAsync(
+            repository,
+            reference,
+            ManifestMediaTypes.OciManifestSchema1,
+            manifest);
+        return new ImageSeed(repository, reference, manifestSeed, configBlob, layers);
+    }
+
+    public Task<ManifestSeed> PutIndexAsync(
+        string repository,
+        string reference,
+        params (ImageSeed Image, string Os, string Architecture)[] images) =>
+        PutIndexAsync(
+            repository,
+            reference,
+            images
+                .Select(item => new PlatformImageSeed(
+                    item.Image,
+                    item.Os,
+                    item.Architecture))
+                .ToArray());
+
+    public Task<ManifestSeed> PutIndexAsync(
+        string repository,
+        string reference,
+        params PlatformImageSeed[] images) =>
+        PutManifestSeedAsync(
+            repository,
+            reference,
+            ManifestMediaTypes.OciImageIndex1,
+            new
+            {
+                schemaVersion = 2,
+                mediaType = ManifestMediaTypes.OciImageIndex1,
+                manifests = images.Select(item => new
+                {
+                    mediaType = ManifestMediaTypes.OciManifestSchema1,
+                    size = item.Image.Manifest.Size,
+                    digest = item.Image.Manifest.Digest,
+                    platform = CreatePlatform(item)
+                })
+            });
+
+    private static Dictionary<string, string> CreatePlatform(PlatformImageSeed item)
+    {
+        Dictionary<string, string> platform = new()
+        {
+            ["os"] = item.Os,
+            ["architecture"] = item.Architecture
+        };
+        if (item.OsVersion is not null)
+        {
+            platform["os.version"] = item.OsVersion;
+        }
+        return platform;
+    }
+
+    public async Task<ArtifactSeed> PutArtifactAsync(
+        ImageSeed subject,
+        string reference,
+        string artifactType,
+        string payloadMediaType,
+        byte[] payload)
+    {
+        BlobSeed emptyConfig = await UploadBlobAsync(subject.Repository, Encoding.UTF8.GetBytes("{}"));
+        BlobSeed payloadBlob = await UploadBlobAsync(subject.Repository, payload);
+        object manifest = new
+        {
+            schemaVersion = 2,
+            mediaType = ManifestMediaTypes.OciManifestSchema1,
+            artifactType,
+            config = new
+            {
+                mediaType = "application/vnd.oci.empty.v1+json",
+                size = emptyConfig.Size,
+                digest = emptyConfig.Digest
+            },
+            layers = new[]
+            {
+                new
+                {
+                    mediaType = payloadMediaType,
+                    size = payloadBlob.Size,
+                    digest = payloadBlob.Digest
+                }
+            },
+            subject = new
+            {
+                mediaType = ManifestMediaTypes.OciManifestSchema1,
+                size = subject.Manifest.Size,
+                digest = subject.Manifest.Digest
+            }
+        };
+        ManifestSeed artifact = await PutManifestSeedAsync(
+            subject.Repository,
+            reference,
+            ManifestMediaTypes.OciManifestSchema1,
+            manifest);
+        return new ArtifactSeed(artifact, payloadBlob, artifactType);
+    }
+
+    public async Task<string> PutManifestAsync(string repository, string reference, object manifest)
+    {
+        ManifestSeed seed = await PutManifestSeedAsync(
+            repository,
+            reference,
+            ManifestMediaTypes.OciManifestSchema1,
+            manifest);
+        return seed.Digest;
+    }
+
+    private async Task<ManifestSeed> PutManifestSeedAsync(
+        string repository,
+        string reference,
+        string mediaType,
+        object manifest)
+    {
+        string json = JsonSerializer.Serialize(manifest);
+        using HttpClient client = new() { BaseAddress = BaseUri };
+        using HttpRequestMessage request = new(
+            HttpMethod.Put,
+            $"v2/{repository}/manifests/{reference}")
+        {
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes(json))
+        };
+        request.Content.Headers.ContentType = new(mediaType);
+
+        using HttpResponseMessage response = await client.SendAsync(
+            request,
+            TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return new(
+            response.Headers.GetValues("Docker-Content-Digest").Single(),
+            Encoding.UTF8.GetByteCount(json));
+    }
+
+    private static string GetDigest(byte[] content) =>
+        $"sha256:{Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant()}";
+
+    private sealed class RegistryClientFactory(Uri baseUri) : IDockerRegistryClientFactory
+    {
+        public Task<IDockerRegistryClient> GetClientAsync(string? registry)
+        {
+            Assert.Equal(baseUri.Authority, registry);
+            IDockerRegistryClient client = new DockerRegistryClientWrapper(
+                new RegistryClient(baseUri.AbsoluteUri));
+            return Task.FromResult(client);
+        }
+    }
+}
+
+public sealed class ZotRegistryFixture : RegistryFixture
+{
+    public ZotRegistryFixture()
+        : base(StartZotContainerAsync)
+    {
+    }
+}
+
+public sealed class AuthenticatedRegistryFixture : RegistryFixture
+{
+    public const string Username = "test-user";
+    public const string Password = "test-password";
+
+    public AuthenticatedRegistryFixture()
+        : base(StartAuthenticatedRegistryAsync)
+    {
+    }
+
+    private static async Task<RegistryInstance> StartAuthenticatedRegistryAsync(string configPath)
+    {
+        string authDirectory = Path.GetDirectoryName(configPath)!;
+        string htpasswdPath = Path.Combine(authDirectory, "htpasswd");
+        await File.WriteAllTextAsync(
+            htpasswdPath,
+            $"{Username}:$2b$05$ncBkeU8pzdoTwEBH.amKf.lBLtR4OMYznHTMD/f4iKEBiQnIwhW8m");
+
+        IContainer container = new ContainerBuilder("registry:3.1.1")
+            .WithPortBinding(RegistryPort, true)
+            .WithResourceMapping(htpasswdPath, "/auth/htpasswd")
+            .WithEnvironment("REGISTRY_AUTH", "htpasswd")
+            .WithEnvironment("REGISTRY_AUTH_HTPASSWD_REALM", "Dredge Test Registry")
+            .WithEnvironment("REGISTRY_AUTH_HTPASSWD_PATH", "/auth/htpasswd/htpasswd")
+            .WithWaitStrategy(
+                Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(RegistryPort))
+            .Build();
+        return await StartContainerAsync(container);
+    }
+}
+
+public sealed record BlobSeed(string Digest, long Size);
+
+public sealed record LayerSeed(string Digest, long Size, string DiffId);
+
+public sealed record ManifestSeed(string Digest, long Size);
+
+public sealed record PlatformImageSeed(
+    ImageSeed Image,
+    string Os,
+    string Architecture,
+    string? OsVersion = null);
+
+public sealed record ImageSeed(
+    string Repository,
+    string Reference,
+    ManifestSeed Manifest,
+    BlobSeed Config,
+    IReadOnlyList<LayerSeed> Layers);
+
+public sealed record ArtifactSeed(
+    ManifestSeed Manifest,
+    BlobSeed Payload,
+    string ArtifactType);
+
+public sealed record LayerEntry(
+    TarEntryType Type,
+    string Path,
+    byte[]? Content,
+    string? LinkTarget)
+{
+    public static LayerEntry File(string path, string content) =>
+        File(path, Encoding.UTF8.GetBytes(content));
+
+    public static LayerEntry File(string path, byte[] content) =>
+        new(TarEntryType.RegularFile, path, content, null);
+
+    public static LayerEntry Directory(string path) =>
+        new(TarEntryType.Directory, path, null, null);
+
+    public static LayerEntry SymbolicLink(string path, string target) =>
+        new(TarEntryType.SymbolicLink, path, null, target);
+}

--- a/src/Valleysoft.Dredge.Tests/RegistryFixtureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryFixtureTests.cs
@@ -1,0 +1,78 @@
+namespace Valleysoft.Dredge.Tests;
+
+public sealed class RegistryFixtureTests
+{
+    [Fact]
+    public async Task InitializeAsync_DoesNotStartRegistry()
+    {
+        int startCount = 0;
+        RegistryFixture fixture = new(_ =>
+        {
+            startCount++;
+            return Task.FromResult(
+                new RegistryFixture.RegistryInstance(
+                    new TrackingAsyncDisposable(),
+                    "localhost:5000"));
+        });
+
+        await fixture.InitializeAsync();
+        await fixture.DisposeAsync();
+
+        Assert.Equal(0, startCount);
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_ConcurrentCallsStartAndDisposeRegistryOnce()
+    {
+        int startCount = 0;
+        TrackingAsyncDisposable container = new();
+        RegistryFixture fixture = new(async _ =>
+        {
+            Interlocked.Increment(ref startCount);
+            await Task.Yield();
+            return new(container, "localhost:5000");
+        });
+
+        await Task.WhenAll(
+            Enumerable.Range(0, 20)
+                .Select(_ => fixture.EnsureInitializedAsync()));
+        await fixture.DisposeAsync();
+
+        Assert.Equal(1, startCount);
+        Assert.Equal(1, container.DisposeCount);
+        Assert.Equal("localhost:5000", fixture.Registry);
+        Assert.Equal(new Uri("http://localhost:5000/"), fixture.BaseUri);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_AfterInitializationFailureDeletesFixtureDirectory()
+    {
+        string? fixtureDirectory = null;
+        RegistryFixture fixture = new(configPath =>
+        {
+            fixtureDirectory = Path.GetDirectoryName(configPath);
+            return Task.FromException<RegistryFixture.RegistryInstance>(
+                new InvalidOperationException("Registry failed to start."));
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            fixture.EnsureInitializedAsync);
+        await fixture.DisposeAsync();
+
+        Assert.NotNull(fixtureDirectory);
+        Assert.False(Directory.Exists(fixtureDirectory));
+    }
+
+    private sealed class TrackingAsyncDisposable : IAsyncDisposable
+    {
+        private int disposeCount;
+
+        public int DisposeCount => disposeCount;
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref disposeCount);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/RegistryIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryIntegrationTests.cs
@@ -1,0 +1,385 @@
+using Newtonsoft.Json.Linq;
+using System.CommandLine;
+using System.Text;
+using Valleysoft.DockerRegistryClient;
+using DigestCommand = Valleysoft.Dredge.Commands.Manifest.DigestCommand;
+using GetCommand = Valleysoft.Dredge.Commands.Manifest.GetCommand;
+using ResolveCommand = Valleysoft.Dredge.Commands.Manifest.ResolveCommand;
+using ReferrerCheckCommand = Valleysoft.Dredge.Commands.Referrer.CheckCommand;
+using ReferrerGetCommand = Valleysoft.Dredge.Commands.Referrer.GetCommand;
+using ReferrerInspectCommand = Valleysoft.Dredge.Commands.Referrer.InspectCommand;
+using ReferrerListCommand = Valleysoft.Dredge.Commands.Referrer.ListCommand;
+using RepoListCommand = Valleysoft.Dredge.Commands.Repo.ListCommand;
+using TagListCommand = Valleysoft.Dredge.Commands.Tag.ListCommand;
+
+namespace Valleysoft.Dredge.Tests;
+
+internal sealed class RegistryIntegrationScenarios
+{
+    private readonly RegistryFixture fixture;
+
+    public RegistryIntegrationScenarios(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    public async Task ManifestCommands_QueryLiveRegistry()
+    {
+        string repository = fixture.GetRepositoryName(nameof(ManifestCommands_QueryLiveRegistry));
+        ImageSeed seed = await fixture.PutImageAsync(
+            repository,
+            "latest",
+            []);
+        string image = $"{fixture.Registry}/{repository}:latest";
+
+        using StringWriter digestOutput = new();
+        int digestExitCode = await InvokeAsync(
+            new DigestCommand(fixture.CreateClientFactory(), digestOutput),
+            image);
+
+        using StringWriter manifestOutput = new();
+        int getExitCode = await InvokeAsync(
+            new GetCommand(fixture.CreateClientFactory(), manifestOutput),
+            image);
+
+        Assert.Equal(0, digestExitCode);
+        Assert.Equal(seed.Manifest.Digest, digestOutput.ToString().Trim());
+        Assert.Equal(0, getExitCode);
+        JObject manifestJson = JObject.Parse(manifestOutput.ToString());
+        Assert.Equal(2, manifestJson["schemaVersion"]);
+        Assert.Equal(seed.Config.Digest, (string?)manifestJson["config"]?["digest"]);
+    }
+
+    public async Task ManifestCommand_WhenTagDoesNotExistReturnsFailure()
+    {
+        string repository = fixture.GetRepositoryName(
+            nameof(ManifestCommand_WhenTagDoesNotExistReturnsFailure));
+        using StringWriter output = new();
+        using StringWriter error = new();
+        RecordingProcessTerminator terminator = new();
+        TestLiveDigestCommand command = new(
+            fixture.CreateClientFactory(),
+            output,
+            error);
+        ((IProcessTerminationAware)command).ProcessTerminator = terminator;
+
+        await command
+            .Parse([$"{fixture.Registry}/{repository}:missing"])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, terminator.ExitCode);
+        Assert.Empty(output.ToString());
+        Assert.NotEmpty(error.ToString());
+    }
+
+    public async Task ListCommands_QueryLiveRegistry()
+    {
+        string repository = fixture.GetRepositoryName(nameof(ListCommands_QueryLiveRegistry));
+        await fixture.PutImageAsync(repository, "stable", []);
+        await fixture.PutImageAsync(repository, "latest", []);
+
+        using StringWriter tagOutput = new();
+        int tagExitCode = await InvokeAsync(
+            new TagListCommand(fixture.CreateClientFactory(), tagOutput),
+            $"{fixture.Registry}/{repository}");
+
+        using StringWriter limitedTagOutput = new();
+        int limitedTagExitCode = await InvokeAsync(
+            new TagListCommand(fixture.CreateClientFactory(), limitedTagOutput),
+            $"{fixture.Registry}/{repository}",
+            "--limit",
+            "1");
+
+        using StringWriter repoOutput = new();
+        int repoExitCode = await InvokeAsync(
+            new RepoListCommand(fixture.CreateClientFactory(), repoOutput),
+            fixture.Registry);
+
+        Assert.Equal(0, tagExitCode);
+        Assert.Equal(["latest", "stable"], JArray.Parse(tagOutput.ToString()).Values<string>());
+        Assert.Equal(0, limitedTagExitCode);
+        string? limitedTag = Assert.Single(
+            JArray.Parse(limitedTagOutput.ToString()).Values<string>());
+        Assert.NotNull(limitedTag);
+        Assert.Contains(limitedTag, new[] { "latest", "stable" });
+        Assert.Equal(0, repoExitCode);
+        Assert.Contains(repository, JArray.Parse(repoOutput.ToString()).Values<string>());
+    }
+
+    public async Task ResolveCommand_SelectsPlatformFromLiveImageIndex()
+    {
+        string repository = fixture.GetRepositoryName(
+            nameof(ResolveCommand_SelectsPlatformFromLiveImageIndex));
+        ImageSeed amd64 = await fixture.PutImageAsync(
+            repository,
+            "amd64",
+            [],
+            architecture: "amd64");
+        ImageSeed arm64 = await fixture.PutImageAsync(
+            repository,
+            "arm64",
+            [],
+            architecture: "arm64");
+        const string WindowsVersion = "10.0.20348.2849";
+        ImageSeed windows = await fixture.PutImageAsync(
+            repository,
+            "windows",
+            [],
+            architecture: "amd64",
+            os: "windows");
+        await fixture.PutIndexAsync(
+            repository,
+            "multi",
+            new PlatformImageSeed(amd64, "linux", "amd64"),
+            new PlatformImageSeed(arm64, "linux", "arm64"),
+            new PlatformImageSeed(windows, "windows", "amd64", WindowsVersion));
+        using StringWriter output = new();
+
+        int exitCode = await InvokeAsync(
+            new ResolveCommand(fixture.CreateClientFactory(), output),
+                $"{fixture.Registry}/{repository}:multi",
+                "--os",
+                "linux",
+                "--arch",
+                "arm64");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            $"{fixture.Registry}/{repository}@{arm64.Manifest.Digest}",
+            output.ToString().Trim());
+
+        string settingsRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-resolve-settings-{Guid.NewGuid():N}");
+        string settingsPath = Path.Combine(settingsRoot, "settings.json");
+        try
+        {
+            AppSettings settings = AppSettings.Load(settingsPath);
+            settings.Platform.Os = "windows";
+            settings.Platform.OsVersion = WindowsVersion;
+            settings.Platform.Architecture = "amd64";
+            settings.Save();
+            using StringWriter settingsOutput = new();
+
+            int settingsExitCode = await InvokeAsync(
+                new ResolveCommand(
+                    fixture.CreateClientFactory(),
+                    settingsOutput,
+                    new AppSettingsStore(settingsPath)),
+                $"{fixture.Registry}/{repository}:multi");
+
+            Assert.Equal(0, settingsExitCode);
+            Assert.Equal(
+                $"{fixture.Registry}/{repository}@{windows.Manifest.Digest}",
+                settingsOutput.ToString().Trim());
+        }
+        finally
+        {
+            if (Directory.Exists(settingsRoot))
+            {
+                Directory.Delete(settingsRoot, recursive: true);
+            }
+        }
+    }
+
+    public async Task ReferrerCommands_QueryAndReadLiveArtifact()
+    {
+        const string ArtifactType = "application/vnd.example.sbom";
+        const string PayloadMediaType = "application/spdx+json";
+        const string Payload = """
+            {
+              "spdxVersion": "SPDX-2.3",
+              "name": "integration-sbom",
+              "documentNamespace": "https://example.test/integration",
+              "creationInfo": {
+                "created": "2026-09-04T00:00:00Z",
+                "creators": ["Tool: dredge-tests"]
+              },
+              "packages": [{}, {}],
+              "files": [{}],
+              "relationships": []
+            }
+            """;
+        string repository = fixture.GetRepositoryName(
+            nameof(ReferrerCommands_QueryAndReadLiveArtifact));
+        ImageSeed subject = await fixture.PutImageAsync(repository, "subject", []);
+        ArtifactSeed artifact = await fixture.PutArtifactAsync(
+            subject,
+            "sbom",
+            ArtifactType,
+            PayloadMediaType,
+            Encoding.UTF8.GetBytes(Payload));
+        string image = $"{fixture.Registry}/{repository}:subject";
+        string digest = artifact.Manifest.Digest;
+        IDockerRegistryClientFactory factory = fixture.CreateClientFactory();
+
+        using StringWriter listOutput = new();
+        int listExitCode = await InvokeAsync(
+            new ReferrerListCommand(factory, listOutput),
+            image,
+            "--artifact-type",
+            ArtifactType);
+
+        using StringWriter checkOutput = new();
+        int checkExitCode = await InvokeAsync(
+            new ReferrerCheckCommand(factory, checkOutput),
+            image,
+            "--artifact-type",
+            ArtifactType,
+            "--output",
+            "json");
+
+        using MemoryStream payloadOutput = new();
+        int getExitCode = await InvokeAsync(
+            new ReferrerGetCommand(factory, payloadOutput),
+            image,
+            digest);
+
+        using StringWriter inspectOutput = new();
+        int inspectExitCode = await InvokeAsync(
+            new ReferrerInspectCommand(factory, inspectOutput),
+            image,
+            digest,
+            "--output",
+            "json");
+
+        Assert.Equal(0, listExitCode);
+        JObject list = JObject.Parse(listOutput.ToString());
+        Assert.Contains(
+            list["manifests"]!,
+            manifest =>
+                (string?)manifest["digest"] == digest &&
+                (string?)manifest["artifactType"] == ArtifactType);
+        Assert.Equal(0, checkExitCode);
+        JObject check = JObject.Parse(checkOutput.ToString());
+        Assert.True((bool)check["succeeded"]!);
+        Assert.Equal(0, getExitCode);
+        Assert.Equal(Payload, Encoding.UTF8.GetString(payloadOutput.ToArray()));
+        Assert.Equal(0, inspectExitCode);
+        JObject inspection = JObject.Parse(inspectOutput.ToString());
+        Assert.Equal(digest, (string?)inspection["artifactDigest"]);
+        Assert.Equal("SPDX", (string?)inspection["payloads"]?[0]?["format"]);
+        Assert.Equal(2, (int?)inspection["payloads"]?[0]?["summary"]?["packageCount"]);
+    }
+
+    private static Task<int> InvokeAsync(Command command, params string[] args)
+    {
+        ((IProcessTerminationAware)command).ProcessTerminator = new TestProcessTerminator();
+        return command
+            .Parse(args)
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+    }
+
+}
+
+internal sealed class TestLiveDigestCommand : DigestCommand
+{
+    private readonly TextWriter error;
+
+    public TestLiveDigestCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        TextWriter output,
+        TextWriter error)
+        : base(dockerRegistryClientFactory, output)
+    {
+        this.error = error;
+    }
+
+    protected override TextWriter Error => error;
+}
+
+[Trait("Category", "Integration")]
+public sealed class ManifestCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ManifestCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Trait("Category", "Integration")]
+    public sealed class ManifestCommandFailureIntegrationTests
+    {
+        private readonly RegistryFixture fixture;
+
+        public ManifestCommandFailureIntegrationTests(RegistryFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task ManifestCommand_WhenTagDoesNotExistReturnsFailure()
+        {
+            await fixture.EnsureInitializedAsync();
+            await new RegistryIntegrationScenarios(fixture)
+                .ManifestCommand_WhenTagDoesNotExistReturnsFailure();
+        }
+    }
+
+    [Fact]
+    public async Task ManifestCommands_QueryLiveRegistry()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new RegistryIntegrationScenarios(fixture).ManifestCommands_QueryLiveRegistry();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class RegistryListCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public RegistryListCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ListCommands_QueryLiveRegistry()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new RegistryIntegrationScenarios(fixture).ListCommands_QueryLiveRegistry();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ManifestResolveCommandIntegrationTests
+{
+    private readonly RegistryFixture fixture;
+
+    public ManifestResolveCommandIntegrationTests(RegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ResolveCommand_SelectsPlatformFromLiveImageIndex()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new RegistryIntegrationScenarios(fixture)
+            .ResolveCommand_SelectsPlatformFromLiveImageIndex();
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ReferrerCommandIntegrationTests
+{
+    private readonly ZotRegistryFixture fixture;
+
+    public ReferrerCommandIntegrationTests(ZotRegistryFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ReferrerCommands_QueryAndReadLiveArtifact()
+    {
+        await fixture.EnsureInitializedAsync();
+        await new RegistryIntegrationScenarios(fixture).ReferrerCommands_QueryAndReadLiveArtifact();
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/SettingsCommandIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/SettingsCommandIntegrationTests.cs
@@ -1,0 +1,193 @@
+using System.CommandLine;
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+using ClearCacheCommand = Valleysoft.Dredge.Commands.Settings.ClearCacheCommand;
+using SettingsGetCommand = Valleysoft.Dredge.Commands.Settings.GetCommand;
+using SettingsOpenCommand = Valleysoft.Dredge.Commands.Settings.OpenCommand;
+using SettingsSetCommand = Valleysoft.Dredge.Commands.Settings.SetCommand;
+
+namespace Valleysoft.Dredge.Tests;
+
+internal sealed class SettingsCommandIntegrationScenarios
+{
+    public async Task SetAndGetCommands_RoundTripIsolatedSettings()
+    {
+        string tempRoot = GetTempPath();
+        string settingsPath = Path.Combine(tempRoot, "settings.json");
+        using StringWriter output = new();
+        try
+        {
+            int setExitCode = await InvokeAsync(
+                new SettingsSetCommand(new AppSettingsStore(settingsPath)),
+                "platform.arch",
+                "arm64");
+            int getExitCode = await InvokeAsync(
+                new SettingsGetCommand(new AppSettingsStore(settingsPath), output),
+                "platform.arch");
+
+            Assert.Equal(0, setExitCode);
+            Assert.Equal(0, getExitCode);
+            Assert.Equal("arm64", output.ToString().Trim());
+            JObject persisted = JObject.Parse(await File.ReadAllTextAsync(
+                settingsPath,
+                TestContext.Current.CancellationToken));
+            Assert.Equal("arm64", (string?)persisted["platform"]?["arch"]);
+        }
+        finally
+        {
+            DeleteDirectory(tempRoot);
+        }
+    }
+
+    public async Task ClearCacheCommand_DeletesIsolatedCache()
+    {
+        string cachePath = GetTempPath();
+        Directory.CreateDirectory(Path.Combine(cachePath, "nested"));
+        await File.WriteAllBytesAsync(
+            Path.Combine(cachePath, "nested", "cache.bin"),
+            [1, 2, 3, 4],
+            TestContext.Current.CancellationToken);
+        using StringWriter output = new();
+
+        int exitCode = await InvokeAsync(
+            new ClearCacheCommand(
+                new TestDredgePathProvider(cachePath),
+                output,
+                new TestProcessTerminator()));
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(cachePath));
+        Assert.Contains("4 bytes deleted", output.ToString());
+    }
+
+    public async Task ClearCacheCommand_WhenCacheDoesNotExistReportsNoWork()
+    {
+        string cachePath = GetTempPath();
+        using StringWriter output = new();
+
+        int exitCode = await InvokeAsync(
+            new ClearCacheCommand(
+                new TestDredgePathProvider(cachePath),
+                output,
+                new TestProcessTerminator()));
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(cachePath));
+        Assert.Equal(
+            $"Nothing to do. Cache directory '{cachePath}' does not exist.{Environment.NewLine}",
+            output.ToString());
+    }
+
+    public async Task OpenCommand_CreatesAndLaunchesIsolatedSettingsFile()
+    {
+        string tempRoot = GetTempPath();
+        string settingsPath = Path.Combine(tempRoot, "settings.json");
+        ProcessStartInfo? launched = null;
+        using StringWriter output = new();
+        try
+        {
+            TestProcessLauncher processLauncher = new();
+            SettingsOpenCommand command = new(
+                new AppSettingsStore(settingsPath),
+                processLauncher,
+                new TestProcessTerminator(),
+                output);
+
+            int exitCode = await InvokeAsync(command);
+            launched = processLauncher.StartInfo;
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(settingsPath));
+            Assert.Equal(settingsPath, launched?.FileName);
+            Assert.True(launched?.UseShellExecute);
+            Assert.Empty(output.ToString());
+        }
+        finally
+        {
+            DeleteDirectory(tempRoot);
+        }
+    }
+
+    public async Task OpenCommand_WhenShellLaunchFailsWritesSettingsPath()
+    {
+        string tempRoot = GetTempPath();
+        string settingsPath = Path.Combine(tempRoot, "settings.json");
+        using StringWriter output = new();
+        try
+        {
+            SettingsOpenCommand command = new(
+                new AppSettingsStore(settingsPath),
+                new ThrowingProcessLauncher(new InvalidOperationException("No shell association.")),
+                new TestProcessTerminator(),
+                output);
+
+            int exitCode = await InvokeAsync(command);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(settingsPath));
+            Assert.Equal($"{settingsPath}{Environment.NewLine}", output.ToString());
+        }
+        finally
+        {
+            DeleteDirectory(tempRoot);
+        }
+    }
+
+    private static Task<int> InvokeAsync(Command command, params string[] args) =>
+        command
+            .Parse(args)
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+    private static string GetTempPath() =>
+        Path.Combine(Path.GetTempPath(), $"dredge-settings-{Guid.NewGuid():N}");
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class SettingsRoundTripIntegrationTests
+{
+    [Fact]
+    public Task SetAndGetCommands_RoundTripIsolatedSettings() =>
+        new SettingsCommandIntegrationScenarios().SetAndGetCommands_RoundTripIsolatedSettings();
+}
+
+[Trait("Category", "Integration")]
+public sealed class SettingsClearCacheIntegrationTests
+{
+    [Fact]
+    public Task ClearCacheCommand_DeletesIsolatedCache() =>
+        new SettingsCommandIntegrationScenarios().ClearCacheCommand_DeletesIsolatedCache();
+}
+
+[Trait("Category", "Integration")]
+public sealed class SettingsClearCacheMissingIntegrationTests
+{
+    [Fact]
+    public Task ClearCacheCommand_WhenCacheDoesNotExistReportsNoWork() =>
+        new SettingsCommandIntegrationScenarios().ClearCacheCommand_WhenCacheDoesNotExistReportsNoWork();
+}
+
+[Trait("Category", "Integration")]
+public sealed class SettingsOpenIntegrationTests
+{
+    [Fact]
+    public Task OpenCommand_CreatesAndLaunchesIsolatedSettingsFile() =>
+        new SettingsCommandIntegrationScenarios().OpenCommand_CreatesAndLaunchesIsolatedSettingsFile();
+}
+
+[Trait("Category", "Integration")]
+public sealed class SettingsOpenFallbackIntegrationTests
+{
+    [Fact]
+    public Task OpenCommand_WhenShellLaunchFailsWritesSettingsPath() =>
+        new SettingsCommandIntegrationScenarios().OpenCommand_WhenShellLaunchFailsWritesSettingsPath();
+}

--- a/src/Valleysoft.Dredge.Tests/TestHelper.cs
+++ b/src/Valleysoft.Dredge.Tests/TestHelper.cs
@@ -1,4 +1,5 @@
-﻿using Spectre.Console.Rendering;
+using System.Diagnostics;
+using Spectre.Console.Rendering;
 using System.Text;
 
 namespace Valleysoft.Dredge.Tests;
@@ -17,4 +18,49 @@ public static class TestHelper
 
     public static string Normalize(string val) =>
         val.Replace("\r", string.Empty).TrimEnd();
+}
+
+internal sealed class TestProcessTerminator : IProcessTerminator
+{
+    public void Exit(int exitCode) =>
+        throw new InvalidOperationException($"Command requested process exit code {exitCode}.");
+}
+
+internal sealed class RecordingProcessTerminator : IProcessTerminator
+{
+    public int? ExitCode { get; private set; }
+
+    public void Exit(int exitCode)
+    {
+        ExitCode = exitCode;
+    }
+}
+
+internal sealed class TestAppSettingsStore(
+    AppSettings settings,
+    string settingsPath = "settings.json") : IAppSettingsStore
+{
+    public string SettingsPath { get; } = settingsPath;
+
+    public AppSettings Load() => settings;
+}
+
+internal sealed class TestDredgePathProvider(string tempPath) : IDredgePathProvider
+{
+    public string TempPath { get; } = tempPath;
+}
+
+internal sealed class TestProcessLauncher : IProcessLauncher
+{
+    public ProcessStartInfo? StartInfo { get; private set; }
+
+    public void Start(ProcessStartInfo startInfo)
+    {
+        StartInfo = startInfo;
+    }
+}
+
+internal sealed class ThrowingProcessLauncher(Exception exception) : IProcessLauncher
+{
+    public void Start(ProcessStartInfo startInfo) => throw exception;
 }

--- a/src/Valleysoft.Dredge.Tests/Usings.cs
+++ b/src/Valleysoft.Dredge.Tests/Usings.cs
@@ -1,2 +1,6 @@
 global using Moq;
 global using Xunit;
+
+[assembly: AssemblyFixture(typeof(Valleysoft.Dredge.Tests.RegistryFixture))]
+[assembly: AssemblyFixture(typeof(Valleysoft.Dredge.Tests.ZotRegistryFixture))]
+[assembly: AssemblyFixture(typeof(Valleysoft.Dredge.Tests.AuthenticatedRegistryFixture))]

--- a/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
+++ b/src/Valleysoft.Dredge.Tests/Valleysoft.Dredge.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers" Version="4.14.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Valleysoft.Dredge/AppSettings.cs
+++ b/src/Valleysoft.Dredge/AppSettings.cs
@@ -5,6 +5,7 @@ namespace Valleysoft.Dredge;
 internal partial class AppSettings
 {
     private static readonly object settingsFileLock = new();
+    private string settingsPath = SettingsPath;
 
     public static readonly string SettingsPath =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Valleysoft.Dredge", "settings.json");
@@ -27,8 +28,8 @@ internal partial class AppSettings
         {
             if (!File.Exists(settingsPath))
             {
-                AppSettings settings = new();
-                string settingsStr = JsonConvert.SerializeObject(settings, JsonHelper.Settings);
+                AppSettings defaultSettings = new() { settingsPath = settingsPath };
+                string settingsStr = JsonConvert.SerializeObject(defaultSettings, JsonHelper.Settings);
 
                 string? dirName = Path.GetDirectoryName(settingsPath);
                 if (!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
@@ -37,11 +38,13 @@ internal partial class AppSettings
                 }
 
                 File.WriteAllText(settingsPath, settingsStr);
-                return settings;
+                return defaultSettings;
             }
 
             string settingsContent = File.ReadAllText(settingsPath);
-            return JsonConvert.DeserializeObject<AppSettings>(settingsContent)!;
+            AppSettings settings = JsonConvert.DeserializeObject<AppSettings>(settingsContent)!;
+            settings.settingsPath = settingsPath;
+            return settings;
         }
     }
 
@@ -50,7 +53,7 @@ internal partial class AppSettings
         lock (settingsFileLock)
         {
             string settingsStr = JsonConvert.SerializeObject(this, JsonHelper.Settings);
-            File.WriteAllText(SettingsPath, settingsStr);
+            File.WriteAllText(settingsPath, settingsStr);
         }
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -7,24 +7,42 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
     private const string BaseOutputDirName = "base";
     private const string TargetOutputDirName = "target";
 
-    private static readonly string CompareTempPath = Path.Combine(DredgeState.DredgeTempPath, "compare");
+    private readonly IAppSettingsStore settingsStore;
+    private readonly IDredgePathProvider pathProvider;
+    private readonly IProcessLauncher processLauncher;
 
     public CompareFilesCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : this(
+            dockerRegistryClientFactory,
+            new AppSettingsStore(),
+            new DredgePathProvider(),
+            new ProcessLauncher())
+    {
+    }
+
+    internal CompareFilesCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IAppSettingsStore settingsStore,
+        IDredgePathProvider pathProvider,
+        IProcessLauncher processLauncher)
         : base("files", "Compares two images by their files", dockerRegistryClientFactory)
     {
+        this.settingsStore = settingsStore;
+        this.pathProvider = pathProvider;
+        this.processLauncher = processLauncher;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         return ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
         {
-            AppSettings settings = AppSettings.Load();
+            AppSettings settings = settingsStore.Load();
             if (settings.FileCompareTool is null ||
                 settings.FileCompareTool.ExePath == string.Empty ||
                 settings.FileCompareTool.Args == string.Empty)
             {
                 throw new Exception(
-                    $"This command requires additional configuration.{Environment.NewLine}In order to compare files, you must first set the '{AppSettings.FileCompareToolName}' setting in {AppSettings.SettingsPath}. This is an external tool of your choosing that will be executed to compare two directories containing files of the specified images. Use '{{0}}' and '{{1}}' placeholders in the args to indicate the base and target path locations that will be the inputs to the compare tool.");
+                    $"This command requires additional configuration.{Environment.NewLine}In order to compare files, you must first set the '{AppSettings.FileCompareToolName}' setting in {settingsStore.SettingsPath}. This is an external tool of your choosing that will be executed to compare two directories containing files of the specified images. Use '{{0}}' and '{{1}}' placeholders in the args to indicate the base and target path locations that will be the inputs to the compare tool.");
             }
 
             await SaveImageLayersToDiskAsync(
@@ -33,11 +51,12 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
             await SaveImageLayersToDiskAsync(
                 Options.TargetImage, TargetOutputDirName, Options.TargetLayerIndex, CompareOptionsBase.TargetArg, ct);
 
+            string compareTempPath = Path.Combine(pathProvider.TempPath, "compare");
             string args = settings.FileCompareTool.Args
-                .Replace("{0}", Path.Combine(CompareTempPath, BaseOutputDirName))
-                .Replace("{1}", Path.Combine(CompareTempPath, TargetOutputDirName));
+                .Replace("{0}", Path.Combine(compareTempPath, BaseOutputDirName))
+                .Replace("{1}", Path.Combine(compareTempPath, TargetOutputDirName));
             ct.ThrowIfCancellationRequested();
-            Process.Start(settings.FileCompareTool.ExePath, args);
+            processLauncher.Start(new ProcessStartInfo(settings.FileCompareTool.ExePath, args));
         });
     }
 
@@ -48,7 +67,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
         string layerIndexArg,
         CancellationToken cancellationToken)
     {
-        string workingDir = Path.Combine(CompareTempPath, outputDirName);
+        string workingDir = Path.Combine(pathProvider.TempPath, "compare", outputDirName);
         if (Directory.Exists(workingDir))
         {
             Directory.Delete(workingDir, recursive: true);
@@ -62,6 +81,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
             layerIndexArg + CompareFilesOptions.LayerIndexSuffix,
             noSquash: false,
             Options,
-            cancellationToken);
+            cancellationToken,
+            pathProvider);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareMetadataCommand.cs
@@ -15,23 +15,23 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
     };
 
     private readonly IAnsiConsole ansiConsole;
-    private readonly Func<PlatformSettings> platformSettingsProvider;
+    private readonly IAppSettingsStore settingsStore;
 
     public CompareMetadataCommand(
         IDockerRegistryClientFactory dockerRegistryClientFactory,
         IAnsiConsole? ansiConsole = null)
-        : this(dockerRegistryClientFactory, ansiConsole, () => AppSettings.Load().Platform)
+        : this(dockerRegistryClientFactory, ansiConsole, new AppSettingsStore())
     {
     }
 
     internal CompareMetadataCommand(
         IDockerRegistryClientFactory dockerRegistryClientFactory,
         IAnsiConsole? ansiConsole,
-        Func<PlatformSettings> platformSettingsProvider)
+        IAppSettingsStore settingsStore)
         : base("metadata", "Compares two images by configuration and platform metadata", dockerRegistryClientFactory)
     {
         this.ansiConsole = ansiConsole ?? AnsiConsole.Console;
-        this.platformSettingsProvider = platformSettingsProvider;
+        this.settingsStore = settingsStore;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
@@ -209,7 +209,7 @@ public class CompareMetadataCommand : RegistryCommandBase<CompareMetadataOptions
             imageName,
             Options,
             initialManifest,
-            platformSettingsProvider,
+            settingsStore,
             cancellationToken);
 
         string configDigest = resolvedManifest.Manifest.Config?.Digest ??

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileCommand.cs
@@ -19,11 +19,20 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
     private static readonly Color LiteralColor = new(150, 220, 254); // light turquoise
     private static readonly Color IdentifierColor = Color.Green;
     private readonly IDockerRegistryClientFactory dockerRegistryClientFactory;
+    private readonly IAnsiConsole ansiConsole;
 
     public DockerfileCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : this(dockerRegistryClientFactory, AnsiConsole.Console)
+    {
+    }
+
+    internal DockerfileCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IAnsiConsole ansiConsole)
         : base("dockerfile", "Generates a Dockerfile that represents the image", dockerRegistryClientFactory)
     {
         this.dockerRegistryClientFactory = dockerRegistryClientFactory;
+        this.ansiConsole = ansiConsole;
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -32,7 +41,7 @@ public partial class DockerfileCommand : RegistryCommandBase<DockerfileOptions>
         await ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
             Markup markupOutput = new(await GetMarkupStringAsync(ct));
-            AnsiConsole.Write(markupOutput);
+            ansiConsole.Write(markupOutput);
         });
     }
 

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -4,9 +4,19 @@ namespace Valleysoft.Dredge.Commands.Image;
 
 public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
 {
+    private readonly IDredgePathProvider pathProvider;
+
     public SaveLayersCommand(IDockerRegistryClientFactory dockerRegistryClientFactory)
+        : this(dockerRegistryClientFactory, new DredgePathProvider())
+    {
+    }
+
+    internal SaveLayersCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        IDredgePathProvider pathProvider)
         : base("save-layers", "Saves an image's extracted layers to disk", dockerRegistryClientFactory)
     {
+        this.pathProvider = pathProvider;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
@@ -26,7 +36,8 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
                 SaveLayersOptions.LayerIndexOptionName,
                 Options.NoSquash,
                 Options,
-                ct);
+                ct,
+                pathProvider);
         });
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveCommand.cs
@@ -4,9 +4,20 @@ namespace Valleysoft.Dredge.Commands.Manifest;
 
 public class ResolveCommand : RegistryCommandBase<SetOptions>
 {
+    private readonly IAppSettingsStore settingsStore;
+
     public ResolveCommand(IDockerRegistryClientFactory dockerRegistryClientFactory, TextWriter? output = null)
+        : this(dockerRegistryClientFactory, output, new AppSettingsStore())
+    {
+    }
+
+    internal ResolveCommand(
+        IDockerRegistryClientFactory dockerRegistryClientFactory,
+        TextWriter? output,
+        IAppSettingsStore settingsStore)
         : base("resolve", "Resolves a manifest to a target platform's fully-qualified image digest", dockerRegistryClientFactory, output)
     {
+        this.settingsStore = settingsStore;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
@@ -16,7 +27,12 @@ public class ResolveCommand : RegistryCommandBase<SetOptions>
         {
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             ManifestInfo manifestInfo =
-                (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).ManifestInfo;
+                (await ManifestHelper.GetResolvedManifestAsync(
+                    client,
+                    imageName,
+                    Options,
+                    ct,
+                    settingsStore)).ManifestInfo;
             ImageName fullyQualifiedDigest = new(imageName.Registry, imageName.Repo, tag: null, manifestInfo.DockerContentDigest);
 
             Output.WriteLine(fullyQualifiedDigest.ToString());

--- a/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
+++ b/src/Valleysoft.Dredge/Commands/RegistryCommandBase.cs
@@ -1,6 +1,8 @@
 ﻿namespace Valleysoft.Dredge.Commands;
 
-public abstract class RegistryCommandBase<TOptions> : CommandWithOptions<TOptions>
+public abstract class RegistryCommandBase<TOptions> :
+    CommandWithOptions<TOptions>,
+    IProcessTerminationAware
     where TOptions : OptionsBase, new()
 {
     public IDockerRegistryClientFactory DockerRegistryClientFactory { get; }
@@ -15,7 +17,16 @@ public abstract class RegistryCommandBase<TOptions> : CommandWithOptions<TOption
     {
         DockerRegistryClientFactory = dockerRegistryClientFactory;
         Output = output ?? Console.Out;
+        ProcessTerminator = new ProcessTerminator();
     }
+
+    IProcessTerminator IProcessTerminationAware.ProcessTerminator
+    {
+        get => ProcessTerminator;
+        set => ProcessTerminator = value;
+    }
+
+    private IProcessTerminator ProcessTerminator { get; set; }
 
     protected Task ExecuteCommandAsync(
         string? registry,
@@ -25,5 +36,5 @@ public abstract class RegistryCommandBase<TOptions> : CommandWithOptions<TOption
 
     protected virtual TextWriter Error => Console.Error;
 
-    protected virtual void Exit(int exitCode) => Environment.Exit(exitCode);
+    protected virtual void Exit(int exitCode) => ProcessTerminator.Exit(exitCode);
 }

--- a/src/Valleysoft.Dredge/Commands/Settings/ClearCacheCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/ClearCacheCommand.cs
@@ -4,9 +4,24 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 public class ClearCacheCommand : Command
 {
+    private readonly IDredgePathProvider pathProvider;
+    private readonly TextWriter output;
+    private readonly IProcessTerminator processTerminator;
+
     public ClearCacheCommand()
+        : this(new DredgePathProvider(), Console.Out, new ProcessTerminator())
+    {
+    }
+
+    internal ClearCacheCommand(
+        IDredgePathProvider pathProvider,
+        TextWriter output,
+        IProcessTerminator processTerminator)
         : base("clear-cache", "Deletes the cached files used by Dredge")
     {
+        this.pathProvider = pathProvider;
+        this.output = output;
+        this.processTerminator = processTerminator;
         this.SetAction((parseResult, cancellationToken) => ExecuteAsync(cancellationToken));
     }
 
@@ -15,7 +30,8 @@ public class ClearCacheCommand : Command
         return CommandHelper.ExecuteCommandAsync(null, cancellationToken, ct =>
         {
             ct.ThrowIfCancellationRequested();
-            DirectoryInfo dredgeTempDir = new(DredgeState.DredgeTempPath);
+            string cachePath = pathProvider.TempPath;
+            DirectoryInfo dredgeTempDir = new(cachePath);
 
             if (dredgeTempDir.Exists)
             {
@@ -23,15 +39,15 @@ public class ClearCacheCommand : Command
                 ct.ThrowIfCancellationRequested();
                 dredgeTempDir.Delete(recursive: true);
 
-                Console.WriteLine($"{dirSize:n0} bytes deleted from '{DredgeState.DredgeTempPath}'");
+                output.WriteLine($"{dirSize:n0} bytes deleted from '{cachePath}'");
             }
             else
             {
-                Console.WriteLine($"Nothing to do. Cache directory '{DredgeState.DredgeTempPath}' does not exist.");
+                output.WriteLine($"Nothing to do. Cache directory '{cachePath}' does not exist.");
             }
 
             return Task.CompletedTask;
-        });
+        }, exit: processTerminator.Exit);
     }
 
     private static long DirSize(DirectoryInfo dir, CancellationToken cancellationToken)

--- a/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/GetCommand.cs
@@ -4,15 +4,25 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 internal partial class GetCommand : CommandWithOptions<GetOptions>
 {
+    private readonly IAppSettingsStore settingsStore;
+    private readonly TextWriter output;
+
     public GetCommand()
+        : this(new AppSettingsStore(), Console.Out)
+    {
+    }
+
+    internal GetCommand(IAppSettingsStore settingsStore, TextWriter output)
         : base("get", "Gets the value of the specified setting")
     {
+        this.settingsStore = settingsStore;
+        this.output = output;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        AppSettings settings = AppSettings.Load();
+        AppSettings settings = settingsStore.Load();
 
         Queue<string> names = new([..Options.Name.Split('.')]);
 
@@ -22,11 +32,11 @@ internal partial class GetCommand : CommandWithOptions<GetOptions>
         {
             if (value.GetType().IsValueType || value is string)
             {
-                Console.WriteLine(value);
+                output.WriteLine(value);
             }
             else
             {
-                Console.WriteLine(JsonConvert.SerializeObject(value, JsonHelper.Settings));
+                output.WriteLine(JsonConvert.SerializeObject(value, JsonHelper.Settings));
             }
         }
 

--- a/src/Valleysoft.Dredge/Commands/Settings/OpenCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/OpenCommand.cs
@@ -5,9 +5,31 @@ namespace Valleysoft.Dredge.Commands.Settings;
 
 public class OpenCommand : Command
 {
+    private readonly IAppSettingsStore settingsStore;
+    private readonly IProcessLauncher processLauncher;
+    private readonly IProcessTerminator processTerminator;
+    private readonly TextWriter output;
+
     public OpenCommand()
+        : this(
+            new AppSettingsStore(),
+            new ProcessLauncher(),
+            new ProcessTerminator(),
+            Console.Out)
+    {
+    }
+
+    internal OpenCommand(
+        IAppSettingsStore settingsStore,
+        IProcessLauncher processLauncher,
+        IProcessTerminator processTerminator,
+        TextWriter output)
         : base("open", "Opens the Dredge settings file")
     {
+        this.settingsStore = settingsStore;
+        this.processLauncher = processLauncher;
+        this.processTerminator = processTerminator;
+        this.output = output;
         this.SetAction((parseResult, cancellationToken) => ExecuteAsync(cancellationToken));
     }
 
@@ -17,18 +39,19 @@ public class OpenCommand : Command
         {
             ct.ThrowIfCancellationRequested();
             // Ensure the settings are loaded which creates a default settings file if necessary
-            AppSettings.Load();
+            settingsStore.Load();
 
             try
             {
-                Process.Start(new ProcessStartInfo(AppSettings.SettingsPath) { UseShellExecute = true });
+                processLauncher.Start(
+                    new ProcessStartInfo(settingsStore.SettingsPath) { UseShellExecute = true });
             }
             catch (Exception)
             {
-                Console.WriteLine(AppSettings.SettingsPath);
+                output.WriteLine(settingsStore.SettingsPath);
             }
 
             return Task.CompletedTask;
-        });
+        }, exit: processTerminator.Exit);
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Settings/SetCommand.cs
@@ -2,15 +2,23 @@
 
 internal partial class SetCommand : CommandWithOptions<SetOptions>
 {
+    private readonly IAppSettingsStore settingsStore;
+
     public SetCommand()
+        : this(new AppSettingsStore())
+    {
+    }
+
+    internal SetCommand(IAppSettingsStore settingsStore)
         : base("set", "Sets the specified setting name to a value")
     {
+        this.settingsStore = settingsStore;
     }
 
     protected override Task ExecuteAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        AppSettings settings = AppSettings.Load();
+        AppSettings settings = settingsStore.Load();
 
         Queue<string> names = new([..Options.Name.Split('.')]);
 

--- a/src/Valleysoft.Dredge/IAppSettingsStore.cs
+++ b/src/Valleysoft.Dredge/IAppSettingsStore.cs
@@ -1,0 +1,25 @@
+namespace Valleysoft.Dredge;
+
+internal interface IAppSettingsStore
+{
+    string SettingsPath { get; }
+
+    AppSettings Load();
+}
+
+internal sealed class AppSettingsStore : IAppSettingsStore
+{
+    public AppSettingsStore()
+        : this(AppSettings.SettingsPath)
+    {
+    }
+
+    internal AppSettingsStore(string settingsPath)
+    {
+        SettingsPath = settingsPath;
+    }
+
+    public string SettingsPath { get; }
+
+    public AppSettings Load() => AppSettings.Load(SettingsPath);
+}

--- a/src/Valleysoft.Dredge/IDredgePathProvider.cs
+++ b/src/Valleysoft.Dredge/IDredgePathProvider.cs
@@ -1,0 +1,11 @@
+namespace Valleysoft.Dredge;
+
+internal interface IDredgePathProvider
+{
+    string TempPath { get; }
+}
+
+internal sealed class DredgePathProvider : IDredgePathProvider
+{
+    public string TempPath => DredgeState.DredgeTempPath;
+}

--- a/src/Valleysoft.Dredge/IProcessLauncher.cs
+++ b/src/Valleysoft.Dredge/IProcessLauncher.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+
+namespace Valleysoft.Dredge;
+
+internal interface IProcessLauncher
+{
+    void Start(ProcessStartInfo startInfo);
+}
+
+internal sealed class ProcessLauncher : IProcessLauncher
+{
+    public void Start(ProcessStartInfo startInfo)
+    {
+        Process.Start(startInfo);
+    }
+}

--- a/src/Valleysoft.Dredge/IProcessTerminator.cs
+++ b/src/Valleysoft.Dredge/IProcessTerminator.cs
@@ -1,0 +1,16 @@
+namespace Valleysoft.Dredge;
+
+internal interface IProcessTerminator
+{
+    void Exit(int exitCode);
+}
+
+internal interface IProcessTerminationAware
+{
+    IProcessTerminator ProcessTerminator { get; set; }
+}
+
+internal sealed class ProcessTerminator : IProcessTerminator
+{
+    public void Exit(int exitCode) => Environment.Exit(exitCode);
+}

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -28,6 +28,10 @@ internal static class ImageHelper
         IImageManifest manifest =
             (await ManifestHelper.GetResolvedManifestAsync(client, imageName, options, cancellationToken)).Manifest;
 
+        string layersTempPath = Path.Combine(
+            (pathProvider ?? new DredgePathProvider()).TempPath,
+            "layers");
+
         int startIndex = 0;
         int layerCount = manifest.Layers.Length;
         if (layerIndex is not null)
@@ -57,9 +61,6 @@ internal static class ImageHelper
 
             string layerName = layer.Digest[(layer.Digest.IndexOf(':') + 1)..];
             ValidateLayerDigest(layerName);
-            string layersTempPath = Path.Combine(
-                (pathProvider ?? new DredgePathProvider()).TempPath,
-                "layers");
             string layerDir = GetContainedPath(layersTempPath, layerName);
             if (Directory.Exists(layerDir))
             {

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -13,12 +13,11 @@ internal static class ImageHelper
     private const string WhiteoutMarkerPrefix = ".wh.";
     private const string OpaqueWhiteoutMarker = ".wh..wh..opq";
 
-    private static readonly string LayersTempPath = Path.Combine(DredgeState.DredgeTempPath, "layers");
-
     public static async Task SaveImageLayersToDiskAsync(
         IDockerRegistryClientFactory dockerRegistryClientFactory, string image, string destPath, int? layerIndex,
         string layerIndexOptionName, bool noSquash, PlatformOptionsBase options,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IDredgePathProvider? pathProvider = null)
     {
         // Spec for OCI image layer filesystem changeset: https://github.com/opencontainers/image-spec/blob/main/layer.md
 
@@ -58,7 +57,10 @@ internal static class ImageHelper
 
             string layerName = layer.Digest[(layer.Digest.IndexOf(':') + 1)..];
             ValidateLayerDigest(layerName);
-            string layerDir = GetContainedPath(LayersTempPath, layerName);
+            string layersTempPath = Path.Combine(
+                (pathProvider ?? new DredgePathProvider()).TempPath,
+                "layers");
+            string layerDir = GetContainedPath(layersTempPath, layerName);
             if (Directory.Exists(layerDir))
             {
                 Console.Error.WriteLine($"\tUsing cached layer on disk...");

--- a/src/Valleysoft.Dredge/ManifestHelper.cs
+++ b/src/Valleysoft.Dredge/ManifestHelper.cs
@@ -14,7 +14,7 @@ internal static class ManifestHelper
         ImageName imageName,
         PlatformOptionsBase options,
         CancellationToken cancellationToken = default,
-        AppSettings? settings = null)
+        IAppSettingsStore? settingsStore = null)
     {
         ManifestInfo manifestInfo = await client.Manifests.GetAsync(
             imageName.Repo, (imageName.Tag ?? imageName.Digest)!, cancellationToken);
@@ -23,7 +23,7 @@ internal static class ManifestHelper
             imageName,
             options,
             manifestInfo,
-            () => (settings ??= AppSettings.Load()).Platform,
+            settingsStore ?? new AppSettingsStore(),
             cancellationToken);
     }
 
@@ -39,7 +39,7 @@ internal static class ManifestHelper
             imageName,
             options,
             manifestInfo,
-            () => AppSettings.Load().Platform,
+            new AppSettingsStore(),
             cancellationToken);
     }
 
@@ -48,7 +48,7 @@ internal static class ManifestHelper
         ImageName imageName,
         PlatformOptionsBase options,
         ManifestInfo manifestInfo,
-        Func<PlatformSettings> platformSettingsProvider,
+        IAppSettingsStore settingsStore,
         CancellationToken cancellationToken)
     {
         if (manifestInfo.Manifest is IManifestList manifestList)
@@ -60,7 +60,7 @@ internal static class ManifestHelper
                 string.IsNullOrEmpty(osVersion) ||
                 string.IsNullOrEmpty(architecture))
             {
-                PlatformSettings settings = platformSettingsProvider();
+                PlatformSettings settings = settingsStore.Load().Platform;
                 os = GetPlatformValue(os, settings.Os);
                 osVersion = GetPlatformValue(osVersion, settings.OsVersion);
                 architecture = GetPlatformValue(architecture, settings.Architecture);
@@ -99,13 +99,6 @@ internal static class ManifestHelper
 
         return new ResolvedManifest(manifestInfo, manifest);
     }
-
-    public static Task<ResolvedManifest> GetResolvedManifestAsync(
-        IDockerRegistryClient client,
-        ImageName imageName,
-        PlatformOptionsBase options,
-        AppSettings settings) =>
-        GetResolvedManifestAsync(client, imageName, options, cancellationToken: default, settings);
 
     private static string? GetPlatformValue(string? options, string settings)
     {


### PR DESCRIPTION
## Summary

Dredge's command tests previously relied primarily on mocked registry behavior, leaving protocol handling, authentication, CLI parsing, filesystem effects, and settings persistence without end-to-end coverage. This adds container-backed integration coverage for every CLI leaf command across .NET 9 and .NET 10.

The tests use lazy xUnit assembly fixtures with unique repositories, settings, caches, and output paths so scenarios can execute safely in parallel. Production dependencies for settings storage, Dredge paths, process launching and termination, and console output are injected through focused abstractions, keeping tests deterministic without changing existing public command constructors.

## Implementation notes

- Uses `registry:3.1.1` for standard and Basic-auth registry scenarios.
- Uses Zot only for OCI referrer behavior because Docker Distribution does not provide the required referrers support.
- Seeds valid OCI blobs, layers, configurations, manifests, indexes, and artifacts through registry HTTP APIs.
- Covers platform resolution, malformed settings, authentication rejection, missing tags, bounded listings, process-level parsing, cache publication races, and command option combinations.
- Preserves the original public `DockerfileCommand` constructor while exposing console injection internally for tests.

## Testing

- 884 tests passed across `net9.0` and `net10.0`.
- 32 container-backed integration tests passed with standard, authenticated, and Zot registries running concurrently.