### PR TITLE
Handle command failures consistently without stack traces

### DIFF
--- a/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
@@ -25,6 +25,20 @@ public sealed class CliProcessTests
         Assert.Contains("not-a-command", result.StandardError);
     }
 
+    [Theory]
+    [InlineData("get", "unknown")]
+    [InlineData("set", "unknown", "value")]
+    public async Task InvalidSetting_ReturnsConciseFailure(params string[] args)
+    {
+        ProcessResult result = await InvokeDredgeProcessAsync(["settings", ..args]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Unknown property: unknown", result.StandardError);
+        Assert.DoesNotContain("Unhandled exception", result.StandardError);
+        Assert.DoesNotContain("System.ArgumentException", result.StandardError);
+        Assert.DoesNotContain(" at Valleysoft.Dredge", result.StandardError);
+    }
+
     private static async Task<ProcessResult> InvokeDredgeProcessAsync(params string[] args)
     {
         ProcessStartInfo startInfo = new("dotnet")

--- a/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
@@ -24,7 +24,7 @@ public class CommandCancellationTests
     [Fact]
     public void CancellationAtRootReturnsFailureWithoutWritingError()
     {
-        CancellationCommand command = new();
+        CanceledCommand command = new();
         using StringWriter error = new();
 
         int exitCode = CommandHelper.InvokeRootCommand(
@@ -33,6 +33,20 @@ public class CommandCancellationTests
 
         Assert.Equal(1, exitCode);
         Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public void UnrelatedCancellationAtRootWritesConciseErrorAndReturnsFailure()
+    {
+        CancellationCommand command = new();
+        using StringWriter error = new();
+
+        int exitCode = CommandHelper.InvokeRootCommand(
+            command.Parse([]),
+            new InvocationConfiguration { Error = error });
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal($"failure{Environment.NewLine}", error.ToString());
     }
 
     [Fact]
@@ -133,7 +147,18 @@ public class CommandCancellationTests
         }
 
         protected override Task ExecuteAsync(CancellationToken cancellationToken) =>
-            throw new OperationCanceledException();
+            throw new OperationCanceledException("failure");
+    }
+
+    private sealed class CanceledCommand : CommandWithOptions<TestOptions>
+    {
+        public CanceledCommand()
+            : base("canceled", "Canceled command")
+        {
+        }
+
+        protected override Task ExecuteAsync(CancellationToken cancellationToken) =>
+            throw new OperationCanceledException(new CancellationToken(canceled: true));
     }
 
     public sealed class TestOptions : OptionsBase

--- a/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandCancellationTests.cs
@@ -8,6 +8,34 @@ public class CommandCancellationTests
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
 
     [Fact]
+    public void RootInvocationWritesConciseErrorAndReturnsFailure()
+    {
+        FailureCommand command = new();
+        using StringWriter error = new();
+
+        int exitCode = CommandHelper.InvokeRootCommand(
+            command.Parse([]),
+            new InvocationConfiguration { Error = error });
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal($"failure{Environment.NewLine}", error.ToString());
+    }
+
+    [Fact]
+    public void CancellationAtRootReturnsFailureWithoutWritingError()
+    {
+        CancellationCommand command = new();
+        using StringWriter error = new();
+
+        int exitCode = CommandHelper.InvokeRootCommand(
+            command.Parse([]),
+            new InvocationConfiguration { Error = error });
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(error.ToString());
+    }
+
+    [Fact]
     public async Task CancellationPropagatesFromCommandHelper()
     {
         using CancellationTokenSource cancellationTokenSource = new();
@@ -29,6 +57,23 @@ public class CommandCancellationTests
 
         Assert.True(executed);
         Assert.Empty(error.ToString());
+    }
+
+    [Fact]
+    public async Task CancellationFromCommandIsFailureWhenInvocationTokenIsNotCanceled()
+    {
+        using StringWriter error = new();
+        int? exitCode = null;
+
+        await CommandHelper.ExecuteCommandAsync(
+            registry: null,
+            CancellationToken.None,
+            ct => throw new OperationCanceledException("failure"),
+            error,
+            code => exitCode = code);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal($"failure{Environment.NewLine}", error.ToString());
     }
 
     [Fact]
@@ -67,6 +112,28 @@ public class CommandCancellationTests
             Started.SetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         }
+    }
+
+    private sealed class FailureCommand : CommandWithOptions<TestOptions>
+    {
+        public FailureCommand()
+            : base("failure", "Failure command")
+        {
+        }
+
+        protected override Task ExecuteAsync(CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("failure");
+    }
+
+    private sealed class CancellationCommand : CommandWithOptions<TestOptions>
+    {
+        public CancellationCommand()
+            : base("cancel", "Cancellation command")
+        {
+        }
+
+        protected override Task ExecuteAsync(CancellationToken cancellationToken) =>
+            throw new OperationCanceledException();
     }
 
     public sealed class TestOptions : OptionsBase

--- a/src/Valleysoft.Dredge.Tests/RegistryIntegrationTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryIntegrationTests.cs
@@ -72,6 +72,9 @@ internal sealed class RegistryIntegrationScenarios
         Assert.Equal(1, terminator.ExitCode);
         Assert.Empty(output.ToString());
         Assert.NotEmpty(error.ToString());
+        Assert.DoesNotContain("Unhandled exception", error.ToString());
+        Assert.DoesNotContain("RegistryException", error.ToString());
+        Assert.DoesNotContain(" at Valleysoft.Dredge", error.ToString());
     }
 
     public async Task ListCommands_QueryLiveRegistry()

--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -17,7 +17,7 @@ internal static class CommandHelper
         {
             return parseResult.Invoke(configuration);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
         {
             return 1;
         }

--- a/src/Valleysoft.Dredge/CommandHelper.cs
+++ b/src/Valleysoft.Dredge/CommandHelper.cs
@@ -1,10 +1,33 @@
-﻿using Valleysoft.DockerRegistryClient;
+﻿using System.CommandLine;
+using Valleysoft.DockerRegistryClient;
 using Valleysoft.DockerRegistryClient.Models;
 
 namespace Valleysoft.Dredge;
 
 internal static class CommandHelper
 {
+    public static int InvokeRootCommand(
+        ParseResult parseResult,
+        InvocationConfiguration? configuration = null)
+    {
+        configuration ??= new InvocationConfiguration();
+        configuration.EnableDefaultExceptionHandler = false;
+
+        try
+        {
+            return parseResult.Invoke(configuration);
+        }
+        catch (OperationCanceledException)
+        {
+            return 1;
+        }
+        catch (Exception e)
+        {
+            WriteError(e, registry: null, configuration.Error);
+            return 1;
+        }
+    }
+
     public static async Task ExecuteCommandAsync(
         string? registry,
         CancellationToken cancellationToken,
@@ -30,29 +53,35 @@ internal static class CommandHelper
     private static void WriteError(Exception e, string? registry, TextWriter? errorWriter)
     {
         ConsoleColor savedColor = Console.ForegroundColor;
-        Console.ForegroundColor = ConsoleColor.Red;
-
-        string message = e.Message;
-        if (e is RegistryException dockerRegistryException)
+        try
         {
-            Error? error = dockerRegistryException.Errors.FirstOrDefault();
-            if (error?.Code == "UNAUTHORIZED")
+            Console.ForegroundColor = ConsoleColor.Red;
+
+            string message = e.Message;
+            if (e is RegistryException dockerRegistryException)
             {
-                string loginCommand = "docker login";
-                if (registry is not null)
+                Error? error = dockerRegistryException.Errors.FirstOrDefault();
+                if (error?.Code == "UNAUTHORIZED")
                 {
-                    loginCommand += $" {registry}";
+                    string loginCommand = "docker login";
+                    if (registry is not null)
+                    {
+                        loginCommand += $" {registry}";
+                    }
+
+                    message = $"The repository does not exist or may require authentication. If authentication is required, ensure that your credentials are stored for the registry by running '{loginCommand}'.";
                 }
+                else
+                {
+                    message = error?.Message ?? message;
+                }
+            }
 
-                message = $"The repository does not exist or may require authentication. If authentication is required, ensure that your credentials are stored for the registry by running '{loginCommand}'.";
-            }
-            else
-            {
-                message = error?.Message ?? message;
-            }
+            (errorWriter ?? Console.Error).WriteLine(message);
         }
-
-        (errorWriter ?? Console.Error).WriteLine(message);
-        Console.ForegroundColor = savedColor;
+        finally
+        {
+            Console.ForegroundColor = savedColor;
+        }
     }
 }

--- a/src/Valleysoft.Dredge/Program.cs
+++ b/src/Valleysoft.Dredge/Program.cs
@@ -21,4 +21,4 @@ RootCommand rootCmd = new("CLI for executing commands on a container registry's 
     new SettingsCommand(),
 };
 
-return rootCmd.Parse(args).Invoke();
+return CommandHelper.InvokeRootCommand(rootCmd.Parse(args));


### PR DESCRIPTION
Some commands relied on System.CommandLine's default exception handler, which exposed full .NET stack traces for expected user errors such as unknown setting names.

## Summary

- add a root invocation boundary that writes concise diagnostics to stderr and returns exit code 1
- preserve registry-specific error and authentication guidance
- retain silent process cancellation while treating unrelated cancellation exceptions as command failures
- cover invalid settings, cancellation paths, and representative registry failures

## Testing

- `dotnet test --no-restore -v minimal -c Release --filter "Category!=Integration"` (984 passed across .NET 9 and .NET 10)
- focused command failure and cancellation tests (42 passed across .NET 9 and .NET 10)
- live-registry integration tests were not run locally because Docker was unavailable

Fixes: #313