### PR TITLE
Validate image references before registry requests

### DIFF
--- a/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CliProcessTests.cs
@@ -25,6 +25,21 @@ public sealed class CliProcessTests
         Assert.Contains("not-a-command", result.StandardError);
     }
 
+    [Fact]
+    public async Task InvalidImageReference_ReturnsComponentErrorAndAcceptedForms()
+    {
+        ProcessResult result = await InvokeDredgeProcessAsync(
+            "manifest",
+            "digest",
+            "Invalid/Repo");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Invalid repository", result.StandardError);
+        Assert.Contains(
+            "Expected <image>, <image>:<tag>, or <image>@<digest>.",
+            result.StandardError);
+    }
+
     private static async Task<ProcessResult> InvokeDredgeProcessAsync(params string[] args)
     {
         ProcessStartInfo startInfo = new("dotnet")

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -500,6 +500,9 @@ public class CommandStructureTests
         {
             Command command = new("test");
             imageOptions.SetCommandOptions(command);
+            string invalidArgumentName = imageOptions is CompareFilesOptions
+                ? CompareOptionsBase.BaseArg
+                : "image";
             string[] arguments = command.Arguments
                 .Select(argument => argument.Name switch
                 {
@@ -522,9 +525,31 @@ public class CommandStructureTests
                 parseResult.Errors,
                 error => error.Message.Contains("Invalid repository", StringComparison.Ordinal) &&
                     error.Message.Contains(
-                        "Expected <image>, <image>:<tag>, or <image>@<digest>.",
+                        $"Expected <{invalidArgumentName}>, <{invalidArgumentName}>:<tag>, " +
+                        $"or <{invalidArgumentName}>@<digest>.",
                         StringComparison.Ordinal));
         }
+    }
+
+    [Theory]
+    [InlineData("Invalid/Repo", "valid/target", "base")]
+    [InlineData("valid/base", "Invalid/Repo", "target")]
+    public void CompareImageArguments_UseArgumentNameInValidationError(
+        string baseImage,
+        string targetImage,
+        string invalidArgumentName)
+    {
+        Command command = new("test");
+        new CompareFilesOptions().SetCommandOptions(command);
+
+        ParseResult parseResult = command.Parse([baseImage, targetImage]);
+
+        ParseError error = Assert.Single(parseResult.Errors);
+        Assert.Contains(
+            $"Expected <{invalidArgumentName}>, <{invalidArgumentName}>:<tag>, " +
+                $"or <{invalidArgumentName}>@<digest>.",
+            error.Message,
+            StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
+++ b/src/Valleysoft.Dredge.Tests/CommandStructureTests.cs
@@ -332,6 +332,77 @@ public class CommandStructureTests
         Assert.Equal(3, referrer.Limit);
     }
 
+    [Fact]
+    public void ImageArguments_RejectInvalidReferencesWithAcceptedForms()
+    {
+        OptionsBase[] options =
+        [
+            new ImageInspectOptions(),
+            new OsOptions(),
+            new LsOptions(),
+            new CatOptions(),
+            new ExtractOptions(),
+            new CompareFilesOptions(),
+            new SaveLayersOptions(),
+            new DockerfileOptions(),
+            new ManifestGetOptions(),
+            new ManifestDigestOptions(),
+            new ManifestResolveOptions(),
+            new ReferrerListOptions(),
+            new CheckOptions(),
+            new ReferrerInspectOptions(),
+            new ReferrerGetOptions()
+        ];
+
+        foreach (OptionsBase imageOptions in options)
+        {
+            Command command = new("test");
+            imageOptions.SetCommandOptions(command);
+            string[] arguments = command.Arguments
+                .Select(argument => argument.Name switch
+                {
+                    "image" or "base" => "Invalid/Repo",
+                    "target" => "valid/target",
+                    "path" => "/path",
+                    "output-path" => "output",
+                    "artifact-digest" => "sha256:artifact",
+                    _ => throw new InvalidOperationException(
+                        $"Unexpected argument '{argument.Name}'.")
+                })
+                .Concat(imageOptions is CheckOptions
+                    ? ["--artifact-type", "application/test"]
+                    : [])
+                .ToArray();
+
+            ParseResult parseResult = command.Parse(arguments);
+
+            Assert.Contains(
+                parseResult.Errors,
+                error => error.Message.Contains("Invalid repository", StringComparison.Ordinal) &&
+                    error.Message.Contains(
+                        "Expected <image>, <image>:<tag>, or <image>@<digest>.",
+                        StringComparison.Ordinal));
+        }
+    }
+
+    [Theory]
+    [InlineData("repository:tag")]
+    [InlineData("repository@sha256:digest")]
+    public void TagListOptions_RejectTagAndDigest(string repository)
+    {
+        Command command = new("test");
+        new TagListOptions().SetCommandOptions(command);
+
+        ParseResult parseResult = command.Parse(repository);
+
+        ParseError error = Assert.Single(parseResult.Errors);
+        Assert.Contains("Invalid repository", error.Message, StringComparison.Ordinal);
+        Assert.Contains(
+            "Expected <repository> or <registry>/<repository>.",
+            error.Message,
+            StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("0")]
     [InlineData("-1")]
@@ -349,7 +420,10 @@ public class CommandStructureTests
             Command command = new("list");
             listOptions.SetCommandOptions(command);
 
-            ParseResult parseResult = command.Parse(["registry.example/repo:tag", "--limit", limit]);
+            string value = listOptions is TagListOptions
+                ? "registry.example/repo"
+                : "registry.example/repo:tag";
+            ParseResult parseResult = command.Parse([value, "--limit", limit]);
 
             Assert.Single(parseResult.Errors);
             Assert.Equal("Limit must be greater than zero.", parseResult.Errors[0].Message);

--- a/src/Valleysoft.Dredge.Tests/ImageNameTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ImageNameTests.cs
@@ -39,12 +39,54 @@ public class ImageNameTests
         null,
         "localhost:5000/dredge:v1")]
     [InlineData(
-        "ghcr.io/mthalman/dredge@sha256:abcdef",
+        "REGISTRY/team/image:v1",
+        "REGISTRY",
+        "team/image",
+        "v1",
+        null,
+        "REGISTRY/team/image:v1")]
+    [InlineData(
+        "09:5000/repo",
+        "09:5000",
+        "repo",
+        "latest",
+        null,
+        "09:5000/repo:latest")]
+    [InlineData(
+        "09/repo",
+        null,
+        "09/repo",
+        "latest",
+        null,
+        "09/repo:latest")]
+    [InlineData(
+        "ghcr.io/mthalman/dredge@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "ghcr.io",
         "mthalman/dredge",
         null,
-        "sha256:abcdef",
-        "ghcr.io/mthalman/dredge@sha256:abcdef")]
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "ghcr.io/mthalman/dredge@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")]
+    [InlineData(
+        "ghcr.io/mthalman/dredge@multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8",
+        "ghcr.io",
+        "mthalman/dredge",
+        null,
+        "multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8",
+        "ghcr.io/mthalman/dredge@multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8")]
+    [InlineData(
+        "localhost/dredge",
+        "localhost",
+        "dredge",
+        "latest",
+        null,
+        "localhost/dredge:latest")]
+    [InlineData(
+        "[2001:db8::1]:5000/team/image:Release-1",
+        "[2001:db8::1]:5000",
+        "team/image",
+        "Release-1",
+        null,
+        "[2001:db8::1]:5000/team/image:Release-1")]
     public void Parse_ReturnsExpectedComponents(
         string value,
         string? expectedRegistry,
@@ -60,6 +102,126 @@ public class ImageNameTests
         Assert.Equal(expectedTag, imageName.Tag);
         Assert.Equal(expectedDigest, imageName.Digest);
         Assert.Equal(expectedString, imageName.ToString());
+    }
+
+    [Theory]
+    [InlineData("", "image reference")]
+    [InlineData(" ", "image reference")]
+    [InlineData("repo/", "repository")]
+    [InlineData("repo//image", "repository")]
+    [InlineData("registry.example/team\n/app:v1", "repository")]
+    [InlineData("Repo", "repository")]
+    [InlineData("repo:", "tag")]
+    [InlineData("repo:bad tag", "tag")]
+    [InlineData("repo@", "digest")]
+    [InlineData("repo@sha256", "digest")]
+    [InlineData("repo@sha256\n:a", "digest")]
+    [InlineData("repo@sha256:bad!", "digest")]
+    [InlineData("repo@sha256:abcdef", "digest")]
+    [InlineData("repo@sha256:ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789", "digest")]
+    [InlineData("repo@sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "digest")]
+    [InlineData("repo@SHA256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "digest")]
+    [InlineData("repo:tag@sha256:value", "both a tag and a digest")]
+    [InlineData("registry.example:/repo", "registry")]
+    [InlineData("registry.example:abc/repo", "registry")]
+    [InlineData("registry.example:+5/repo", "registry")]
+    [InlineData("registry.example: 5/repo", "registry")]
+    [InlineData("registry.example:5 /repo", "registry")]
+    [InlineData("registry.example:65536/repo", "registry")]
+    [InlineData("registry..example/repo", "registry")]
+    [InlineData("MY_HOST/repo", "registry")]
+    [InlineData("[fe80::1%12]/repo", "registry")]
+    [InlineData("[::ffff:192.0.2.1]/repo", "registry")]
+    [InlineData("https://registry.example/repo", "registry")]
+    public void TryParse_InvalidReference_ReturnsComponentError(
+        string value,
+        string expectedError)
+    {
+        bool succeeded = ImageName.TryParse(value, out ImageName? imageName, out string? error);
+
+        Assert.False(succeeded);
+        Assert.Null(imageName);
+        Assert.Contains(expectedError, error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("ubuntu", null, "library/ubuntu")]
+    [InlineData("owner/image", null, "owner/image")]
+    [InlineData(
+        "registry.example:5000/owner/image",
+        "registry.example:5000",
+        "owner/image")]
+    public void TryParseRepository_ValidRepository_ReturnsImageName(
+        string value,
+        string? expectedRegistry,
+        string expectedRepo)
+    {
+        bool succeeded = ImageName.TryParseRepository(
+            value,
+            out ImageName? imageName,
+            out string? error);
+
+        Assert.True(succeeded, error);
+        Assert.NotNull(imageName);
+        Assert.Equal(expectedRegistry, imageName.Registry);
+        Assert.Equal(expectedRepo, imageName.Repo);
+        Assert.Equal("latest", imageName.Tag);
+        Assert.Null(imageName.Digest);
+    }
+
+    [Theory]
+    [InlineData("ubuntu:latest")]
+    [InlineData("owner/image@sha256:value")]
+    public void TryParseRepository_TagOrDigest_ReturnsRepositoryError(string value)
+    {
+        bool succeeded = ImageName.TryParseRepository(
+            value,
+            out ImageName? imageName,
+            out string? error);
+
+        Assert.False(succeeded);
+        Assert.Null(imageName);
+        Assert.Contains("repository", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_InvalidReference_ThrowsComponentError()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => ImageName.Parse("registry.example:invalid/repo"));
+
+        Assert.Contains("registry", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryParse_DockerHubShorthandAtNormalizedLengthLimit_Succeeds()
+    {
+        string value = new('a', 247);
+
+        bool succeeded = ImageName.TryParse(
+            value,
+            out ImageName? imageName,
+            out string? error);
+
+        Assert.True(succeeded, error);
+        Assert.NotNull(imageName);
+        Assert.Equal(255, imageName.Repo.Length);
+    }
+
+    [Fact]
+    public void TryParse_DockerHubShorthandOverNormalizedLengthLimit_ReturnsRepositoryError()
+    {
+        string value = new('a', 248);
+
+        bool succeeded = ImageName.TryParse(
+            value,
+            out ImageName? imageName,
+            out string? error);
+
+        Assert.False(succeeded);
+        Assert.Null(imageName);
+        Assert.Contains("repository", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("255", error, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerArtifactCommandTests.cs
@@ -13,7 +13,8 @@ public class ReferrerArtifactCommandTests
 {
     private const string Registry = "registry.example";
     private const string Repository = "repo";
-    private const string SubjectDigest = "sha256:subject";
+    private const string SubjectDigest =
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     private const string ArtifactDigest = "sha256:artifact";
 
     [Fact]

--- a/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/ReferrerCheckCommandTests.cs
@@ -11,6 +11,8 @@ using OciManifestReference = Valleysoft.DockerRegistryClient.Models.Manifests.Oc
 public class ReferrerCheckCommandTests
 {
     private const string Registry = "registry.example";
+    private const string ImageDigest =
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     [Fact]
     public async Task CheckCommand_ResolvesTagCombinesPagesAndReportsAllMatches()
@@ -28,9 +30,9 @@ public class ReferrerCheckCommandTests
         Mock<IDockerRegistryClient> client = CreateClient();
         client
             .Setup(o => o.Manifests.GetAsync("repo", "tag", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateManifestInfo("sha256:image"));
+            .ReturnsAsync(CreateManifestInfo(ImageDigest));
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Page<OciImageIndex>(
                 new OciImageIndex { Manifests = [sbom] },
                 "next"));
@@ -65,7 +67,7 @@ public class ReferrerCheckCommandTests
             """.ReplaceLineEndings(),
             output.ToString());
         client.Verify(
-            o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()),
+            o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()),
             Times.Once);
         client.Verify(
             o => o.Referrers.GetNextAsync("next", It.IsAny<CancellationToken>()),
@@ -77,7 +79,7 @@ public class ReferrerCheckCommandTests
     {
         Mock<IDockerRegistryClient> client = CreateClient();
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Page<OciImageIndex>(
                 new OciImageIndex
                 {
@@ -96,7 +98,7 @@ public class ReferrerCheckCommandTests
         {
             Options = new CheckOptions
             {
-                Image = $"{Registry}/repo@sha256:image",
+                Image = $"{Registry}/repo@{ImageDigest}",
                 ArtifactTypes =
                 [
                     "application/spdx+json",
@@ -129,7 +131,7 @@ public class ReferrerCheckCommandTests
     {
         Mock<IDockerRegistryClient> client = CreateClient();
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Page<OciImageIndex>(
                 new OciImageIndex
                 {
@@ -150,7 +152,7 @@ public class ReferrerCheckCommandTests
         {
             Options = new CheckOptions
             {
-                Image = $"{Registry}/repo@sha256:image",
+                Image = $"{Registry}/repo@{ImageDigest}",
                 ArtifactTypes = ["application/spdx+json"],
                 OutputFormat = CheckOutput.Json
             }
@@ -171,14 +173,14 @@ public class ReferrerCheckCommandTests
     {
         Mock<IDockerRegistryClient> client = CreateClient();
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("failure"));
         using StringWriter output = new();
         TestCheckCommand command = new(CreateFactory(client.Object), output)
         {
             Options = new CheckOptions
             {
-                Image = $"{Registry}/repo@sha256:image",
+                Image = $"{Registry}/repo@{ImageDigest}",
                 ArtifactTypes = ["application/spdx+json"]
             }
         };

--- a/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
+++ b/src/Valleysoft.Dredge.Tests/RegistryCommandTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Valleysoft.Dredge.Tests;
 
+using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text;
@@ -26,6 +27,35 @@ using OciManifestReference = Valleysoft.DockerRegistryClient.Models.Manifests.Oc
 public class RegistryCommandTests
 {
     private const string Registry = "registry.example";
+    private const string ImageDigest =
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    [Theory]
+    [InlineData("Invalid/Repo")]
+    [InlineData("[fe80::1%12]/repo")]
+    [InlineData("[::ffff:192.0.2.1]/repo")]
+    [InlineData("registry.example/team\n/app:v1")]
+    [InlineData("repo@sha256\n:a")]
+    [InlineData("repo@sha256:abcdef")]
+    [InlineData("repo@sha256:ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789")]
+    [InlineData("repo@sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")]
+    [InlineData("registry.example:+5/repo")]
+    [InlineData("registry.example: 5/repo")]
+    [InlineData("registry.example:5 /repo")]
+    public async Task DigestCommand_InvalidImage_DoesNotCreateRegistryClient(string image)
+    {
+        Mock<IDockerRegistryClientFactory> factory = new(MockBehavior.Strict);
+        DigestCommand command = new(factory.Object);
+
+        int exitCode = await command
+            .Parse([image])
+            .InvokeAsync(
+                new InvocationConfiguration(),
+                TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(0, exitCode);
+        factory.VerifyNoOtherCalls();
+    }
 
     [Fact]
     public async Task DigestCommand_WritesManifestDigest()
@@ -285,7 +315,7 @@ public class RegistryCommandTests
         OciManifestReference second = new() { Digest = "sha256:second" };
         Mock<IDockerRegistryClient> client = CreateClient();
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", "application/test", It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, "application/test", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Page<OciImageIndex>(
                 new OciImageIndex { Manifests = [first] },
                 "next"));
@@ -299,7 +329,7 @@ public class RegistryCommandTests
         {
             Options = new ReferrerListOptions
             {
-                Image = $"{Registry}/repo@sha256:image",
+                Image = $"{Registry}/repo@{ImageDigest}",
                 ArtifactType = "application/test"
             }
         };
@@ -320,7 +350,7 @@ public class RegistryCommandTests
         OciManifestReference second = new() { Digest = "sha256:second" };
         Mock<IDockerRegistryClient> client = CreateClient();
         client
-            .Setup(o => o.Referrers.GetAsync("repo", "sha256:image", null, It.IsAny<CancellationToken>()))
+            .Setup(o => o.Referrers.GetAsync("repo", ImageDigest, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Page<OciImageIndex>(
                 new OciImageIndex
                 {
@@ -333,7 +363,7 @@ public class RegistryCommandTests
         {
             Options = new ReferrerListOptions
             {
-                Image = $"{Registry}/repo@sha256:image",
+                Image = $"{Registry}/repo@{ImageDigest}",
                 Limit = 2
             }
         };

--- a/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CatOptions.cs
@@ -12,10 +12,7 @@ public class CatOptions : PlatformOptionsBase
 
     public CatOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         pathArgument = Add(new Argument<string>("path")
         {
             Description = "Image file path to write to standard output"

--- a/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/CompareOptionsBase.cs
@@ -15,8 +15,8 @@ public class CompareOptionsBase : PlatformOptionsBase
 
     public CompareOptionsBase()
     {
-        baseImageArg = Add(new Argument<string>(BaseArg) { Description = "Base container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
-        targetImageArg = Add(new Argument<string>(TargetArg) { Description = "Target container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        baseImageArg = Add(ImageReferenceArgument.Create(BaseArg, "Base container image"));
+        targetImageArg = Add(ImageReferenceArgument.Create(TargetArg, "Target container image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/DockerfileOptions.cs
@@ -14,7 +14,7 @@ public class DockerfileOptions : PlatformOptionsBase
 
     public DockerfileOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
         noColorOption = Add(new Option<bool>("--no-color") { Description = "Disables use of syntax color in the output" });
         noFormatOption = Add(new Option<bool>("--no-format") { Description = "Disables use of heuristics to format the layer history for better readability" });
     }

--- a/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/ExtractOptions.cs
@@ -14,10 +14,7 @@ public class ExtractOptions : PlatformOptionsBase
 
     public ExtractOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         pathArgument = Add(new Argument<string>("path")
         {
             Description = "Image file or directory path to extract"

--- a/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/InspectOptions.cs
@@ -10,7 +10,7 @@ public class InspectOptions : PlatformOptionsBase
 
     public InspectOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/LsOptions.cs
@@ -22,10 +22,7 @@ public class LsOptions : PlatformOptionsBase
 
     public LsOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         pathArgument = Add(new Argument<string?>("path")
         {
             Description = "Image path to list",

--- a/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/OsOptions.cs
@@ -10,7 +10,7 @@ public class OsOptions : PlatformOptionsBase
 
     public OsOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Image/SaveLayersOptions.cs
@@ -20,7 +20,7 @@ public class SaveLayersOptions : PlatformOptionsBase
 
     public SaveLayersOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
         outputPathArg = Add(new Argument<string>("output-path") { Description = "Path to the output location" });
         noSquashOption = Add(new Option<bool>("--no-squash") { Description = "Do not squash the image layers" });
         layerIndexOption = Add(new Option<int?>(LayerIndexOptionName) { Description = "Index of the image layer to target" });

--- a/src/Valleysoft.Dredge/Commands/ImageReferenceArgument.cs
+++ b/src/Valleysoft.Dredge/Commands/ImageReferenceArgument.cs
@@ -18,7 +18,7 @@ internal static class ImageReferenceArgument
             if (!ImageName.TryParse(value, out _, out string? error))
             {
                 result.AddError(
-                    $"{error} Expected <image>, <image>:<tag>, or <image>@<digest>.");
+                    $"{error} Expected <{name}>, <{name}>:<tag>, or <{name}>@<digest>.");
             }
         });
         return argument;

--- a/src/Valleysoft.Dredge/Commands/ImageReferenceArgument.cs
+++ b/src/Valleysoft.Dredge/Commands/ImageReferenceArgument.cs
@@ -1,0 +1,44 @@
+using System.CommandLine;
+
+namespace Valleysoft.Dredge.Commands;
+
+internal static class ImageReferenceArgument
+{
+    public const string Syntax = "(<image>, <image>:<tag>, or <image>@<digest>)";
+
+    public static Argument<string> Create(string name, string subject = "Container image")
+    {
+        Argument<string> argument = new(name)
+        {
+            Description = $"{subject} reference {Syntax}"
+        };
+        argument.Validators.Add(result =>
+        {
+            string? value = result.GetValueOrDefault<string>();
+            if (!ImageName.TryParse(value, out _, out string? error))
+            {
+                result.AddError(
+                    $"{error} Expected <image>, <image>:<tag>, or <image>@<digest>.");
+            }
+        });
+        return argument;
+    }
+
+    public static Argument<string> CreateRepository()
+    {
+        Argument<string> argument = new("repository")
+        {
+            Description = "Container repository name"
+        };
+        argument.Validators.Add(result =>
+        {
+            string? value = result.GetValueOrDefault<string>();
+            if (!ImageName.TryParseRepository(value, out _, out string? error))
+            {
+                result.AddError(
+                    $"{error} Expected <repository> or <registry>/<repository>.");
+            }
+        });
+        return argument;
+    }
+}

--- a/src/Valleysoft.Dredge/Commands/Manifest/DigestOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/DigestOptions.cs
@@ -10,7 +10,7 @@ public class DigestOptions : OptionsBase
 
     public DigestOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Manifest/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/GetOptions.cs
@@ -10,7 +10,7 @@ public class GetOptions : OptionsBase
 
     public GetOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Manifest/ResolveOptions.cs
@@ -10,7 +10,7 @@ public class SetOptions : PlatformOptionsBase
 
     public SetOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/CheckOptions.cs
@@ -14,10 +14,7 @@ public class CheckOptions : OptionsBase
 
     public CheckOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         artifactTypeOption = Add(new Option<string[]>("--artifact-type")
         {
             Description = "Required artifact media type; may be specified multiple times",

--- a/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/GetOptions.cs
@@ -16,10 +16,7 @@ public class GetOptions : OptionsBase
 
     public GetOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         artifactDigestArgument = Add(new Argument<string>("artifact-digest")
         {
             Description = "Digest of the artifact manifest"

--- a/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/InspectOptions.cs
@@ -14,10 +14,7 @@ public class InspectOptions : OptionsBase
 
     public InspectOptions()
     {
-        imageArgument = Add(new Argument<string>("image")
-        {
-            Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)"
-        });
+        imageArgument = Add(ImageReferenceArgument.Create("image"));
         artifactDigestArgument = Add(new Argument<string>("artifact-digest")
         {
             Description = "Digest of the artifact manifest"

--- a/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Referrer/ListOptions.cs
@@ -12,7 +12,7 @@ public class ListOptions : BoundedListOptionsBase
 
     public ListOptions()
     {
-        imageArg = Add(new Argument<string>("image") { Description = "Container image reference (<image>, <image>:<tag>, or <image>@<digest>)" });
+        imageArg = Add(ImageReferenceArgument.Create("image"));
         artifactTypeArg = Add(new Option<string>("--artifact-type") { Description = "Artifact media type to filter by" });
     }
 

--- a/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
+++ b/src/Valleysoft.Dredge/Commands/Tag/ListOptions.cs
@@ -10,7 +10,7 @@ public class ListOptions : BoundedListOptionsBase
 
     public ListOptions()
     {
-        repositoryArg = Add(new Argument<string>("repository") { Description = "Container repository name" });
+        repositoryArg = Add(ImageReferenceArgument.CreateRepository());
     }
 
     protected override void GetValues()

--- a/src/Valleysoft.Dredge/ImageName.cs
+++ b/src/Valleysoft.Dredge/ImageName.cs
@@ -1,7 +1,26 @@
-﻿namespace Valleysoft.Dredge;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+namespace Valleysoft.Dredge;
 
 public class ImageName
 {
+    private const int MaxRepositoryLength = 255;
+    private static readonly Regex RepositoryComponentPattern = new(
+        @"\A[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*\z",
+        RegexOptions.CultureInvariant);
+    private static readonly Regex TagPattern = new(
+        @"\A[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\z",
+        RegexOptions.CultureInvariant);
+    private static readonly Regex DigestAlgorithmPattern = new(
+        @"\A[a-z0-9]+(?:[+._-][a-z0-9]+)*\z",
+        RegexOptions.CultureInvariant);
+    private static readonly Regex DigestEncodedPattern = new(
+        @"\A[A-Za-z0-9=_-]+\z",
+        RegexOptions.CultureInvariant);
+
     public ImageName(string? registry, string repo, string? tag, string? digest)
     {
         Registry = registry;
@@ -17,23 +36,95 @@ public class ImageName
 
     public static ImageName Parse(string imageName)
     {
+        if (!TryParse(imageName, out ImageName? result, out string? error))
+        {
+            throw new ArgumentException(error, nameof(imageName));
+        }
+
+        return result;
+    }
+
+    public static bool TryParse(
+        string? imageName,
+        [NotNullWhen(true)]
+        out ImageName? result,
+        [NotNullWhen(false)]
+        out string? error) =>
+        TryParse(imageName, allowTagOrDigest: true, out result, out error);
+
+    internal static bool TryParseRepository(
+        string? repository,
+        [NotNullWhen(true)]
+        out ImageName? result,
+        [NotNullWhen(false)]
+        out string? error) =>
+        TryParse(repository, allowTagOrDigest: false, out result, out error);
+
+    private static bool TryParse(
+        string? imageName,
+        bool allowTagOrDigest,
+        [NotNullWhen(true)]
+        out ImageName? result,
+        [NotNullWhen(false)]
+        out string? error)
+    {
+        result = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(imageName))
+        {
+            error = "The image reference cannot be empty or whitespace.";
+            return false;
+        }
+
+        if (!string.Equals(imageName, imageName.Trim(), StringComparison.Ordinal))
+        {
+            error = "The image reference cannot contain leading or trailing whitespace.";
+            return false;
+        }
+
         string? registry = null;
         int separatorIndex = imageName.IndexOf('/');
         if (separatorIndex >= 0)
         {
             string firstSegment = imageName[..separatorIndex];
-            if (firstSegment.Contains('.') || firstSegment.Contains(':'))
+            if (firstSegment.Contains('.') ||
+                firstSegment.Contains(':') ||
+                firstSegment.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                firstSegment.StartsWith('[') ||
+                firstSegment.Any(char.IsAsciiLetterUpper))
             {
                 registry = firstSegment;
                 imageName = imageName[(separatorIndex + 1)..];
             }
         }
 
+        if (registry is not null && !IsValidRegistry(registry, out string? registryError))
+        {
+            error = $"Invalid registry '{registry}': {registryError}";
+            return false;
+        }
+
         string? tag = null;
         string? digest = null;
 
         separatorIndex = imageName.IndexOf('@');
-        if (separatorIndex < 0)
+        if (separatorIndex >= 0)
+        {
+            if (imageName.IndexOf('@', separatorIndex + 1) >= 0)
+            {
+                error = "Invalid digest: an image reference can contain only one '@' separator.";
+                return false;
+            }
+
+            digest = imageName[(separatorIndex + 1)..];
+            if (imageName[..separatorIndex].Contains(':'))
+            {
+                error = "An image reference cannot contain both a tag and a digest.";
+                return false;
+            }
+        }
+        else
         {
             separatorIndex = imageName.IndexOf(':');
             if (separatorIndex >= 0)
@@ -41,9 +132,11 @@ public class ImageName
                 tag = imageName[(separatorIndex + 1)..];
             }
         }
-        else
+
+        if (!allowTagOrDigest && separatorIndex >= 0)
         {
-            digest = imageName[(separatorIndex + 1)..];
+            error = "Invalid repository: tags and digests are not accepted for this argument.";
+            return false;
         }
 
         if (tag is null && digest is null)
@@ -61,9 +154,198 @@ public class ImageName
             repo = imageName;
         }
 
-        repo = DockerHubHelper.ResolveRepoName(registry, repo);
+        if (!IsValidRepository(repo, out string? repositoryError))
+        {
+            error = $"Invalid repository '{repo}': {repositoryError}";
+            return false;
+        }
 
-        return new ImageName(registry, repo, tag, digest);
+        if (tag is not null && !TagPattern.IsMatch(tag))
+        {
+            error = $"Invalid tag '{tag}': tags must start with an ASCII letter, digit, or underscore, contain only ASCII letters, digits, underscores, periods, and hyphens, and be at most 128 characters.";
+            return false;
+        }
+
+        if (digest is not null && !IsValidDigest(digest, out string? digestError))
+        {
+            error = $"Invalid digest '{digest}': {digestError}";
+            return false;
+        }
+
+        repo = DockerHubHelper.ResolveRepoName(registry, repo);
+        if (repo.Length > MaxRepositoryLength)
+        {
+            error = $"Invalid repository '{repo}': the repository cannot exceed {MaxRepositoryLength} characters.";
+            return false;
+        }
+
+        result = new ImageName(registry, repo, tag, digest);
+        return true;
+    }
+
+    private static bool IsValidRegistry(string registry, out string? error)
+    {
+        error = null;
+        string host;
+        string? port = null;
+
+        if (registry.StartsWith('['))
+        {
+            int closingBracket = registry.IndexOf(']');
+            if (closingBracket < 0)
+            {
+                error = "an IPv6 address must end with ']'.";
+                return false;
+            }
+
+            host = registry[1..closingBracket];
+            string suffix = registry[(closingBracket + 1)..];
+            if (suffix.Length > 0)
+            {
+                if (!suffix.StartsWith(':'))
+                {
+                    error = "unexpected characters follow the IPv6 address.";
+                    return false;
+                }
+
+                port = suffix[1..];
+            }
+
+            if (host.Any(character => !char.IsAsciiHexDigit(character) && character != ':') ||
+                !IPAddress.TryParse(host, out IPAddress? address) ||
+                address.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                error = "the bracketed host must be a valid IPv6 address.";
+                return false;
+            }
+        }
+        else
+        {
+            int colonIndex = registry.LastIndexOf(':');
+            if (colonIndex >= 0)
+            {
+                if (registry.IndexOf(':') != colonIndex)
+                {
+                    error = "IPv6 addresses must be enclosed in brackets.";
+                    return false;
+                }
+
+                host = registry[..colonIndex];
+                port = registry[(colonIndex + 1)..];
+            }
+            else
+            {
+                host = registry;
+            }
+
+            if (!IsValidHost(host))
+            {
+                error = "the host must be a valid DNS name, IPv4 address, or localhost.";
+                return false;
+            }
+        }
+
+        if (port is not null &&
+            (port.Length == 0 ||
+                !port.All(char.IsAsciiDigit) ||
+                !int.TryParse(port, out int portNumber) ||
+                portNumber is < 1 or > 65535))
+        {
+            error = "the port must be a number from 1 through 65535.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsValidHost(string host)
+    {
+        if (host.Length is 0 or > 253)
+        {
+            return false;
+        }
+
+        if (host.All(character => char.IsAsciiDigit(character) || character == '.'))
+        {
+            if (IPAddress.TryParse(host, out IPAddress? address) &&
+                address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                return true;
+            }
+        }
+
+        return host.Split('.').All(label =>
+            label.Length is > 0 and <= 63 &&
+            char.IsAsciiLetterOrDigit(label[0]) &&
+            char.IsAsciiLetterOrDigit(label[^1]) &&
+            label.All(character => char.IsAsciiLetterOrDigit(character) || character == '-'));
+    }
+
+    private static bool IsValidRepository(string repository, out string? error)
+    {
+        if (repository.Length == 0)
+        {
+            error = "the repository cannot be empty.";
+            return false;
+        }
+
+        if (repository.Length > MaxRepositoryLength)
+        {
+            error = $"the repository cannot exceed {MaxRepositoryLength} characters.";
+            return false;
+        }
+
+        if (!repository.Split('/').All(component => RepositoryComponentPattern.IsMatch(component)))
+        {
+            error = "each path component must be lowercase, start and end with a letter or digit, and use only periods, underscores, or hyphens as separators.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool IsValidDigest(string digest, out string? error)
+    {
+        int separatorIndex = digest.IndexOf(':');
+        if (separatorIndex <= 0 || separatorIndex == digest.Length - 1 ||
+            digest.IndexOf(':', separatorIndex + 1) >= 0)
+        {
+            error = "digests must use the form '<algorithm>:<encoded>'.";
+            return false;
+        }
+
+        string algorithm = digest[..separatorIndex];
+        if (!DigestAlgorithmPattern.IsMatch(algorithm))
+        {
+            error = "the algorithm is not valid.";
+            return false;
+        }
+
+        string encoded = digest[(separatorIndex + 1)..];
+        if (!DigestEncodedPattern.IsMatch(encoded))
+        {
+            error = "the encoded value contains invalid characters.";
+            return false;
+        }
+
+        int? requiredLength = algorithm switch
+        {
+            "sha256" => 64,
+            "sha512" => 128,
+            _ => null
+        };
+        if (requiredLength is not null &&
+            (encoded.Length != requiredLength ||
+                !encoded.All(character =>
+                    char.IsAsciiDigit(character) || character is >= 'a' and <= 'f')))
+        {
+            error = $"the encoded value for {algorithm} must contain exactly {requiredLength} lowercase hexadecimal characters.";
+            return false;
+        }
+
+        error = null;
+        return true;
     }
 
     public override string ToString()


### PR DESCRIPTION
Malformed image references currently reach registry client creation, producing avoidable network requests and less actionable failures. This change validates references at the CLI boundary so invalid registry, repository, tag, and digest components are reported immediately.

## Summary

- Add component-aware image reference parsing with Docker-compatible registry, repository, tag, digest, port, IPv4, and IPv6 validation.
- Reuse a shared System.CommandLine validator across image, manifest, referrer, comparison, and tag-list arguments.
- Preserve Docker Hub shorthand and normalization, while requiring `tag list` to receive a repository without a tag or digest.
- Add parser boundaries, CLI diagnostics, command wiring, and no-registry-client regression coverage.

## Testing

- `dotnet test src\Valleysoft.Dredge.sln --no-restore -v normal -c Release`

Fixes: #314