### PR TITLE
Validate layer indexes during command parsing

### DIFF
--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -2,6 +2,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Globalization;
 using Valleysoft.Dredge.Commands;
 using Valleysoft.Dredge.Commands.Image;
 using Valleysoft.Dredge.Commands.Manifest;
@@ -157,6 +158,147 @@ public class CommandStructureTests
         Assert.Equal(1, options.BaseLayerIndex);
         Assert.Equal(2, options.TargetLayerIndex);
         Assert.Equal(CompareFilesOutput.ExternalTool, options.OutputType);
+    }
+
+    [Fact]
+    public void LayerIndexOptions_DescribeIndexesAsZeroBased()
+    {
+        (OptionsBase Options, string OptionName, string ExpectedDescription)[] cases =
+        [
+            (
+                new SaveLayersOptions(),
+                "--layer-index",
+                "Zero-based index of the image layer to target"),
+            (
+                new CompareFilesOptions(),
+                CompareFilesOptions.BaseLayerIndexOptionName,
+                "Zero-based non-empty layer index of the base container image to compare with"),
+            (
+                new CompareFilesOptions(),
+                CompareFilesOptions.TargetLayerIndexOptionName,
+                "Zero-based non-empty layer index of the target container image to compare against")
+        ];
+
+        foreach ((OptionsBase options, string optionName, string expectedDescription) in cases)
+        {
+            Command command = new("test");
+            options.SetCommandOptions(command);
+
+            Option option = Assert.Single(command.Options, option => option.Name == optionName);
+
+            Assert.Equal(expectedDescription, option.Description);
+        }
+    }
+
+    [Fact]
+    public void LayerIndexOptions_RejectNegativeValuesAndAcceptZero()
+    {
+        (OptionsBase Options, string[] Arguments, string OptionName)[] cases =
+        [
+            (
+                new SaveLayersOptions(),
+                ["image", "output", "--layer-index"],
+                "--layer-index"),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.BaseLayerIndexOptionName],
+                CompareFilesOptions.BaseLayerIndexOptionName),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.TargetLayerIndexOptionName],
+                CompareFilesOptions.TargetLayerIndexOptionName)
+        ];
+
+        foreach ((OptionsBase options, string[] arguments, string optionName) in cases)
+        {
+            Command command = new("test");
+            options.SetCommandOptions(command);
+
+            ParseResult negativeResult = command.Parse([.. arguments, "-1"]);
+            ParseResult zeroResult = command.Parse([.. arguments, "0"]);
+
+            Assert.Single(negativeResult.Errors);
+            Assert.Equal(
+                $"Layer index for option '{optionName}' must be zero or greater.",
+                negativeResult.Errors[0].Message);
+            Assert.Empty(zeroResult.Errors);
+        }
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("2147483648")]
+    [InlineData("-2147483649")]
+    public void LayerIndexOptions_ReportInvalidIntegerValuesWithoutThrowing(string value)
+    {
+        (OptionsBase Options, string[] Arguments)[] cases =
+        [
+            (
+                new SaveLayersOptions(),
+                ["image", "output", "--layer-index"]),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.BaseLayerIndexOptionName]),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.TargetLayerIndexOptionName])
+        ];
+
+        foreach ((OptionsBase options, string[] arguments) in cases)
+        {
+            Command command = new("test");
+            options.SetCommandOptions(command);
+
+            ParseResult result = command.Parse([.. arguments, value]);
+
+            Assert.Single(result.Errors);
+            Assert.Contains(value, result.Errors[0].Message);
+        }
+    }
+
+    [Fact]
+    public void LayerIndexOptions_RejectCultureSpecificNegativeValues()
+    {
+        (OptionsBase Options, string[] Arguments, string OptionName)[] cases =
+        [
+            (
+                new SaveLayersOptions(),
+                ["image", "output", "--layer-index"],
+                "--layer-index"),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.BaseLayerIndexOptionName],
+                CompareFilesOptions.BaseLayerIndexOptionName),
+            (
+                new CompareFilesOptions(),
+                ["base", "target", CompareFilesOptions.TargetLayerIndexOptionName],
+                CompareFilesOptions.TargetLayerIndexOptionName)
+        ];
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("sv-SE");
+            string negativeOne =
+                $"{CultureInfo.CurrentCulture.NumberFormat.NegativeSign}1";
+
+            foreach ((OptionsBase options, string[] arguments, string optionName) in cases)
+            {
+                Command command = new("test");
+                options.SetCommandOptions(command);
+
+                ParseResult result = command.Parse([.. arguments, negativeOne]);
+
+                Assert.Single(result.Errors);
+                Assert.Equal(
+                    $"Layer index for option '{optionName}' must be zero or greater.",
+                    result.Errors[0].Message);
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageHelperTests.cs
@@ -176,6 +176,68 @@ public class ImageHelperTests
         }
     }
 
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenLayerIndexIsLastManifestLayer_Succeeds()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        string firstDigest = $"sha256:{id}-one";
+        string secondDigest = $"sha256:{id}-two";
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"dredge-layer-boundary-{id}");
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest
+                {
+                    Layers =
+                    [
+                        new ManifestLayer { Digest = firstDigest },
+                        new ManifestLayer { Digest = secondDigest }
+                    ]
+                }));
+        client
+            .Setup(o => o.Blobs.GetAsync("library/image", secondDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => CreateLayer(("file.txt", "content")));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        try
+        {
+            await ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                Path.Combine(tempRoot, "output"),
+                layerIndex: 1,
+                "--layer-index",
+                noSquash: true,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken,
+                new TestDredgePathProvider(tempRoot));
+
+            client.Verify(
+                o => o.Blobs.GetAsync(
+                    "library/image",
+                    firstDigest,
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+            client.Verify(
+                o => o.Blobs.GetAsync(
+                    "library/image",
+                    secondDigest,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(2)]
@@ -206,9 +268,44 @@ public class ImageHelperTests
                 layerIndex,
                 "--layer-index",
                 noSquash: false,
-                new PlatformOptionsBase()));
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken));
 
-        Assert.Equal("Value is out of range for the '--layer-index' option.", exception.Message);
+        Assert.Equal(
+            "Value for the '--layer-index' option must be in the range 0-1.",
+            exception.Message);
+        client.Verify(
+            o => o.Blobs.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveImageLayersToDiskAsync_WhenManifestHasNoLayers_Throws()
+    {
+        Mock<IDockerRegistryClient> client = new() { DefaultValue = DefaultValue.Mock };
+        client
+            .Setup(o => o.Manifests.GetAsync("library/image", "latest", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ManifestInfo(
+                "application/test",
+                "sha256:manifest",
+                new DockerManifest { Layers = [] }));
+        Mock<IDockerRegistryClientFactory> factory = new();
+        factory.Setup(o => o.GetClientAsync(null)).ReturnsAsync(client.Object);
+
+        Exception exception = await Assert.ThrowsAsync<Exception>(
+            () => ImageHelper.SaveImageLayersToDiskAsync(
+                factory.Object,
+                "image",
+                "output",
+                layerIndex: 0,
+                "--layer-index",
+                noSquash: false,
+                new PlatformOptionsBase(),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "The image has no layers, so the '--layer-index' option cannot be used.",
+            exception.Message);
         client.Verify(
             o => o.Blobs.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesCommand.cs
@@ -46,10 +46,18 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
             }
 
             await SaveImageLayersToDiskAsync(
-                Options.BaseImage, BaseOutputDirName, Options.BaseLayerIndex, CompareOptionsBase.BaseArg, ct);
+                Options.BaseImage,
+                BaseOutputDirName,
+                Options.BaseLayerIndex,
+                CompareFilesOptions.BaseLayerIndexOptionName,
+                ct);
             Console.Error.WriteLine();
             await SaveImageLayersToDiskAsync(
-                Options.TargetImage, TargetOutputDirName, Options.TargetLayerIndex, CompareOptionsBase.TargetArg, ct);
+                Options.TargetImage,
+                TargetOutputDirName,
+                Options.TargetLayerIndex,
+                CompareFilesOptions.TargetLayerIndexOptionName,
+                ct);
 
             string compareTempPath = Path.Combine(pathProvider.TempPath, "compare");
             string args = settings.FileCompareTool.Args
@@ -64,7 +72,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
         string image,
         string outputDirName,
         int? layerIndex,
-        string layerIndexArg,
+        string layerIndexOptionName,
         CancellationToken cancellationToken)
     {
         string workingDir = Path.Combine(pathProvider.TempPath, "compare", outputDirName);
@@ -78,7 +86,7 @@ public class CompareFilesCommand : RegistryCommandBase<CompareFilesOptions>
             image,
             workingDir,
             layerIndex,
-            layerIndexArg + CompareFilesOptions.LayerIndexSuffix,
+            layerIndexOptionName,
             noSquash: false,
             Options,
             cancellationToken,

--- a/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareFilesOptions.cs
@@ -5,6 +5,8 @@ namespace Valleysoft.Dredge.Commands.Image;
 public class CompareFilesOptions : CompareOptionsBase
 {
     public const string LayerIndexSuffix = "-layer-index";
+    public const string BaseLayerIndexOptionName = $"--{BaseArg}{LayerIndexSuffix}";
+    public const string TargetLayerIndexOptionName = $"--{TargetArg}{LayerIndexSuffix}";
 
     private readonly Option<int?> baseLayerIndex;
     private readonly Option<int?> targetLayerIndex;
@@ -16,8 +18,12 @@ public class CompareFilesOptions : CompareOptionsBase
 
     public CompareFilesOptions()
     {
-        baseLayerIndex = Add(new Option<int?>($"--{BaseArg}{LayerIndexSuffix}") { Description = "Non-empty layer index of the base container image to compare with" });
-        targetLayerIndex = Add(new Option<int?>($"--{TargetArg}{LayerIndexSuffix}") { Description = "Non-empty layer index of the target container image to compare against" });
+        baseLayerIndex = Add(LayerIndexOption.Create(
+            BaseLayerIndexOptionName,
+            "non-empty layer index of the base container image to compare with"));
+        targetLayerIndex = Add(LayerIndexOption.Create(
+            TargetLayerIndexOptionName,
+            "non-empty layer index of the target container image to compare against"));
         outputOption = new CliOutputOption<CompareFilesOutput>(
             "Output type",
             CompareFilesOutput.ExternalTool,

--- a/src/Valleysoft.Dredge/Commands/Image/LayerIndexOption.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LayerIndexOption.cs
@@ -1,0 +1,30 @@
+using System.CommandLine;
+using System.Globalization;
+
+namespace Valleysoft.Dredge.Commands.Image;
+
+internal static class LayerIndexOption
+{
+    public static Option<int?> Create(string name, string description)
+    {
+        Option<int?> option = new(name)
+        {
+            Description = $"Zero-based {description}"
+        };
+        option.Validators.Add(result =>
+        {
+            if (result.Tokens.Count is 1 &&
+                int.TryParse(
+                    result.Tokens[0].Value,
+                    NumberStyles.Integer,
+                    CultureInfo.CurrentCulture,
+                    out int value) &&
+                value < 0)
+            {
+                result.AddError($"Layer index for option '{name}' must be zero or greater.");
+            }
+        });
+
+        return option;
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
@@ -21,7 +21,9 @@ public class SaveLayersOptions : PlatformOptionsBase
         imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
         outputPathArg = Add(new Argument<string>("output-path") { Description = "Path to the output location" });
         noSquashOption = Add(new Option<bool>("--no-squash") { Description = "Do not squash the image layers" });
-        layerIndexOption = Add(new Option<int?>(LayerIndexOptionName) { Description = "Index of the image layer to target" });
+        layerIndexOption = Add(LayerIndexOption.Create(
+            LayerIndexOptionName,
+            "index of the image layer to target"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/ImageHelper.cs
+++ b/src/Valleysoft.Dredge/ImageHelper.cs
@@ -38,7 +38,10 @@ internal static class ImageHelper
         {
             if (layerIndex < 0 || layerIndex >= manifest.Layers.Length)
             {
-                throw new Exception($"Value is out of range for the '{layerIndexOptionName}' option.");
+                string message = manifest.Layers.Length is 0
+                    ? $"The image has no layers, so the '{layerIndexOptionName}' option cannot be used."
+                    : $"Value for the '{layerIndexOptionName}' option must be in the range 0-{manifest.Layers.Length - 1}.";
+                throw new Exception(message);
             }
             layerCount = layerIndex.Value + 1;
 


### PR DESCRIPTION
Negative layer indexes were accepted until after the image manifest had been fetched, causing avoidable registry work and producing vague range errors.

This change centralizes layer-index option construction so all affected options advertise zero-based indexing and reject negative values during parsing. Manifest-dependent upper-bound validation remains in `ImageHelper`, with explicit valid ranges and a dedicated message for images with no layers. The comparison commands now share their full option names between registration and runtime diagnostics.

Tests cover negative, malformed, overflowing, culture-specific, boundary, and empty-manifest inputs across .NET 9 and .NET 10. The complete Docker-backed suite passes with 501 tests per target framework.

Fixes: #316