### PR TITLE
Protect existing files when saving image layers

### DIFF
--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -364,13 +364,18 @@ dredge image compare files amd64/node:19.1-alpine amd64/node:19.1-alpine --base-
 Saves the extracted layers of an image to disk.
 
 ```console
-dredge image save-layers <image> <output-path> [--no-squash] [--layer-index <n>] [--os <os>] [--arch <arch>] [--os-version <version>]
+dredge image save-layers <image> <output-path> [--no-squash] [--layer-index <n>] [--force] [--os <os>] [--arch <arch>] [--os-version <version>]
 ```
+
+Set `output-path` to a new path or an existing regular directory. By default,
+an existing directory must be empty. Use `--force` to write to a non-empty
+directory.
 
 | Option | Description |
 |--------|-------------|
 | `--no-squash` | Save each selected layer in a separate directory instead of merging the layers |
 | `--layer-index` | Select a zero-based layer index. With squashing, Dredge applies layers `0` through this index. With `--no-squash`, Dredge saves only this layer |
+| `--force` | Allow writes to a non-empty output directory. Squashed output may overwrite, replace, or delete entries, including entries targeted by OCI whiteouts. With `--no-squash`, Dredge replaces each matching `layer<index>-<digest>` directory |
 
 Example:
 

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -120,6 +120,7 @@ public class CommandStructureTests
             "image:tag",
             "output",
             "--no-squash",
+            "--force",
             "--layer-index",
             "3",
             "--os",
@@ -132,6 +133,7 @@ public class CommandStructureTests
         Assert.Equal("image:tag", options.Image);
         Assert.Equal("output", options.OutputPath);
         Assert.True(options.NoSquash);
+        Assert.True(options.Force);
         Assert.Equal(3, options.LayerIndex);
         Assert.Equal("linux", options.Os);
         Assert.Equal("1", options.OsVersion);

--- a/src/Valleysoft.Dredge.Tests/SaveLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/SaveLayersCommandTests.cs
@@ -1,0 +1,353 @@
+namespace Valleysoft.Dredge.Tests;
+
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using Valleysoft.DockerRegistryClient.Models.Manifests;
+using Valleysoft.DockerRegistryClient.Models.Manifests.Docker;
+using Valleysoft.Dredge.Commands.Image;
+
+public class SaveLayersCommandTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenOutputDirectoryIsNotEmpty_RejectsBeforeRegistryAccess()
+    {
+        string outputPath = CreateOutputPath();
+        string existingPath = Path.Combine(outputPath, "existing.txt");
+        Directory.CreateDirectory(outputPath);
+        await File.WriteAllTextAsync(existingPath, "existing", TestContext.Current.CancellationToken);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        using StringWriter error = new();
+        TestSaveLayersCommand command = new(factory.Object, error)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = outputPath
+            }
+        };
+
+        try
+        {
+            CommandExitException exception =
+                await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+            Assert.Equal(1, exception.ExitCode);
+            Assert.Equal("existing", await File.ReadAllTextAsync(
+                existingPath,
+                TestContext.Current.CancellationToken));
+            Assert.Contains("is not empty", error.ToString());
+            Assert.Contains("--force", error.ToString());
+            factory.Verify(
+                item => item.GetClientAsync(It.IsAny<string?>()),
+                Times.Never);
+        }
+        finally
+        {
+            Directory.Delete(outputPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithForce_OverwritesAndDeletesExistingContent()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string outputPath = CreateOutputPath();
+        string layerCachePath = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        Directory.CreateDirectory(outputPath);
+        string overwritePath = Path.Combine(outputPath, "overwrite.txt");
+        Directory.CreateDirectory(overwritePath);
+        await File.WriteAllTextAsync(
+            Path.Combine(overwritePath, "old.txt"),
+            "old",
+            TestContext.Current.CancellationToken);
+        string directoryPath = Path.Combine(outputPath, "directory");
+        await File.WriteAllTextAsync(
+            directoryPath,
+            "old",
+            TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(
+            Path.Combine(outputPath, "delete.txt"), "delete", TestContext.Current.CancellationToken);
+        string linkTargetPath = Path.Combine(outputPath, "link-target.txt");
+        string linkPath = Path.Combine(outputPath, "link.txt");
+        await File.WriteAllTextAsync(
+            linkTargetPath, "target", TestContext.Current.CancellationToken);
+        File.CreateSymbolicLink(linkPath, linkTargetPath);
+        Mock<IDockerRegistryClient> client = CreateClient(
+            digest,
+            () => CreateLayer(
+                ("overwrite.txt", "new"),
+                ("directory/new.txt", "new"),
+                ("link.txt", "new"),
+                (".wh.delete.txt", string.Empty)));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync(null)).ReturnsAsync(client.Object);
+        TestSaveLayersCommand command = new(factory.Object, TextWriter.Null)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = outputPath,
+                Force = true
+            }
+        };
+
+        try
+        {
+            await command.RunAsync();
+
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                overwritePath,
+                TestContext.Current.CancellationToken));
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(directoryPath, "new.txt"),
+                TestContext.Current.CancellationToken));
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                linkPath,
+                TestContext.Current.CancellationToken));
+            Assert.Equal("target", await File.ReadAllTextAsync(
+                linkTargetPath,
+                TestContext.Current.CancellationToken));
+            Assert.False(File.Exists(Path.Combine(outputPath, "delete.txt")));
+        }
+        finally
+        {
+            Directory.Delete(outputPath, recursive: true);
+            if (Directory.Exists(layerCachePath))
+            {
+                Directory.Delete(layerCachePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithForceAndNoSquash_ReplacesExistingLayerDirectory()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string outputPath = CreateOutputPath();
+        string layerOutputPath = Path.Combine(outputPath, $"layer0-{id}");
+        string layerCachePath = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        Directory.CreateDirectory(layerOutputPath);
+        await File.WriteAllTextAsync(
+            Path.Combine(layerOutputPath, "existing.txt"),
+            "old",
+            TestContext.Current.CancellationToken);
+        Mock<IDockerRegistryClient> client = CreateClient(
+            digest,
+            () => CreateLayer(("existing.txt", "new")));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync(null)).ReturnsAsync(client.Object);
+        TestSaveLayersCommand command = new(factory.Object, TextWriter.Null)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = outputPath,
+                NoSquash = true,
+                Force = true
+            }
+        };
+
+        try
+        {
+            await command.RunAsync();
+
+            Assert.Equal("new", await File.ReadAllTextAsync(
+                Path.Combine(layerOutputPath, "existing.txt"),
+                TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            Directory.Delete(outputPath, recursive: true);
+            if (Directory.Exists(layerCachePath))
+            {
+                Directory.Delete(layerCachePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOutputPathIsFile_RejectsEvenWithForce()
+    {
+        string outputPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dredge-output-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(
+            outputPath,
+            "existing",
+            TestContext.Current.CancellationToken);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        using StringWriter error = new();
+        TestSaveLayersCommand command = new(factory.Object, error)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = outputPath,
+                Force = true
+            }
+        };
+
+        try
+        {
+            CommandExitException exception =
+                await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+            Assert.Equal(1, exception.ExitCode);
+            Assert.Contains("is an existing file", error.ToString());
+            factory.Verify(
+                item => item.GetClientAsync(It.IsAny<string?>()),
+                Times.Never);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOutputPathIsSymbolicLink_RejectsBeforeRegistryAccess()
+    {
+        string rootPath = CreateOutputPath();
+        string actualPath = Path.Combine(rootPath, "actual");
+        string linkPath = Path.Combine(rootPath, "link");
+        string sentinelPath = Path.Combine(actualPath, "collision", "sentinel.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(sentinelPath)!);
+        await File.WriteAllTextAsync(
+            sentinelPath,
+            "sentinel",
+            TestContext.Current.CancellationToken);
+        Directory.CreateSymbolicLink(linkPath, actualPath);
+        Mock<IDockerRegistryClientFactory> factory = new();
+        using StringWriter error = new();
+        TestSaveLayersCommand command = new(factory.Object, error)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = linkPath,
+                Force = true
+            }
+        };
+
+        try
+        {
+            CommandExitException exception =
+                await Assert.ThrowsAsync<CommandExitException>(command.RunAsync);
+
+            Assert.Equal(1, exception.ExitCode);
+            Assert.Contains("symbolic link", error.ToString());
+            Assert.Equal("sentinel", await File.ReadAllTextAsync(
+                sentinelPath,
+                TestContext.Current.CancellationToken));
+            factory.Verify(
+                item => item.GetClientAsync(It.IsAny<string?>()),
+                Times.Never);
+        }
+        finally
+        {
+            Directory.Delete(linkPath);
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ValidateDestinationPath_WhenAncestorIsSymbolicLink_AllowsDestination()
+    {
+        string rootPath = CreateOutputPath();
+        string actualPath = Path.Combine(rootPath, "actual");
+        string linkPath = Path.Combine(rootPath, "link");
+        Directory.CreateDirectory(actualPath);
+        Directory.CreateSymbolicLink(linkPath, actualPath);
+
+        try
+        {
+            ImageHelper.ValidateDestinationPath(Path.Combine(linkPath, "output"));
+        }
+        finally
+        {
+            Directory.Delete(linkPath);
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private static string CreateOutputPath() =>
+        Path.Combine(Path.GetTempPath(), $"dredge-output-{Guid.NewGuid():N}");
+
+    private static Mock<IDockerRegistryClient> CreateClient(
+        string digest,
+        Func<Stream> createLayer)
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(item => item.Manifests.GetAsync(
+                "library/image",
+                "latest",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Config = new ManifestConfig { Digest = "sha256:config" },
+                    Layers = [new ManifestLayer { Digest = digest }]
+                }));
+        client
+            .Setup(item => item.Blobs.GetAsync(
+                "library/image",
+                digest,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createLayer);
+        return client;
+    }
+
+    private static Stream CreateLayer(params (string Name, string Content)[] files)
+    {
+        MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, leaveOpen: true))
+        {
+            foreach ((string name, string content) in files)
+            {
+                PaxTarEntry entry = new(TarEntryType.RegularFile, name)
+                {
+                    DataStream = new MemoryStream(Encoding.UTF8.GetBytes(content))
+                };
+                writer.WriteEntry(entry);
+            }
+        }
+        compressed.Position = 0;
+        return compressed;
+    }
+
+    private sealed class TestSaveLayersCommand : SaveLayersCommand
+    {
+        private readonly TextWriter error;
+
+        public TestSaveLayersCommand(
+            IDockerRegistryClientFactory dockerRegistryClientFactory,
+            TextWriter error)
+            : base(dockerRegistryClientFactory)
+        {
+            this.error = error;
+        }
+
+        public Task RunAsync() => ExecuteAsync(TestContext.Current.CancellationToken);
+
+        protected override TextWriter Error => error;
+
+        protected override void Exit(int exitCode) => throw new CommandExitException(exitCode);
+    }
+
+    private sealed class CommandExitException : Exception
+    {
+        public CommandExitException(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/Valleysoft.Dredge.Tests/SaveLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/SaveLayersCommandTests.cs
@@ -169,6 +169,47 @@ public class SaveLayersCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithForce_ReplacesDanglingDirectoryLinkWithFileLink()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string digest = $"sha256:{id}";
+        string outputPath = CreateOutputPath();
+        string layerCachePath = Path.Combine(DredgeState.DredgeTempPath, "layers", id);
+        string linkPath = Path.Combine(outputPath, "link");
+        Directory.CreateDirectory(outputPath);
+        Directory.CreateSymbolicLink(linkPath, Path.Combine(outputPath, "missing"));
+        Mock<IDockerRegistryClient> client = CreateClient(
+            digest,
+            () => CreateSymbolicLinkLayer("link", "target.txt"));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(item => item.GetClientAsync(null)).ReturnsAsync(client.Object);
+        TestSaveLayersCommand command = new(factory.Object, TextWriter.Null)
+        {
+            Options = new SaveLayersOptions
+            {
+                Image = "image",
+                OutputPath = outputPath,
+                Force = true
+            }
+        };
+
+        try
+        {
+            await command.RunAsync();
+
+            Assert.Equal("target.txt", new FileInfo(linkPath).LinkTarget);
+        }
+        finally
+        {
+            Directory.Delete(outputPath, recursive: true);
+            if (Directory.Exists(layerCachePath))
+            {
+                Directory.Delete(layerCachePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenOutputPathIsFile_RejectsEvenWithForce()
     {
         string outputPath = Path.Combine(
@@ -317,6 +358,21 @@ public class SaveLayersCommandTests
                 };
                 writer.WriteEntry(entry);
             }
+        }
+        compressed.Position = 0;
+        return compressed;
+    }
+
+    private static Stream CreateSymbolicLinkLayer(string name, string target)
+    {
+        MemoryStream compressed = new();
+        using (GZipStream gzip = new(compressed, CompressionMode.Compress, leaveOpen: true))
+        using (TarWriter writer = new(gzip, leaveOpen: true))
+        {
+            writer.WriteEntry(new PaxTarEntry(TarEntryType.SymbolicLink, name)
+            {
+                LinkName = target
+            });
         }
         compressed.Position = 0;
         return compressed;

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersCommand.cs
@@ -14,6 +14,8 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
         ImageName imageName = ImageName.Parse(Options.Image);
         return ExecuteCommandAsync(imageName.Registry, cancellationToken, async ct =>
         {
+            ValidateOutputPath();
+
             using IDockerRegistryClient client = await DockerRegistryClientFactory.GetClientAsync(imageName.Registry);
             IImageManifest manifest =
                 (await ManifestHelper.GetResolvedManifestAsync(client, imageName, Options, ct)).Manifest;
@@ -26,7 +28,26 @@ public class SaveLayersCommand : RegistryCommandBase<SaveLayersOptions>
                 SaveLayersOptions.LayerIndexOptionName,
                 Options.NoSquash,
                 Options,
-                ct);
+                ct,
+                overwriteExisting: Options.Force);
         });
+    }
+
+    private void ValidateOutputPath()
+    {
+        ImageHelper.ValidateDestinationPath(Options.OutputPath);
+
+        if (File.Exists(Options.OutputPath))
+        {
+            throw new IOException($"Output path '{Options.OutputPath}' is an existing file.");
+        }
+
+        if (!Options.Force &&
+            Directory.Exists(Options.OutputPath) &&
+            Directory.EnumerateFileSystemEntries(Options.OutputPath).Any())
+        {
+            throw new IOException(
+                $"Output directory '{Options.OutputPath}' is not empty. Use '--force' to allow existing content to be overwritten or deleted.");
+        }
     }
 }

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
@@ -10,11 +10,13 @@ public class SaveLayersOptions : PlatformOptionsBase
     private readonly Argument<string> outputPathArg;
     private readonly Option<bool> noSquashOption;
     private readonly Option<int?> layerIndexOption;
+    private readonly Option<bool> forceOption;
 
     public string Image { get; set; } = string.Empty;
     public string OutputPath { get; set; } = string.Empty;
     public bool NoSquash { get; set; }
     public int? LayerIndex { get; set; }
+    public bool Force { get; set; }
 
     public SaveLayersOptions()
     {
@@ -22,6 +24,7 @@ public class SaveLayersOptions : PlatformOptionsBase
         outputPathArg = Add(new Argument<string>("output-path") { Description = "Path to the output location" });
         noSquashOption = Add(new Option<bool>("--no-squash") { Description = "Do not squash the image layers" });
         layerIndexOption = Add(new Option<int?>(LayerIndexOptionName) { Description = "Index of the image layer to target" });
+        forceOption = Add(new Option<bool>("--force") { Description = "Allow existing output content to be overwritten or deleted" });
     }
 
     protected override void GetValues()
@@ -31,5 +34,6 @@ public class SaveLayersOptions : PlatformOptionsBase
         OutputPath = GetValue(outputPathArg);
         NoSquash = GetValue(noSquashOption);
         LayerIndex = GetValue(layerIndexOption);
+        Force = GetValue(forceOption);
     }
 }

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -18,9 +18,11 @@ internal static class ImageHelper
     public static async Task SaveImageLayersToDiskAsync(
         IDockerRegistryClientFactory dockerRegistryClientFactory, string image, string destPath, int? layerIndex,
         string layerIndexOptionName, bool noSquash, PlatformOptionsBase options,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default, bool overwriteExisting = false)
     {
         // Spec for OCI image layer filesystem changeset: https://github.com/opencontainers/image-spec/blob/main/layer.md
+
+        ValidateDestinationPath(destPath);
 
         Console.Error.WriteLine($"Getting layers for {image}");
 
@@ -74,12 +76,25 @@ internal static class ImageHelper
 
             if (noSquash)
             {
+                string layerOutputPath = GetContainedPath(
+                    destPath,
+                    $"layer{i}-{layerName}",
+                    allowFinalLink: overwriteExisting);
+                if (overwriteExisting)
+                {
+                    DeleteDestinationEntry(layerOutputPath);
+                }
+
                 await FileHelper.CopyDirectoryAsync(
-                    layerDir, Path.Combine(destPath, $"layer{i}-{layerName}"), cancellationToken);
+                    layerDir, layerOutputPath, cancellationToken);
             }
             else
             {
-                await ApplyLayerAsync(layerDir, destPath, cancellationToken);
+                await ApplyLayerAsync(
+                    layerDir,
+                    destPath,
+                    overwriteExisting,
+                    cancellationToken);
             }
         }
     }
@@ -223,6 +238,7 @@ internal static class ImageHelper
     private static async Task ApplyLayerAsync(
         string layerDir,
         string workingDir,
+        bool overwriteExisting,
         CancellationToken cancellationToken)
     {
         Console.Error.WriteLine($"\tApplying layer...");
@@ -240,11 +256,11 @@ internal static class ImageHelper
                 throw new Exception("The opaque whiteout file marker should not exist in the root directory.");
             }
 
-            string fullDirPath = GetContainedPath(workingDir, layerFileDirName);
-            if (Directory.Exists(fullDirPath))
-            {
-                Directory.Delete(fullDirPath, recursive: true);
-            }
+            string fullDirPath = GetContainedPath(
+                workingDir,
+                layerFileDirName,
+                allowFinalLink: true);
+            DeleteDestinationEntry(fullDirPath);
         }
 
         foreach (FileInfo layerFile in layerFiles.Where(IsWhiteout))
@@ -256,35 +272,30 @@ internal static class ImageHelper
             ValidatePathSegment(actualFileName, "whiteout target");
             string fullPath = GetContainedPath(
                 workingDir,
-                Path.Combine(layerFileDirName ?? string.Empty, actualFileName));
-
-            if (File.Exists(fullPath))
-            {
-                File.Delete(fullPath);
-            }
-            else if (Directory.Exists(fullPath))
-            {
-                bool isLink = File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
-                Directory.Delete(fullPath, recursive: !isLink);
-            }
+                Path.Combine(layerFileDirName ?? string.Empty, actualFileName),
+                allowFinalLink: true);
+            DeleteDestinationEntry(fullPath);
         }
 
         foreach (FileInfo layerFile in layerFiles.Where(file => !IsOpaqueWhiteout(file) && !IsWhiteout(file)))
         {
             cancellationToken.ThrowIfCancellationRequested();
             string layerFileRelativePath = Path.GetRelativePath(layerDir, layerFile.FullName);
-            string dest = GetContainedPath(workingDir, layerFileRelativePath);
+            string dest = GetContainedPath(
+                workingDir,
+                layerFileRelativePath,
+                allowFinalLink: true);
             string destDir = Path.GetDirectoryName(dest)!;
             if (!Directory.Exists(destDir))
             {
-                Directory.CreateDirectory(destDir);
+                CreateDestinationDirectory(workingDir, destDir, overwriteExisting);
             }
 
             if (layerFile.LinkTarget is not null)
             {
                 if (File.Exists(dest) || Directory.Exists(dest))
                 {
-                    File.Delete(dest);
+                    DeleteDestinationEntry(dest);
                 }
 
                 string sourceTarget = GetLinkTargetPath(layerDir, layerFile.FullName, layerFile.LinkTarget);
@@ -295,9 +306,73 @@ internal static class ImageHelper
             }
             else
             {
+                if (IsReparsePoint(dest) ||
+                    (overwriteExisting && Directory.Exists(dest)))
+                {
+                    DeleteDestinationEntry(dest);
+                }
+
                 await FileHelper.CopyFileAsync(
                     layerFile, dest, overwrite: true, cancellationToken);
             }
+        }
+    }
+
+    private static void CreateDestinationDirectory(
+        string workingDir,
+        string directoryPath,
+        bool overwriteExisting)
+    {
+        if (!overwriteExisting)
+        {
+            Directory.CreateDirectory(directoryPath);
+            return;
+        }
+
+        string currentPath = Path.GetFullPath(workingDir);
+        Directory.CreateDirectory(currentPath);
+        string relativePath = Path.GetRelativePath(currentPath, directoryPath);
+        if (relativePath == ".")
+        {
+            return;
+        }
+
+        foreach (string segment in relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries))
+        {
+            currentPath = Path.Combine(currentPath, segment);
+            if (File.Exists(currentPath))
+            {
+                File.Delete(currentPath);
+            }
+
+            Directory.CreateDirectory(currentPath);
+        }
+    }
+
+    private static void DeleteDestinationEntry(string path)
+    {
+        if (IsReparsePoint(path))
+        {
+            FileAttributes attributes = File.GetAttributes(path);
+            if (attributes.HasFlag(FileAttributes.Directory))
+            {
+                Directory.Delete(path);
+            }
+            else
+            {
+                File.Delete(path);
+            }
+        }
+        else if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+        else if (Directory.Exists(path))
+        {
+            bool isLink = File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+            Directory.Delete(path, recursive: !isLink);
         }
     }
 
@@ -377,7 +452,10 @@ internal static class ImageHelper
         return GetContainedPath(workingDir, target);
     }
 
-    private static string GetContainedPath(string rootPath, string relativePath)
+    private static string GetContainedPath(
+        string rootPath,
+        string relativePath,
+        bool allowFinalLink = false)
     {
         string fullRootPath = Path.GetFullPath(rootPath);
         string fullPath = Path.GetFullPath(Path.Combine(fullRootPath, relativePath));
@@ -392,21 +470,36 @@ internal static class ImageHelper
         }
 
         ValidateNoLinkParents(fullRootPath, fullPath);
-        if (IsReparsePoint(fullPath))
+        if (!allowFinalLink && IsReparsePoint(fullPath))
         {
             throw new InvalidDataException($"Path '{fullPath}' is a symbolic link.");
         }
         return fullPath;
     }
 
+    internal static void ValidateDestinationPath(string destinationPath)
+    {
+        string fullPath = Path.GetFullPath(destinationPath);
+        if (IsReparsePoint(fullPath))
+        {
+            throw new InvalidDataException(
+                $"Output path '{fullPath}' cannot be a symbolic link.");
+        }
+    }
+
     private static void ValidateNoLinkParents(string rootPath, string fullPath)
     {
         string? path = Path.GetDirectoryName(fullPath);
-        while (path is not null && !Path.GetFullPath(path).Equals(rootPath, StringComparison.OrdinalIgnoreCase))
+        while (path is not null)
         {
             if (IsReparsePoint(path))
             {
                 throw new InvalidDataException($"Path '{fullPath}' traverses a symbolic link.");
+            }
+
+            if (Path.GetFullPath(path).Equals(rootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                break;
             }
 
             path = Path.GetDirectoryName(path);

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -297,10 +297,7 @@ internal static class ImageHelper
 
             if (layerFile.LinkTarget is not null)
             {
-                if (File.Exists(dest) || Directory.Exists(dest))
-                {
-                    DeleteDestinationEntry(dest);
-                }
+                DeleteDestinationEntry(dest);
 
                 string sourceTarget = GetLinkTargetPath(layerDir, layerFile.FullName, layerFile.LinkTarget);
                 string destTarget = GetContainedPath(


### PR DESCRIPTION
Saving image layers into an existing output directory could overwrite or delete user content without explicit consent. This change makes destructive behavior opt-in while preserving the ability to intentionally refresh saved layers.

## Changes

- Reject existing files, symbolic-link output roots, and non-empty directories by default.
- Add `--force` to explicitly allow replacing conflicting files, directories, and symbolic-link leaves.
- Apply OCI whiteouts safely without following symbolic-link targets.
- Replace matching per-layer directories when using `--no-squash --force`.
- Preserve valid output paths beneath linked filesystem ancestors.
- Add regression coverage for validation, collision handling, whiteouts, symbolic links, and option binding.
- Document the output-path requirements and mode-specific `--force` behavior.

Fixes: #309