### PR TITLE
Return distinct exit code for layer differences

### DIFF
--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -271,6 +271,14 @@ dredge image compare layers <base> <target> [--output <format>] [--history] [--c
 | `--compressed-size` | Show compressed layer sizes |
 | `--no-color` | Disable color output and use text-based diff indicators instead |
 
+The command returns the following exit codes:
+
+| Exit code | Meaning |
+|----------:|---------|
+| `0` | The images have equal layers |
+| `1` | The command failed before completing the comparison |
+| `2` | The comparison completed and found layer differences |
+
 ### Inline output example
 
 ```diff

--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -800,7 +800,7 @@ public class CompareLayersCommandTests
 
         await command.RunAsync();
 
-        Assert.Null(processTerminator.ExitCode);
+        Assert.True(processTerminator.ExitCode is null or 0);
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CompareLayersCommandTests.cs
@@ -790,6 +790,66 @@ public class CompareLayersCommandTests
         Assert.Equal(longHistory, result.LayerComparisons.First().Base!.History);
     }
 
+    [Fact]
+    public async Task EqualImages_DoNotRequestNonzeroExitCode()
+    {
+        ImageSetup setup = new(new Image(), []);
+        TestCompareLayersCommand command = CreateTestCommand(setup, setup);
+        RecordingProcessTerminator processTerminator = new();
+        ((IProcessTerminationAware)command).ProcessTerminator = processTerminator;
+
+        await command.RunAsync();
+
+        Assert.Null(processTerminator.ExitCode);
+    }
+
+    [Fact]
+    public async Task DifferentImages_ExitTwo()
+    {
+        ImageSetup baseSetup = new(new Image(), []);
+        ImageSetup targetSetup = new(
+            new Image
+            {
+                History =
+                [
+                    new LayerHistory
+                    {
+                        CreatedBy = "added layer"
+                    }
+                ]
+            },
+            [
+                new ManifestLayer
+                {
+                    Digest = "layer-0",
+                    Size = 1
+                }
+            ]);
+        TestCompareLayersCommand command = CreateTestCommand(baseSetup, targetSetup);
+        RecordingProcessTerminator processTerminator = new();
+        ((IProcessTerminationAware)command).ProcessTerminator = processTerminator;
+
+        await command.RunAsync();
+
+        Assert.Equal(2, processTerminator.ExitCode);
+    }
+
+    [Fact]
+    public async Task RegistryFailure_ExitsOne()
+    {
+        Mock<IDockerRegistryClientFactory> clientFactory = new();
+        clientFactory
+            .Setup(o => o.GetClientAsync(Registry))
+            .ThrowsAsync(new InvalidOperationException("failure"));
+        TestCompareLayersCommand command = CreateTestCommand(clientFactory.Object);
+        RecordingProcessTerminator processTerminator = new();
+        ((IProcessTerminationAware)command).ProcessTerminator = processTerminator;
+
+        await command.RunAsync();
+
+        Assert.Equal(1, processTerminator.ExitCode);
+    }
+
     [Theory]
     [MemberData(nameof(GetTestData), CompareOutput.Inline)]
     public async Task Inline(
@@ -940,6 +1000,51 @@ public class CompareLayersCommandTests
             .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(imageConfig))));
     }
 
+    private static TestCompareLayersCommand CreateTestCommand(
+        ImageSetup baseImageSetup,
+        ImageSetup targetImageSetup)
+    {
+        Mock<IDockerRegistryClient> registryClient = new();
+        SetupDockerRegistryClient(
+            registryClient,
+            baseImageName,
+            baseImageSetup.Image,
+            baseImageSetup.Layers);
+        SetupDockerRegistryClient(
+            registryClient,
+            targetImageName,
+            targetImageSetup.Image,
+            targetImageSetup.Layers);
+        Mock<IDockerRegistryClientFactory> clientFactory = new();
+        clientFactory
+            .Setup(o => o.GetClientAsync(Registry))
+            .ReturnsAsync(registryClient.Object);
+
+        return CreateTestCommand(clientFactory.Object);
+    }
+
+    private static TestCompareLayersCommand CreateTestCommand(
+        IDockerRegistryClientFactory clientFactory)
+    {
+        IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(new StringWriter()),
+            Enrichment = new ProfileEnrichment
+            {
+                UseDefaultEnrichers = false
+            }
+        });
+
+        return new TestCompareLayersCommand(clientFactory, console)
+        {
+            Options = new CompareLayersOptions
+            {
+                BaseImage = baseImageName.ToString(),
+                TargetImage = targetImageName.ToString()
+            }
+        };
+    }
+
     private static string[] ToArray(params string?[] strings) =>
         [.. strings
             .Where(str => str is not null)
@@ -973,4 +1078,18 @@ public class CompareLayersCommandTests
             CompareDiff.Removed => "Removed",
             _ => throw new NotSupportedException()
         };
+
+    private sealed class TestCompareLayersCommand : CompareLayersCommand
+    {
+        public TestCompareLayersCommand(
+            IDockerRegistryClientFactory dockerRegistryClientFactory,
+            IAnsiConsole ansiConsole)
+            : base(dockerRegistryClientFactory, ansiConsole)
+        {
+        }
+
+        public Task RunAsync() => ExecuteAsync(TestContext.Current.CancellationToken);
+
+        protected override TextWriter Error => TextWriter.Null;
+    }
 }

--- a/src/Valleysoft.Dredge.Tests/ImageCommandIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageCommandIntegrationTests.cs
@@ -228,14 +228,20 @@ internal sealed class ImageCommandIntegrationScenarios
         IDockerRegistryClientFactory factory = fixture.CreateClientFactory();
 
         StringWriter layerOutput = new();
-        int layerExitCode = await InvokeAsync(
-            new CompareLayersCommand(factory, CreateConsole(layerOutput)),
-            baseName,
-            targetName,
-            "--output",
-            "json",
-            "--history",
-            "--compressed-size");
+        CompareLayersCommand layerCommand = new(factory, CreateConsole(layerOutput));
+        RecordingProcessTerminator layerProcessTerminator = new();
+        ((IProcessTerminationAware)layerCommand).ProcessTerminator = layerProcessTerminator;
+        await layerCommand
+            .Parse([
+                baseName,
+                targetName,
+                "--output",
+                "json",
+                "--history",
+                "--compressed-size"])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
 
         StringWriter metadataOutput = new();
         string settingsRoot = GetTempPath();
@@ -257,7 +263,7 @@ internal sealed class ImageCommandIntegrationScenarios
             DeleteDirectory(settingsRoot);
         }
 
-        Assert.Equal(0, layerExitCode);
+        Assert.Equal(2, layerProcessTerminator.ExitCode);
         JsonObject layers = JsonNode.Parse(layerOutput.ToString())!.AsObject();
         Assert.False(layers["summary"]!["areEqual"]!.GetValue<bool>());
         Assert.True(layers["summary"]!["targetIncludesAllBaseLayers"]!.GetValue<bool>());

--- a/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareLayersCommand.cs
@@ -22,9 +22,10 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
         this.ansiConsole = ansiConsole ?? AnsiConsole.Console;
     }
 
-    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        return ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
+        bool areEqual = true;
+        await ExecuteCommandAsync(registry: null, cancellationToken, async ct =>
         {
             CompareLayersResult result = await GetCompareLayersResult(ct);
             if (Options.OutputFormat == CompareOutput.Json)
@@ -36,7 +37,14 @@ public class CompareLayersCommand : RegistryCommandBase<CompareLayersOptions>
             {
                 ansiConsole.Write(GetOutput(result));
             }
+
+            areEqual = result.Summary.AreEqual;
         });
+
+        if (!areEqual)
+        {
+            Exit(2);
+        }
     }
 
     public async Task<IRenderable> GetOutputAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
`dredge image compare layers` currently requires automation to parse rendered output to determine whether two images differ. This change makes the comparison result available through a stable process exit status.

## Changes

- Return `0` when compared layers are equal, `2` when the comparison completes with differences, and preserve `1` for operational failures.
- Keep rendered and JSON output unchanged.
- Add command-level coverage for equal, different, and failed comparisons, and update the live-registry integration expectation.
- Document the exit-code contract. This intentionally changes the default exit status for completed comparisons that find differences.

## Validation

- Release build succeeds for .NET 9 and .NET 10.
- 488 focused layer-comparison tests pass.
- 960 non-integration tests pass.
- Docker-backed integration tests were not run because Docker is unavailable in the current environment.

Fixes: #310